### PR TITLE
Add JDK 9 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       addons:
         apt:
           packages:
-            - oracle-java9-installer
+            - oracle-java9-installer # Forces use of even newer JDK 9 build
 
 script: ./gradlew :provider:check --info --stacktrace --console=plain --max-workers=1 --no-daemon -Dkotlin.compiler.execution.strategy=in-proces -Dkotlin.colors.enabled=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
     - os: linux
       sudo: false
       jdk: openjdk8
+    - os: linux
+      sudo: false
+      jdk: oraclejdk9 # JDK 9+175 or newer
 
 script: ./gradlew :provider:check --info --stacktrace --console=plain --max-workers=1 --no-daemon -Dkotlin.compiler.execution.strategy=in-proces -Dkotlin.colors.enabled=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
     - os: linux
       sudo: false
       jdk: oraclejdk9 # JDK 9+175 or newer
+      addons:
+        apt:
+          packages:
+            - oracle-java9-installer
 
 script: ./gradlew :provider:check --info --stacktrace --console=plain --max-workers=1 --no-daemon -Dkotlin.compiler.execution.strategy=in-proces -Dkotlin.colors.enabled=false
 

--- a/fixtures/build.gradle.kts
+++ b/fixtures/build.gradle.kts
@@ -11,9 +11,9 @@ val subProjectTasks = rootDir
     .filter { isProjectDir(it) }
     .filter { isCompatibleWithJDK(it) }
     .map { subProjectDir ->
-    task<GradleBuild>("prepare-${subProjectDir.name}") {
-        setDir(subProjectDir)
+        task<GradleBuild>("prepare-${subProjectDir.name}") {
+            setDir(subProjectDir)
+        }
     }
-}
 
 setDefaultTasks(subProjectTasks.map { it.name })

--- a/fixtures/build.gradle.kts
+++ b/fixtures/build.gradle.kts
@@ -3,7 +3,14 @@ import org.gradle.api.tasks.GradleBuild
 fun isProjectDir(candidate: File) =
     candidate.isDirectory && File(candidate, "settings.gradle").exists()
 
-val subProjectTasks = rootDir.listFiles().filter { isProjectDir(it) }.map { subProjectDir ->
+fun isCompatibleWithJDK(candidate: File) =
+    candidate.name.endsWith("kotlin-1.0") && JavaVersion.current() < JavaVersion.VERSION_1_9
+
+val subProjectTasks = rootDir
+    .listFiles()
+    .filter { isProjectDir(it) }
+    .filter { isCompatibleWithJDK(it) }
+    .map { subProjectDir ->
     task<GradleBuild>("prepare-${subProjectDir.name}") {
         setDir(subProjectDir)
     }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -1,5 +1,6 @@
 package org.gradle.kotlin.dsl.integration
 
+import org.gradle.api.JavaVersion
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
@@ -8,6 +9,7 @@ import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 
+import org.junit.Assume.assumeTrue
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
@@ -124,6 +126,7 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
 
     @Test
     fun `given a plugin compiled against Kotlin one dot zero, it will run against the embedded Kotlin version`() {
+        assumeTrue("Test disabled under JDK 9 and higher", JavaVersion.current() < JavaVersion.VERSION_1_9)
 
         withBuildScript("""
             buildscript {


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Related/demonstration of to #454

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [ ] ~Ensure that tests pass locally: `./gradlew check --parallel`~ (This is the problem I'm trying to demonstrate)
