### PR TITLE
Add Spotless plugin for code linting and reformatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Make sure that windows checks out kotlin files with the right line endings for spotless linting
+*.kts text eol=lf
+*.kt text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
             - oracle-java8-installer
             - oracle-java8-set-default
 
-script: ./gradlew :provider:check --info --stacktrace --console=plain --max-workers=1 --no-daemon -Dkotlin.compiler.execution.strategy=in-proces -Dkotlin.colors.enabled=false
+script: ./gradlew spotlessCheck :provider:check --info --stacktrace --console=plain --max-workers=1 --no-daemon -Dkotlin.compiler.execution.strategy=in-proces -Dkotlin.colors.enabled=false
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,10 +36,14 @@ allprojects {
         val ktLintVersion = "0.9.0"
         kotlinGradle {
             ktlint(ktLintVersion)
+            endWithNewline()
+            trimTrailingWhitespace()
         }
         plugins.withId("kotlin") {
             kotlin {
                 ktlint(ktLintVersion)
+                endWithNewline()
+                trimTrailingWhitespace()
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,11 +99,10 @@ artifactory {
 
 fun buildTagFor(version: String): String =
     when (version.substringAfterLast('-')) {
-        "SNAPSHOT"                  -> "snapshot"
+        "SNAPSHOT" -> "snapshot"
         in Regex("""M\d+[a-z]*$""") -> "milestone"
-        else                        -> "release"
+        else -> "release"
     }
-
 
 // -- Integration testing ----------------------------------------------
 val prepareIntegrationTestFixtures by task<GradleBuild> {
@@ -140,13 +139,11 @@ val customInstallation by task<Copy> {
     into("$customInstallationDir/lib")
 }
 
-
 // -- Performance testing ----------------------------------------------
 val benchmark by task<integration.Benchmark> {
     dependsOn(customInstallation)
     latestInstallation = customInstallationDir
 }
-
 
 // --- Utility functions -----------------------------------------------
 operator fun Regex.contains(s: String) = matches(s)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,28 @@ buildscript {
 
 plugins {
     base
+    id("com.diffplug.gradle.spotless") version "3.5.1"
     id("com.jfrog.artifactory") version "4.1.1"
 }
 
 allprojects {
+    apply {
+        plugin("com.diffplug.gradle.spotless")
+    }
     group = "org.gradle"
     version = "0.12.0-SNAPSHOT"
+
+    spotless {
+        val ktLintVersion = "0.9.0"
+        kotlinGradle {
+            ktlint(ktLintVersion)
+        }
+        plugins.withId("kotlin") {
+            kotlin {
+                ktlint(ktLintVersion)
+            }
+        }
+    }
 }
 
 val publishedPluginsVersion by extra { "0.11.2" }

--- a/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
+++ b/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
@@ -49,18 +49,14 @@ package org.gradle.kotlin.dsl
 
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
-
 import org.gradle.api.artifacts.repositories.ArtifactRepository
-
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
-
 
 /**
  * The version of the Kotlin compiler embedded in gradle-kotlin-dsl (currently _${embeddedKotlinVersion}_).
  */
 val embeddedKotlinVersion = "$embeddedKotlinVersion"
-
 
 /**
  * Adds the remote repository containing the Kotlin libraries embedded in gradle-kotlin-dsl.
@@ -68,7 +64,6 @@ val embeddedKotlinVersion = "$embeddedKotlinVersion"
 @Deprecated("Will be removed in 1.0")
 fun RepositoryHandler.gradleScriptKotlin(): ArtifactRepository =
     maven { it.setUrl("$kotlinDslRepository") }
-
 
 /**
  * Builds the dependency notation for the named Kotlin [module] at the given [version].
@@ -79,11 +74,9 @@ fun RepositoryHandler.gradleScriptKotlin(): ArtifactRepository =
 fun DependencyHandler.kotlin(module: String, version: String? = null): Any =
     "org.jetbrains.kotlin:kotlin-${'$'}module:${'$'}{version ?: embeddedKotlinVersion}"
 
-
 @Deprecated("Will be removed in 1.0", ReplaceWith("kotlin(module, version)"))
 fun DependencyHandler.kotlinModule(module: String, version: String? = null): Any =
     kotlin(module, version)
-
 
 /**
  * Applies the given Kotlin plugin [module] at the (optional) given [version] ([embeddedKotlinVersion] by default).
@@ -97,7 +90,6 @@ fun DependencyHandler.kotlinModule(module: String, version: String? = null): Any
  */
 fun PluginDependenciesSpec.kotlin(module: String, version: String? = null): PluginDependencySpec =
     id("org.jetbrains.kotlin.${'$'}module") version (version ?: embeddedKotlinVersion)
-
 
 /**
  * The `embedded-kotlin` plugin.
@@ -122,7 +114,6 @@ val PluginDependenciesSpec.`embedded-kotlin`: PluginDependencySpec
  */
 val PluginDependenciesSpec.`kotlin-dsl`: PluginDependencySpec
     get() = id("org.gradle.kotlin.kotlin-dsl") version "$kotlinDslPluginsVersion"
-
 """)
     }
 }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     testImplementation(project(":test-fixtures"))
 }
 
-
 // --- Plugins declaration ----------------------------------------------
 
 data class GradlePlugin(val displayName: String, val id: String, val implementationClass: String)

--- a/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
@@ -24,7 +24,6 @@ import org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
 import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension
 import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverGradleSubplugin
 
-
 /**
  * The `kotlin-dsl` plugin.
  *

--- a/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -24,7 +24,6 @@ import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
 
 import javax.inject.Inject
 
-
 /**
  * The `embedded-kotlin` plugin.
  *

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/AbstractPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/AbstractPluginTest.kt
@@ -7,7 +7,7 @@ import org.gradle.util.TextUtil.normaliseFileSeparators
 import org.junit.Before
 
 import java.io.File
-import java.util.*
+import java.util.Properties
 
 open class AbstractPluginTest : AbstractIntegrationTest() {
 

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -14,7 +14,6 @@ import org.junit.Test
 
 import java.io.File
 
-
 class KotlinDslPluginTest : AbstractPluginTest() {
 
     @Test

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -225,4 +225,3 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
             "$configuration(\"org.jetbrains.kotlin:kotlin-$it:${version ?: embeddedKotlinVersion}\")"
         }.joinToString("\n")
 }
-

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -26,7 +26,6 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class EmbeddedKotlinPluginTest : AbstractPluginTest() {
 
     @Test

--- a/provider/build.gradle.kts
+++ b/provider/build.gradle.kts
@@ -1,4 +1,8 @@
-import build.*
+import build.withParallelTests
+import build.futureKotlin
+import build.kotlin
+import build.kotlinVersion
+import build.kotlinRepo
 
 import codegen.GenerateKotlinDependencyExtensions
 
@@ -24,7 +28,6 @@ dependencies {
     testCompile(project(":test-fixtures"))
 }
 
-
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = file("src/generated/kotlin")
 
@@ -49,7 +52,6 @@ compileKotlin.dependsOn(generateExtensions)
 
 val clean: Delete by tasks
 clean.delete(apiExtensionsOutputDir)
-
 
 // -- Testing ----------------------------------------------------------
 val prepareIntegrationTestFixtures by rootProject.tasks

--- a/provider/build.gradle.kts
+++ b/provider/build.gradle.kts
@@ -68,4 +68,3 @@ withParallelTests()
 // --- Utility functions -----------------------------------------------
 inline
 fun <reified T : Task> task(noinline configuration: T.() -> Unit) = tasks.creating(T::class, configuration)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
@@ -20,7 +20,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 
 import kotlin.reflect.KProperty
 
-
 /**
  * Property delegate for [ConfigurableFileCollection] instances.
  *
@@ -28,7 +27,6 @@ import kotlin.reflect.KProperty
  */
 operator fun ConfigurableFileCollection.getValue(receiver: Any?, property: KProperty<*>): ConfigurableFileCollection =
     this
-
 
 /**
  * Property delegate for [ConfigurableFileCollection] instances.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
@@ -35,4 +35,3 @@ operator fun ConfigurableFileCollection.getValue(receiver: Any?, property: KProp
  */
 operator fun ConfigurableFileCollection.setValue(receiver: Any?, property: KProperty<*>, value: Iterable<*>) =
     setFrom(value)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
@@ -20,7 +20,6 @@ import org.gradle.api.internal.HasConvention
 import org.gradle.api.plugins.Convention
 import kotlin.reflect.KClass
 
-
 /**
  * Looks for the convention plugin of a given name and casts it to the expected type [T].
  *
@@ -36,15 +35,12 @@ fun <reified T : Any> Convention.getPluginByName(name: String): T =
         (it as T?) ?: throw IllegalStateException("Convention '$name' of type '${it::class.java.name}' cannot be cast to '${T::class.java.name}'.")
     } ?: throw IllegalStateException("A convention named '$name' could not be found.")
 
-
 inline
 fun <reified T : Any> Convention.getPlugin() =
     getPlugin(T::class)
 
-
 fun <T : Any> Convention.getPlugin(conventionType: KClass<T>) =
     getPlugin(conventionType.java)
-
 
 /**
  * Evaluates the given [function] against the convention plugin of the given [conventionType].

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
@@ -58,4 +58,3 @@ fun <ConventionType : Any, ReturnType> Any.withConvention(conventionType: KClass
         is HasConvention -> convention.getPlugin(conventionType).run(function)
         else -> throw IllegalStateException("Object `$this` doesn't support conventions!")
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/CopySpecExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/CopySpecExtensions.kt
@@ -20,12 +20,10 @@ import org.gradle.api.file.CopySpec
 
 import java.io.FilterReader
 
-
 // Interim extensions until those methods are added to CopySpec
 inline
 fun <reified T : FilterReader> CopySpec.filter(vararg properties: Pair<String, Any?>) =
     filter(mapOf(*properties), T::class.java)
-
 
 inline
 fun <reified T : FilterReader> CopySpec.filter(properties: Map<String, Any?>) =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -29,7 +29,6 @@ import org.gradle.internal.Cast.uncheckedCast
 import org.gradle.kotlin.dsl.support.excludeMapFor
 import org.gradle.kotlin.dsl.support.mapOfNonNullValuesOf
 
-
 /**
  * Creates a dependency on a module without adding it to a configuration.
  *
@@ -61,7 +60,6 @@ fun DependencyHandler.create(
             "classifier" to classifier,
             "ext" to ext)) as ExternalModuleDependency
 
-
 /**
  * Creates a dependency on a client module without adding it to a configuration.
  *
@@ -92,7 +90,6 @@ fun DependencyHandler.module(
             "configuration" to configuration,
             "classifier" to classifier,
             "ext" to ext)) as ClientModule
-
 
 /**
  * Creates a dependency on a client module without adding it to a configuration.
@@ -128,7 +125,6 @@ fun DependencyHandler.module(
                 "ext" to ext)) as ClientModule,
         clientModuleConfiguration)
 
-
 /**
  * Creates a dependency on a client module without adding it to a configuration.
  *
@@ -142,7 +138,6 @@ fun DependencyHandler.module(
 
     configureClientModule(module(notation) as ClientModule, clientModuleConfiguration)
 
-
 private inline
 fun DependencyHandler.configureClientModule(
     module: ClientModule,
@@ -150,7 +145,6 @@ fun DependencyHandler.configureClientModule(
     module.apply {
         ClientModuleScope(this@configureClientModule, this@apply).clientModuleConfiguration()
     }
-
 
 /**
  * Receiver for [ClientModule] configuration blocks.
@@ -160,12 +154,12 @@ class ClientModuleScope(
     val clientModule: ClientModule) : ClientModule by clientModule {
 
     fun module(group: String,
-               name: String,
-               version: String? = null,
-               configuration: String? = null,
-               classifier: String? = null,
-               ext: String? = null,
-               setup: ClientModuleScope.() -> Unit) {
+        name: String,
+        version: String? = null,
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null,
+        setup: ClientModuleScope.() -> Unit) {
         clientModule.addDependency(
             dependencyHandler.module(group, name, version, configuration, classifier, ext, setup))
     }
@@ -192,7 +186,6 @@ class ClientModuleScope(
         (dependencyHandler.create(notation) as ExternalModuleDependency).apply(dependencyConfiguration)
 }
 
-
 /**
  * Creates a dependency on a project without adding it to a configuration.
  *
@@ -209,7 +202,6 @@ fun DependencyHandler.project(
             if (configuration != null) mapOf("path" to path, "configuration" to configuration)
             else mapOf("path" to path)))
 
-
 /**
  * Adds a dependency to the given configuration, and configures the dependency using the given expression.
  *
@@ -225,7 +217,6 @@ fun DependencyHandler.add(
     dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
 
     add(configuration, create(dependencyNotation) as ExternalModuleDependency, dependencyConfiguration)
-
 
 /**
  * Adds a dependency to the given configuration, and configures the dependency using the given expression.
@@ -245,7 +236,6 @@ fun <T : ModuleDependency> DependencyHandler.add(
         dependencyConfiguration()
         add(configuration, this)
     }
-
 
 /**
  * Adds an exclude rule to exclude transitive dependencies of this dependency.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -261,4 +261,3 @@ fun <T : ModuleDependency> DependencyHandler.add(
  */
 fun <T : ModuleDependency> T.exclude(group: String? = null, module: String? = null): T =
     uncheckedCast(exclude(excludeMapFor(group, module)))
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DomainObjectCollectionExtensions.kt
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl
 
 import org.gradle.api.DomainObjectCollection
 
-
 /**
  * Returns a collection containing the objects in this collection of the given type. Equivalent to calling
  * {@code withType(type).all(configureAction)}
@@ -32,7 +31,6 @@ import org.gradle.api.DomainObjectCollection
 inline
 fun <reified S : Any> DomainObjectCollection<in S>.withType(crossinline configuration: S.() -> Unit) =
     withType(S::class.java, { it.configuration() })
-
 
 /**
  * Returns a collection containing the objects in this collection of the given type. The

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DomainObjectCollectionExtensions.kt
@@ -45,4 +45,3 @@ fun <reified S : Any> DomainObjectCollection<in S>.withType(crossinline configur
 inline
 fun <reified S : Any> DomainObjectCollection<in S>.withType() =
     withType(S::class.java)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionContainerExtensions.kt
@@ -21,7 +21,6 @@ import org.gradle.api.plugins.ExtensionContainer
 
 import kotlin.reflect.KProperty
 
-
 /**
  * Looks for the extension of a given name. If none found it will throw an exception.
  *
@@ -33,7 +32,6 @@ import kotlin.reflect.KProperty
  */
 operator fun ExtensionContainer.get(name: String): Any =
     getByName(name)
-
 
 /**
  * Looks for the extension of a given name and casts it to the expected type [T].
@@ -52,9 +50,8 @@ fun <reified T : Any> ExtensionContainer.getByName(name: String) =
     getByName(name).let {
         it as? T
             ?: throw IllegalStateException(
-                "Element '$name' of type '${it::class.java.name}' from container '$this' cannot be cast to '${T::class.qualifiedName}'.")
+            "Element '$name' of type '${it::class.java.name}' from container '$this' cannot be cast to '${T::class.qualifiedName}'.")
     }
-
 
 inline
 operator fun <reified T : Any> ExtensionContainer.getValue(thisRef: Any?, property: KProperty<*>): T =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
@@ -24,7 +24,6 @@ import org.gradle.internal.Cast.uncheckedCast
 
 import kotlin.reflect.KProperty
 
-
 /**
  * The extra properties extension in this object's extension container.
  *
@@ -33,10 +32,8 @@ import kotlin.reflect.KProperty
 val ExtensionAware.extra: ExtraPropertiesExtension
     get() = extensions.extraProperties
 
-
 operator fun ExtraPropertiesExtension.setValue(receiver: Any?, property: KProperty<*>, value: Any) =
     set(property.name, value)
-
 
 operator fun <T> ExtraPropertiesExtension.getValue(receiver: Any?, property: KProperty<*>): T =
     /* We would like to be able to express optional properties via nullability of the return type
@@ -48,7 +45,6 @@ operator fun <T> ExtraPropertiesExtension.getValue(receiver: Any?, property: KPr
     */
     uncheckedCast(get(property.name))
 
-
 /**
  * Returns a property delegate provider that will initialize the extra property to the value provided
  * by [initialValueProvider].
@@ -59,7 +55,6 @@ inline
 operator fun <T : Any> ExtraPropertiesExtension.invoke(initialValueProvider: () -> T): ExtraPropertyDelegateProvider<T> =
     invoke(initialValueProvider())
 
-
 /**
  * Returns a property delegate provider that will initialize the extra property to the given [initialValue].
  *
@@ -67,7 +62,6 @@ operator fun <T : Any> ExtraPropertiesExtension.invoke(initialValueProvider: () 
  */
 operator fun <T : Any> ExtraPropertiesExtension.invoke(initialValue: T): ExtraPropertyDelegateProvider<T> =
     ExtraPropertyDelegateProvider(this, initialValue)
-
 
 class ExtraPropertyDelegateProvider<T : Any>(
     val extra: ExtraPropertiesExtension,
@@ -78,7 +72,6 @@ class ExtraPropertyDelegateProvider<T : Any>(
         return ExtraPropertyDelegate(extra)
     }
 }
-
 
 /**
  * Enables typed access to extra properties.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/GradleDsl.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/GradleDsl.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl
 
-
 /**
  * Delimits a Gradle DSL.
  *

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
@@ -19,11 +19,8 @@ package org.gradle.kotlin.dsl
 import groovy.lang.Closure
 import groovy.lang.GroovyObject
 import groovy.lang.MetaClass
-
-import org.gradle.internal.Cast.uncheckedCast
-
 import org.codehaus.groovy.runtime.InvokerHelper.getMetaClass
-
+import org.gradle.internal.Cast.uncheckedCast
 
 /**
  * Adapts a Kotlin function to a single argument Groovy [Closure].
@@ -35,7 +32,6 @@ import org.codehaus.groovy.runtime.InvokerHelper.getMetaClass
  */
 fun <T : Any> Any.closureOf(action: T.() -> Unit): Closure<Any?> =
     KotlinClosure1(action, this, this)
-
 
 /**
  * Adapts a Kotlin function to a Groovy [Closure] that operates on the
@@ -52,7 +48,6 @@ fun <T> Any.delegateClosureOf(action: T.() -> Unit) =
         fun doCall() = uncheckedCast<T>(delegate).action()
     }
 
-
 /**
  * Adapts a parameterless Kotlin function to a parameterless Groovy [Closure].
  *
@@ -64,14 +59,13 @@ fun <T> Any.delegateClosureOf(action: T.() -> Unit) =
  * @see Closure
  */
 open class KotlinClosure0<V : Any>(
-    val function : () -> V?,
+    val function: () -> V?,
     owner: Any? = null,
     thisObject: Any? = null) : groovy.lang.Closure<V?>(owner, thisObject) {
 
     @Suppress("unused") // to be called dynamically by Groovy
     fun doCall(): V? = function()
 }
-
 
 /**
  * Adapts an unary Kotlin function to an unary Groovy [Closure].
@@ -92,7 +86,6 @@ class KotlinClosure1<in T : Any, V : Any>(
     @Suppress("unused") // to be called dynamically by Groovy
     fun doCall(it: T): V? = it.function()
 }
-
 
 /**
  * Adapts a binary Kotlin function to a binary Groovy [Closure].
@@ -115,13 +108,11 @@ class KotlinClosure2<in T : Any, in U : Any, V : Any>(
     fun doCall(t: T, u: U): V? = function(t, u)
 }
 
-
 operator fun <T> Closure<T>.invoke(): T = call()
 
 operator fun <T> Closure<T>.invoke(x: Any?): T = call(x)
 
 operator fun <T> Closure<T>.invoke(vararg xs: Any?): T = call(*xs)
-
 
 /**
  * Executes the given [builder] against this object's [GroovyBuilderScope].
@@ -131,7 +122,6 @@ operator fun <T> Closure<T>.invoke(vararg xs: Any?): T = call(*xs)
 inline
 fun <T> Any.withGroovyBuilder(builder: GroovyBuilderScope.() -> T): T =
     GroovyBuilderScope.of(this).builder()
-
 
 /**
  * Provides a dynamic dispatching DSL with Groovy semantics for better integration with
@@ -164,7 +154,7 @@ interface GroovyBuilderScope : GroovyObject {
         fun of(value: Any): GroovyBuilderScope =
             when (value) {
                 is GroovyObject -> GroovyBuilderScopeForGroovyObject(value)
-                else            -> GroovyBuilderScopeForRegularObject(value)
+                else -> GroovyBuilderScopeForRegularObject(value)
             }
     }
 
@@ -190,14 +180,12 @@ interface GroovyBuilderScope : GroovyObject {
         }
 }
 
-
 private
 class GroovyBuilderScopeForGroovyObject(private val receiver: GroovyObject) : GroovyBuilderScope, GroovyObject by receiver {
 
     override fun String.invoke(vararg arguments: Any?): Any? =
         receiver.invokeMethod(this, arguments)
 }
-
 
 private
 class GroovyBuilderScopeForRegularObject(private val receiver: Any) : GroovyBuilderScope {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -17,14 +17,10 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.Project
-
-import org.gradle.plugin.use.PluginDependenciesSpec
-
 import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver
-
+import org.gradle.plugin.use.PluginDependenciesSpec
 import kotlin.script.extensions.SamWithReceiverAnnotations
 import kotlin.script.templates.ScriptTemplateDefinition
-
 
 /**
  * Base class for Kotlin build scripts.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -48,4 +48,3 @@ abstract class KotlinBuildScript(project: Project) : Project by project {
     @Suppress("unused")
     fun plugins(@Suppress("unused_parameter") block: PluginDependenciesSpecScope.() -> Unit) = Unit
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
@@ -23,7 +23,6 @@ import org.gradle.kotlin.dsl.support.illegalElementType
 
 import kotlin.reflect.KProperty
 
-
 /**
  * Idiomatic way of referring to an existing element in a collection
  * via a delegate property.
@@ -31,8 +30,8 @@ import kotlin.reflect.KProperty
  * `tasks { val jar by getting }`
  */
 inline
-val <T : Any, U : NamedDomainObjectCollection<in T>> U.getting: U get() = this
-
+val <T : Any, U : NamedDomainObjectCollection<in T>> U.getting: U
+    get() = this
 
 /**
  * Idiomatic way of referring and configuring an existing element in a collection
@@ -43,7 +42,6 @@ val <T : Any, U : NamedDomainObjectCollection<in T>> U.getting: U get() = this
 fun <T : Any, U : NamedDomainObjectCollection<T>> U.getting(configuration: T.() -> Unit) =
     NamedDomainObjectCollectionDelegateProvider(this, configuration)
 
-
 class NamedDomainObjectCollectionDelegateProvider<T>(
     val collection: NamedDomainObjectCollection<T>,
     val configuration: T.() -> Unit) {
@@ -53,7 +51,6 @@ class NamedDomainObjectCollectionDelegateProvider<T>(
             getByName(property.name).apply(configuration)
         }
 }
-
 
 /**
  * Locates an object by name, failing if there is no such object.
@@ -66,7 +63,6 @@ class NamedDomainObjectCollectionDelegateProvider<T>(
  */
 operator fun <T : Any> NamedDomainObjectCollection<T>.get(name: String): T =
     getByName(name)
-
 
 /**
  * Allows a [NamedDomainObjectCollection] to be used as a property delegate.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -25,7 +25,6 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.safeCast
 
-
 /**
  * Allows the container to be configured, creating missing objects as they are referenced.
  *
@@ -39,7 +38,6 @@ operator fun <T : Any, C : NamedDomainObjectContainer<T>> C.invoke(
     apply {
         configuration(NamedDomainObjectContainerScope(this))
     }
-
 
 /**
  * Receiver for [NamedDomainObjectContainer] configuration blocks.
@@ -107,13 +105,11 @@ class NamedDomainObjectContainerScope<T : Any>(
             ?: throw IllegalArgumentException("Container '$container' is not polymorphic.")
 }
 
-
 /**
  * Provides a property delegate that creates elements of the default collection type.
  */
 val <T : Any> NamedDomainObjectContainer<T>.creating
     get() = NamedDomainObjectContainerDelegateProvider(this, {})
-
 
 /**
  * Provides a property delegate that creates elements of the default collection type with the given [configuration].
@@ -122,7 +118,6 @@ val <T : Any> NamedDomainObjectContainer<T>.creating
  */
 fun <T : Any> NamedDomainObjectContainer<T>.creating(configuration: T.() -> Unit) =
     NamedDomainObjectContainerDelegateProvider(this, configuration)
-
 
 /**
  * A property delegate that creates elements in the given [NamedDomainObjectContainer].
@@ -139,13 +134,11 @@ class NamedDomainObjectContainerDelegateProvider<T : Any>(
         }
 }
 
-
 /**
  * Provides a property delegate that creates elements of the given [type].
  */
 fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.creating(type: KClass<U>) =
     creating(type.java, {})
-
 
 /**
  * Provides a property delegate that creates elements of the given [type] with the given [configuration].
@@ -153,14 +146,12 @@ fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.creating(type: KClass<U
 fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.creating(type: KClass<U>, configuration: U.() -> Unit) =
     creating(type.java, configuration)
 
-
 /**
  * Provides a property delegate that creates elements of the given [type] expressed as a [java.lang.Class]
  * with the given [configuration].
  */
 fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.creating(type: Class<U>, configuration: U.() -> Unit) =
     PolymorphicDomainObjectContainerDelegateProvider(this, type, configuration)
-
 
 /**
  * A property delegate that creates elements of the given [type] with the given [configuration] in the given [container].
@@ -177,20 +168,17 @@ class PolymorphicDomainObjectContainerDelegateProvider<T : Any, U : T>(
         } as PolymorphicDomainObjectContainer<U>
 }
 
-
 /**
  * Provides a property delegate that gets elements of the given [type] and applies the given [configuration].
  */
 fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getting(type: KClass<U>, configuration: U.() -> Unit) =
     PolymorphicDomainObjectContainerGettingDelegateProvider(this, type, configuration)
 
-
 /**
  * Provides a property delegate that gets elements of the given [type].
  */
 fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getting(type: KClass<U>) =
     PolymorphicDomainObjectContainerGettingDelegate(this, type)
-
 
 /**
  * A property delegate that gets elements of the given [type] in the given [container].
@@ -202,7 +190,6 @@ class PolymorphicDomainObjectContainerGettingDelegate<T : Any, U : T>(
     operator fun getValue(receiver: Any?, property: kotlin.reflect.KProperty<*>): U =
         container.getByName(property.name, type)
 }
-
 
 /**
  * A property delegate that gets elements of the given [type] from the given [container]
@@ -219,7 +206,6 @@ class PolymorphicDomainObjectContainerGettingDelegateProvider<T : Any, U : T>(
             getByName(property.name, type).configuration()
         } as PolymorphicDomainObjectContainer<U>
 }
-
 
 private
 fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getByName(name: String, type: KClass<U>): U =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
 
-
 /**
  * The `build-scan` plugin.
  *

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
@@ -19,7 +19,6 @@ package org.gradle.kotlin.dsl
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
 
-
 /**
  * Receiver for the `plugins` block.
  *
@@ -31,14 +30,12 @@ import org.gradle.plugin.use.PluginDependencySpec
 @GradleDsl
 class PluginDependenciesSpecScope(plugins: PluginDependenciesSpec) : PluginDependenciesSpec by plugins
 
-
 /**
  * Specify the version of the plugin to depend on.
  *
  * Infix version of [PluginDependencySpec.version].
  */
 infix fun PluginDependencySpec.version(version: String?): PluginDependencySpec = version(version)
-
 
 /**
  * Specifies whether the plugin should be applied to the current project. Otherwise it is only put

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
@@ -19,7 +19,6 @@ package org.gradle.kotlin.dsl
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.PolymorphicDomainObjectContainer
 
-
 /**
  * Creates a domain object with the specified name and type, adds it to the container,
  * and configures it with the specified action.
@@ -38,7 +37,6 @@ fun <reified U : Any> PolymorphicDomainObjectContainer<in U>.create(
     crossinline configuration: U.() -> Unit) =
 
     this.create(name, U::class.java, { configuration(it) })
-
 
 /**
  * Creates a domain object with the specified name and type, and adds it to the container.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -48,7 +48,6 @@ import java.io.File
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
-
 /**
  * Sets the the default tasks of this project. These are used when no tasks names are provided when
  * starting the build.
@@ -58,7 +57,6 @@ inline
 fun Project.defaultTasks(vararg tasks: Task) {
     defaultTasks(*tasks.map { it.name }.toTypedArray())
 }
-
 
 /**
  * Applies zero or more plugins or scripts.
@@ -70,7 +68,6 @@ fun Project.defaultTasks(vararg tasks: Task) {
 inline
 fun Project.apply(crossinline block: ObjectConfigurationAction.() -> Unit) =
     apply({ it.block() })
-
 
 /**
  * Applies the given plugin. Does nothing if the plugin has already been applied.
@@ -85,7 +82,6 @@ inline
 fun <reified T : Plugin<Project>> Project.apply() =
     pluginManager.apply(T::class.java)
 
-
 /**
  * Executes the given configuration block against the [plugin convention]
  * [Convention.getPlugin] or extension of the specified type.
@@ -99,7 +95,6 @@ fun <reified T : Any> Project.configure(noinline configuration: T.() -> Unit) =
     convention.findPlugin(T::class.java)?.let(configuration)
         ?: convention.configure(T::class.java, configuration)
 
-
 /**
  * Returns the plugin convention or extension of the specified type.
  */
@@ -107,10 +102,8 @@ inline
 fun <reified T : Any> Project.the() =
     the(T::class)
 
-
 fun <T : Any> Project.the(extensionType: KClass<T>) =
     convention.findPlugin(extensionType.java) ?: convention.getByType(extensionType.java)
-
 
 /**
  * Creates a [Task] with the given [name] and [type], configures it with the given [configuration] action,
@@ -119,7 +112,6 @@ fun <T : Any> Project.the(extensionType: KClass<T>) =
 inline
 fun <reified type : Task> Project.task(name: String, noinline configuration: type.() -> Unit) =
     task(name, type::class, configuration)
-
 
 /**
  * Creates a [Task] with the given [name] and [type], and adds it to this project tasks container.
@@ -132,10 +124,8 @@ inline
 fun <reified type : Task> Project.task(name: String) =
     tasks.create(name, type::class.java)
 
-
 fun <T : Task> Project.task(name: String, type: KClass<T>, configuration: T.() -> Unit) =
     createTask(name, type, configuration)
-
 
 /**
  * Creates a [Task] with the given [name ] and [DefaultTask] type, configures it with the given [configuration] action,
@@ -144,10 +134,8 @@ fun <T : Task> Project.task(name: String, type: KClass<T>, configuration: T.() -
 fun Project.task(name: String, configuration: Task.() -> Unit): DefaultTask =
     createTask(name, DefaultTask::class, configuration)
 
-
 fun <T : Task> Project.createTask(name: String, type: KClass<T>, configuration: T.() -> Unit): T =
     tasks.create(name, type.java, configuration)
-
 
 /**
  * Configures the repositories for this project.
@@ -160,10 +148,8 @@ fun <T : Task> Project.createTask(name: String, type: KClass<T>, configuration: 
 fun Project.repositories(configuration: RepositoryHandler.() -> Unit) =
     repositories.configuration()
 
-
 fun ScriptHandler.repositories(configuration: RepositoryHandler.() -> Unit) =
     repositories.configuration()
-
 
 /**
  * Configures the dependencies for this project.
@@ -176,13 +162,11 @@ fun ScriptHandler.repositories(configuration: RepositoryHandler.() -> Unit) =
 fun Project.dependencies(configuration: DependencyHandlerScope.() -> Unit) =
     DependencyHandlerScope(dependencies).configuration()
 
-
 /**
  * Locates a [Project] property using [Project.findProperty].
  */
 operator fun Project.getValue(any: Any, property: KProperty<*>): Any? =
     findProperty(property.name)
-
 
 /**
  * Creates a [PropertyState] that holds values of the given type [T].
@@ -193,7 +177,6 @@ operator fun Project.getValue(any: Any, property: KProperty<*>): Any? =
 inline
 fun <reified T> Project.property(): PropertyState<T> =
     property(T::class.java)
-
 
 /**
  * Creates a dependency on the API of the current version of the Gradle Kotlin DSL.
@@ -208,11 +191,9 @@ fun Project.gradleKotlinDsl(): Dependency =
             gradleKotlinDslOf(project),
             "gradleKotlinDsl") as FileCollectionInternal)
 
-
 @Deprecated("Will be removed in 1.0", ReplaceWith("gradleKotlinDsl()"))
 fun Project.gradleScriptKotlinApi(): Dependency =
     gradleKotlinDsl()
-
 
 private
 fun fileCollectionOf(files: Collection<File>, name: String): FileCollection =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PropertyStateExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PropertyStateExtensions.kt
@@ -20,14 +20,12 @@ import org.gradle.api.provider.PropertyState
 
 import kotlin.reflect.KProperty
 
-
 /**
  * Property delegate for [PropertyState] instances.
  *
  * Example: `val someProperty by somePropertyState`
  */
 operator fun <T> PropertyState<T>.getValue(receiver: Any?, property: KProperty<*>): T = get()
-
 
 /**
  * Property delegate for [PropertyState] instances.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensions.kt
@@ -19,7 +19,6 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 
-
 /**
  * Adds and configures a Maven repository.
  *
@@ -34,7 +33,6 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
  */
 fun RepositoryHandler.maven(url: Any) =
     maven { it.setUrl(url) }
-
 
 /**
  * Adds and configures a Maven repository.
@@ -55,7 +53,6 @@ fun RepositoryHandler.maven(url: Any, action: MavenArtifactRepository.() -> Unit
         it.action()
     }
 
-
 /**
  * Adds and configures an Ivy repository.
  *
@@ -70,7 +67,6 @@ fun RepositoryHandler.maven(url: Any, action: MavenArtifactRepository.() -> Unit
  */
 fun RepositoryHandler.ivy(url: Any) =
     ivy { it.setUrl(url) }
-
 
 /**
  * Adds and configures an Ivy repository.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.initialization.dsl.ScriptHandler.CLASSPATH_CONFIGURATION
 
-
 /**
  * Receiver for the `buildscript` block.
  */

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -18,31 +18,23 @@ package org.gradle.kotlin.dsl.accessors
 
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
-
 import org.gradle.cache.internal.CacheKeyBuilder.CacheKeySpec
-
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
-
 import org.gradle.kotlin.dsl.cache.ScriptCache
 import org.gradle.kotlin.dsl.codegen.fileHeader
 import org.gradle.kotlin.dsl.support.compileToJar
 import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.serviceOf
-
 import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
-
 import org.jetbrains.org.objectweb.asm.ClassReader
 import org.jetbrains.org.objectweb.asm.Opcodes.ACC_PUBLIC
 import org.jetbrains.org.objectweb.asm.Opcodes.ACC_SYNTHETIC
-
 import java.io.BufferedWriter
 import java.io.Closeable
 import java.io.File
-
-import java.util.*
+import java.util.AbstractMap
 import java.util.jar.JarFile
-
 
 fun accessorsClassPathFor(project: Project, classPath: ClassPath) =
     project.getOrCreateSingletonProperty {
@@ -50,9 +42,7 @@ fun accessorsClassPathFor(project: Project, classPath: ClassPath) =
             ?: AccessorsClassPath(ClassPath.EMPTY, ClassPath.EMPTY)
     }
 
-
 data class AccessorsClassPath(val bin: ClassPath, val src: ClassPath)
-
 
 private
 fun buildAccessorsClassPathFor(project: Project, classPath: ClassPath) =
@@ -67,11 +57,9 @@ fun buildAccessorsClassPathFor(project: Project, classPath: ClassPath) =
             DefaultClassPath(accessorsSourceDir(cacheDir)))
     }
 
-
 private
 fun configuredProjectSchemaOf(project: Project) =
     aotProjectSchemaOf(project) ?: jitProjectSchemaOf(project)
-
 
 private
 fun aotProjectSchemaOf(project: Project) =
@@ -80,7 +68,6 @@ fun aotProjectSchemaOf(project: Project) =
         .getOrCreateSingletonProperty { multiProjectSchemaSnapshotOf(project) }
         .schema
         ?.let { it[project.path] }
-
 
 private
 fun jitProjectSchemaOf(project: Project) =
@@ -91,10 +78,8 @@ fun jitProjectSchemaOf(project: Project) =
         schemaFor(project).withKotlinTypeStrings()
     }
 
-
 private
 fun scriptCacheOf(project: Project) = project.serviceOf<ScriptCache>()
-
 
 private
 fun buildAccessorsJarFor(projectSchema: ProjectSchema<String>, classPath: ClassPath, outputDir: File) {
@@ -115,13 +100,11 @@ fun buildAccessorsJarFor(projectSchema: ProjectSchema<String>, classPath: ClassP
     })
 }
 
-
 internal
 sealed class TypeAccessibility {
     data class Accessible(val type: String) : TypeAccessibility()
     data class Inaccessible(val type: String, val reasons: List<InaccessibilityReason>) : TypeAccessibility()
 }
-
 
 internal
 sealed class InaccessibilityReason {
@@ -130,13 +113,13 @@ sealed class InaccessibilityReason {
     data class NonAvailable(val type: String) : InaccessibilityReason()
     data class Synthetic(val type: String) : InaccessibilityReason()
 
-    val explanation get() = when (this) {
-        is NonPublic    -> "`$type` is not public"
-        is NonAvailable -> "`$type` is not available"
-        is Synthetic    -> "`$type` is synthetic"
-    }
+    val explanation
+        get() = when (this) {
+            is NonPublic -> "`$type` is not public"
+            is NonAvailable -> "`$type` is not available"
+            is Synthetic -> "`$type` is synthetic"
+        }
 }
-
 
 internal
 fun availableProjectSchemaFor(projectSchema: ProjectSchema<String>, classPath: ClassPath) =
@@ -144,10 +127,8 @@ fun availableProjectSchemaFor(projectSchema: ProjectSchema<String>, classPath: C
         projectSchema.map(accessibilityProvider::accessibilityForType)
     }
 
-
 private
 typealias ClassFileIndex = (String) -> ByteArray?
-
 
 internal
 class TypeAccessibilityProvider(classPath: ClassPath) : Closeable {
@@ -180,9 +161,9 @@ class TypeAccessibilityProvider(classPath: ClassPath) : Closeable {
         val classBytes = classBytesFor(className) ?: return nonAvailable(className)
         val access = classAccessFrom(classBytes)
         return when {
-            ACC_PUBLIC !in access   -> nonPublic(className)
+            ACC_PUBLIC !in access -> nonPublic(className)
             ACC_SYNTHETIC in access -> synthetic(className)
-            else                    -> null
+            else -> null
         }
     }
 
@@ -195,9 +176,9 @@ class TypeAccessibilityProvider(classPath: ClassPath) : Closeable {
     private
     fun classFileIndexFor(jarOrDir: File): ClassFileIndex =
         when {
-            jarOrDir.isFile      -> jarIndexFor(jarOrDir)
+            jarOrDir.isFile -> jarIndexFor(jarOrDir)
             jarOrDir.isDirectory -> directoryIndexFor(jarOrDir)
-            else                 -> { _ -> null }
+            else -> { _ -> null }
         }
 
     private
@@ -236,53 +217,42 @@ class TypeAccessibilityProvider(classPath: ClassPath) : Closeable {
         ClassReader(classBytes).access
 }
 
-
 private
 operator fun Int.contains(flag: Int) =
     and(flag) == flag
-
 
 internal
 fun nonAvailable(type: String): InaccessibilityReason =
     InaccessibilityReason.NonAvailable(type)
 
-
 internal
 fun nonPublic(type: String): InaccessibilityReason =
     InaccessibilityReason.NonPublic(type)
-
 
 internal
 fun synthetic(type: String): InaccessibilityReason =
     InaccessibilityReason.Synthetic(type)
 
-
 internal
 fun accessible(type: String): TypeAccessibility =
     TypeAccessibility.Accessible(type)
-
 
 internal
 fun inaccessible(type: String, vararg reasons: InaccessibilityReason) =
     inaccessible(type, reasons.toList())
 
-
 internal
 fun inaccessible(type: String, reasons: List<InaccessibilityReason>): TypeAccessibility =
     TypeAccessibility.Inaccessible(type, reasons)
 
-
 private
 val logger by lazy { loggerFor<AccessorsClassPath>() }
-
 
 private
 fun accessorsSourceDir(baseDir: File) = File(baseDir, "src")
 
-
 private
 fun accessorsJar(baseDir: File) = File(baseDir, "gradle-kotlin-dsl-accessors.jar")
-
 
 private
 fun multiProjectSchemaSnapshotOf(project: Project) =
@@ -291,10 +261,8 @@ fun multiProjectSchemaSnapshotOf(project: Project) =
             loadMultiProjectSchemaFrom(it)
         })
 
-
 private
 data class MultiProjectSchemaSnapshot(val schema: Map<String, ProjectSchema<String>>?)
-
 
 private
 fun projectSchemaSnapshotFileOf(project: Project): File? =
@@ -303,38 +271,32 @@ fun projectSchemaSnapshotFileOf(project: Project): File? =
         .file(PROJECT_SCHEMA_RESOURCE_PATH)
         .takeIf { it.isFile }
 
-
 private
 fun classLoaderScopeOf(project: Project) =
     (project as ProjectInternal).classLoaderScope
-
 
 private
 fun cacheKeyFor(projectSchema: ProjectSchema<String>): CacheKeySpec =
     CacheKeySpec.withPrefix("gradle-kotlin-dsl-accessors") + projectSchema.toCacheKeyString()
 
-
 private
 fun ProjectSchema<String>.toCacheKeyString(): String =
     (extensions.entries.asSequence()
-     + conventions.entries.asSequence()
-     + mapEntry("configurations", configurations.sorted().joinToString(",")))
+        + conventions.entries.asSequence()
+        + mapEntry("configurations", configurations.sorted().joinToString(",")))
         .map { "${it.key}=${it.value}" }
         .sorted()
         .joinToString(separator = ":")
 
-
 private
 fun <K, V> mapEntry(key: K, value: V) =
     AbstractMap.SimpleEntry(key, value)
-
 
 private
 fun enabledJitAccessors(project: Project) =
     project.findProperty("org.gradle.kotlin.dsl.accessors")?.let {
         it != "false" && it != "off"
     } ?: true
-
 
 private
 fun writeAccessorsTo(outputFile: File, projectSchema: ProjectSchema<TypeAccessibility>): File =
@@ -344,7 +306,6 @@ fun writeAccessorsTo(outputFile: File, projectSchema: ProjectSchema<TypeAccessib
             writeAccessorsFor(projectSchema, writer)
         }
     }
-
 
 private
 fun writeAccessorsFor(projectSchema: ProjectSchema<TypeAccessibility>, writer: BufferedWriter) {
@@ -366,7 +327,6 @@ fun writeAccessorsFor(projectSchema: ProjectSchema<TypeAccessibility>, writer: B
         }
     }
 }
-
 
 /**
  * Location of the project schema snapshot taken by the _kotlinDslAccessorsSnapshot_ task relative to the root project.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -113,8 +113,7 @@ sealed class InaccessibilityReason {
     data class NonAvailable(val type: String) : InaccessibilityReason()
     data class Synthetic(val type: String) : InaccessibilityReason()
 
-    val explanation
-        get() = when (this) {
+    val explanation get() = when (this) {
             is NonPublic -> "`$type` is not public"
             is NonAvailable -> "`$type` is not available"
             is Synthetic -> "`$type` is synthetic"

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -255,4 +255,3 @@ fun isKotlinIdentifier(candidate: String): Boolean =
             && tokenEnd == candidate.length
             && tokenType == KtTokens.IDENTIFIER
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -19,7 +19,6 @@ package org.gradle.kotlin.dsl.accessors
 import org.jetbrains.kotlin.lexer.KotlinLexer
 import org.jetbrains.kotlin.lexer.KtTokens
 
-
 internal
 fun ProjectSchema<TypeAccessibility>.forEachAccessor(action: (String) -> Unit) {
     extensions.forEach { (name, type) ->
@@ -39,11 +38,10 @@ private
 fun extensionAccessorFor(name: String, typeAccess: TypeAccessibility): String? =
     codeForExtension(name) {
         when (typeAccess) {
-            is TypeAccessibility.Accessible   -> accessibleExtensionAccessorFor(name, typeAccess.type)
+            is TypeAccessibility.Accessible -> accessibleExtensionAccessorFor(name, typeAccess.type)
             is TypeAccessibility.Inaccessible -> inaccessibleExtensionAccessorFor(name, typeAccess)
         }
     }
-
 
 private
 fun accessibleExtensionAccessorFor(name: String, type: String): String =
@@ -61,7 +59,6 @@ fun accessibleExtensionAccessorFor(name: String, type: String): String =
             extensions.configure("$name", configure)
 
     """
-
 
 private
 fun inaccessibleExtensionAccessorFor(name: String, typeAccess: TypeAccessibility.Inaccessible): String =
@@ -84,16 +81,14 @@ fun inaccessibleExtensionAccessorFor(name: String, typeAccess: TypeAccessibility
 
     """
 
-
 private
 fun conventionAccessorFor(name: String, typeAccess: TypeAccessibility): String? =
     codeForExtension(name) {
         when (typeAccess) {
-            is TypeAccessibility.Accessible   -> accessibleConventionAccessorFor(name, typeAccess.type)
+            is TypeAccessibility.Accessible -> accessibleConventionAccessorFor(name, typeAccess.type)
             is TypeAccessibility.Inaccessible -> inaccessibleConventionAccessorFor(name, typeAccess)
         }
     }
-
 
 private
 fun accessibleConventionAccessorFor(name: String, type: String): String =
@@ -111,7 +106,6 @@ fun accessibleConventionAccessorFor(name: String, type: String): String =
             configure(`$name`)
 
     """
-
 
 private
 fun inaccessibleConventionAccessorFor(name: String, typeAccess: TypeAccessibility.Inaccessible): String =
@@ -133,7 +127,6 @@ fun inaccessibleConventionAccessorFor(name: String, typeAccess: TypeAccessibilit
             configure(`$name`)
 
     """
-
 
 private
 fun configurationAccessorFor(name: String): String? =
@@ -235,29 +228,24 @@ fun configurationAccessorFor(name: String): String? =
         """
     }
 
-
 private
 fun documentInaccessibilityReasons(name: String, typeAccess: TypeAccessibility.Inaccessible): String =
     "`$name` is not accessible in a type safe way because:\n${typeAccess.reasons.map { reason ->
         "         * - ${reason.explanation}"
     }.joinToString("\n")}"
 
-
 private inline
 fun codeForExtension(extensionName: String, code: () -> String): String? =
     if (isLegalExtensionName(extensionName)) code().replaceIndent()
     else null
-
 
 internal
 fun isLegalExtensionName(name: String): Boolean =
     isKotlinIdentifier("`$name`")
         && name.indexOfAny(invalidNameChars) < 0
 
-
 private
 val invalidNameChars = charArrayOf('.', '/', '\\')
-
 
 private
 fun isKotlinIdentifier(candidate: String): Boolean =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchema.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchema.kt
@@ -26,7 +26,6 @@ import org.gradle.api.reflect.TypeOf.typeOf
 import java.io.File
 import java.io.Serializable
 
-
 internal
 data class ProjectSchema<out T>(
     val extensions: Map<String, T>,
@@ -40,16 +39,13 @@ data class ProjectSchema<out T>(
             configurations.toList())
 }
 
-
 internal
 fun multiProjectKotlinStringSchemaFor(root: Project): Map<String, ProjectSchema<String>> =
     multiProjectSchemaFor(root).mapValues { it.value.withKotlinTypeStrings() }
 
-
 internal
 fun multiProjectSchemaFor(root: Project): Map<String, ProjectSchema<TypeOf<*>>> =
     root.allprojects.map { it.path to schemaFor(it) }.toMap()
-
 
 internal
 fun schemaFor(project: Project): ProjectSchema<TypeOf<*>> =
@@ -57,7 +53,6 @@ fun schemaFor(project: Project): ProjectSchema<TypeOf<*>> =
         project.extensions.schema,
         project.convention.plugins,
         project.configurations.names.toList())
-
 
 internal
 fun accessibleProjectSchemaFrom(
@@ -74,21 +69,17 @@ fun accessibleProjectSchemaFrom(
         configurations = configurationNames
             .filter(::isPublic))
 
-
 internal
 fun isPublic(name: String): Boolean =
     !name.startsWith("_")
-
 
 internal
 fun toJson(multiProjectStringSchema: Map<String, ProjectSchema<String>>): String =
     toJson(multiProjectStringSchema)
 
-
 internal
 fun ProjectSchema<TypeOf<*>>.withKotlinTypeStrings() =
     map(::kotlinTypeStringFor)
-
 
 @Suppress("unchecked_cast")
 internal
@@ -99,7 +90,6 @@ fun loadMultiProjectSchemaFrom(file: File) =
             conventions = it.value["conventions"] as? Map<String, String> ?: emptyMap(),
             configurations = it.value["configurations"] as? List<String> ?: emptyList())
     }
-
 
 internal
 fun kotlinTypeStringFor(type: TypeOf<*>): String =
@@ -115,7 +105,6 @@ fun kotlinTypeStringFor(type: TypeOf<*>): String =
                 toString().let { primitiveTypeStrings[it] ?: it }
         }
     }
-
 
 private
 val primitiveTypeStrings =
@@ -138,7 +127,6 @@ val primitiveTypeStrings =
         "float" to "Float",
         "java.lang.Double" to "Double",
         "double" to "Double")
-
 
 internal
 val primitiveKotlinTypeNames = primitiveTypeStrings.values.toHashSet()

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/SingletonProperties.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/SingletonProperties.kt
@@ -20,7 +20,6 @@ import org.gradle.api.plugins.ExtensionAware
 
 import org.gradle.kotlin.dsl.extra
 
-
 internal inline
 fun <reified T : Any> ExtensionAware.getOrCreateSingletonProperty(crossinline create: () -> T): T =
     extra.run {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
@@ -18,9 +18,10 @@ package org.gradle.kotlin.dsl.accessors.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
-
-import org.gradle.kotlin.dsl.accessors.*
-
+import org.gradle.kotlin.dsl.accessors.accessible
+import org.gradle.kotlin.dsl.accessors.forEachAccessor
+import org.gradle.kotlin.dsl.accessors.schemaFor
+import org.gradle.kotlin.dsl.accessors.withKotlinTypeStrings
 
 open class PrintAccessors : DefaultTask() {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/UpdateProjectSchema.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/UpdateProjectSchema.kt
@@ -22,11 +22,11 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import org.gradle.kotlin.dsl.accessors.*
+import org.gradle.kotlin.dsl.accessors.PROJECT_SCHEMA_RESOURCE_PATH
+import org.gradle.kotlin.dsl.accessors.multiProjectKotlinStringSchemaFor
+import org.gradle.kotlin.dsl.accessors.toJson
 
 import java.io.File
-
 
 open class UpdateProjectSchema : DefaultTask() {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
@@ -21,7 +21,6 @@ import org.gradle.StartParameter
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.internal.CacheKeyBuilder
 
-
 internal
 object BuildServices {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
@@ -24,7 +24,6 @@ import org.gradle.cache.internal.CacheKeyBuilder.CacheKeySpec
 
 import java.io.File
 
-
 internal
 class ScriptCache(
 
@@ -49,14 +48,13 @@ class ScriptCache(
             .apply { if (recompileScripts) withValidator { false } }
             .withInitializer(initializer)
             .open().run {
-                close()
-                baseDir
-            }
+            close()
+            baseDir
+        }
 
     private
     fun cacheKeyFor(spec: CacheKeySpec) = cacheKeyBuilder.build(spec)
 }
-
 
 internal
 operator fun CacheKeySpec.plus(files: List<File>) =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
@@ -59,4 +59,3 @@ class ScriptCache(
 internal
 operator fun CacheKeySpec.plus(files: List<File>) =
     files.fold(this, CacheKeySpec::plus)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
@@ -16,24 +16,20 @@
 
 package org.gradle.kotlin.dsl.codegen
 
-import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.compileToDirectory
+import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.zipTo
-
 import java.io.File
-
 
 internal
 fun generateApiExtensionsJar(outputFile: File, gradleJars: Collection<File>, onProgress: () -> Unit) {
     ApiExtensionsJarGenerator(onProgress = onProgress).generate(outputFile, gradleJars)
 }
 
-
 internal
 interface KotlinFileCompiler {
     fun compileToDirectory(outputDirectory: File, sourceFiles: Collection<File>, classPath: Collection<File>)
 }
-
 
 internal
 class ApiExtensionsJarGenerator(
@@ -80,7 +76,6 @@ class ApiExtensionsJarGenerator(
     private
     val packageDir = packageName.replace('.', '/')
 }
-
 
 internal
 object StandardKotlinFileCompiler : KotlinFileCompiler {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/Constants.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/Constants.kt
@@ -42,4 +42,3 @@ const val licenseHeader = """/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */"""
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/Constants.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/Constants.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl.codegen
 
-
 internal
 val fileHeader: String
     get() = """$licenseHeader
@@ -24,10 +23,8 @@ val fileHeader: String
 package $packageName
 """
 
-
 internal
 const val packageName = "org.gradle.kotlin.dsl"
-
 
 internal
 const val licenseHeader = """/*

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -24,22 +24,22 @@ import java.io.File
 import java.util.Properties
 import java.util.jar.JarFile
 
-
 internal
 fun writeBuiltinPluginIdExtensionsTo(file: File, gradleJars: Iterable<File>) {
-    file.bufferedWriter().use { it.apply {
-        write(fileHeader)
-        write("\n")
-        write("import ${PluginDependenciesSpec::class.qualifiedName}\n")
-        write("import ${PluginDependencySpec::class.qualifiedName}\n")
-        pluginIdExtensionDeclarationsFor(gradleJars).forEach {
+    file.bufferedWriter().use {
+        it.apply {
+            write(fileHeader)
             write("\n")
-            write(it)
-            write("\n")
+            write("import ${PluginDependenciesSpec::class.qualifiedName}\n")
+            write("import ${PluginDependencySpec::class.qualifiedName}\n")
+            pluginIdExtensionDeclarationsFor(gradleJars).forEach {
+                write("\n")
+                write(it)
+                write("\n")
+            }
         }
-    }}
+    }
 }
-
 
 private
 fun pluginIdExtensionDeclarationsFor(jars: Iterable<File>): Sequence<String> {
@@ -62,7 +62,6 @@ fun pluginIdExtensionDeclarationsFor(jars: Iterable<File>): Sequence<String> {
         }
 }
 
-
 private
 data class PluginExtension(
     val memberName: String,
@@ -70,14 +69,12 @@ data class PluginExtension(
     val website: String?,
     val implementationClass: String)
 
-
 private
 fun pluginExtensionsFrom(jars: Iterable<File>): Sequence<PluginExtension> =
     jars
         .asSequence()
         .filter { it.name.startsWith("gradle-") }
         .flatMap(::pluginExtensionsFrom)
-
 
 private
 fun pluginExtensionsFrom(file: File): Sequence<PluginExtension> =
@@ -89,7 +86,6 @@ fun pluginExtensionsFrom(file: File): Sequence<PluginExtension> =
             // One plugin extension for the simple id, e.g., "application"
             PluginExtension(simpleId, id, website, implementationClass)
         }
-
 
 internal
 object UserGuideLink {
@@ -241,10 +237,8 @@ object UserGuideLink {
             "wrapper" to "wrapper_plugin.html")
 }
 
-
 private
 data class PluginEntry(val pluginId: String, val implementationClass: String)
-
 
 private
 fun pluginEntriesFrom(jar: File): List<PluginEntry> =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -252,4 +252,3 @@ fun pluginEntriesFrom(jar: File): List<PluginEntry> =
             PluginEntry(id, implementationClass)
         }.toList()
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ZipInputStreamEntry.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ZipInputStreamEntry.kt
@@ -18,9 +18,7 @@ package org.gradle.kotlin.dsl.codegen
 
 import java.util.zip.ZipEntry
 
-
 internal
 val ZipEntry.isFile: Boolean
     get() = !isDirectory
-
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ZipInputStreamEntry.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ZipInputStreamEntry.kt
@@ -21,4 +21,3 @@ import java.util.zip.ZipEntry
 internal
 val ZipEntry.isFile: Boolean
     get() = !isDirectory
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/Either.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/Either.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl.concurrent
 
-
 /**
  * Represents values with two possibilities.
  */
@@ -34,18 +33,15 @@ sealed class Either<out L, out R> {
     }
 }
 
-
 /**
  * Constructs a [Either.Left] value.
  */
 internal
 fun <L, R> left(value: L): Either<L, R> = Either.Left<L, R>(value)
 
-
 /**
  * Constructs a [Either.Right] value.
  */
 internal
 fun <L, R> right(value: R): Either<L, R> = Either.Right<L, R>(value)
-
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/Either.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/Either.kt
@@ -44,4 +44,3 @@ fun <L, R> left(value: L): Either<L, R> = Either.Left<L, R>(value)
  */
 internal
 fun <L, R> right(value: R): Either<L, R> = Either.Right<L, R>(value)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/future.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/future.kt
@@ -26,7 +26,6 @@ import kotlin.coroutines.experimental.CoroutineContext
 import kotlin.coroutines.experimental.EmptyCoroutineContext
 import kotlin.coroutines.experimental.startCoroutine
 
-
 /**
  * Starts and exposes the given suspending [computation] as a [Future] value.
  *
@@ -37,7 +36,6 @@ fun <T> future(context: CoroutineContext = EmptyCoroutineContext, computation: s
     FutureContinuation<T>(context).also { k ->
         computation.startCoroutine(completion = k)
     }
-
 
 private
 class FutureContinuation<T>(override val context: CoroutineContext) : Future<T>, Continuation<T> {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
@@ -44,4 +44,3 @@ fun <T> Continuation<T>.asResultHandler(): ResultHandler<T> =
         override fun onFailure(failure: GradleConnectionException) =
             resumeWithException(failure)
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
@@ -22,7 +22,6 @@ import org.gradle.tooling.ResultHandler
 import kotlin.coroutines.experimental.Continuation
 import kotlin.coroutines.experimental.suspendCoroutine
 
-
 /**
  * Universal Tooling API wrapper.
  *
@@ -30,18 +29,18 @@ import kotlin.coroutines.experimental.suspendCoroutine
  *
  * Execution will continue on the TAPI executor thread.
  */
-internal inline
-suspend fun <T> tapi(crossinline computation: (ResultHandler<T>) -> Unit): T =
+internal suspend
+inline fun <T> tapi(crossinline computation: (ResultHandler<T>) -> Unit): T =
     suspendCoroutine { k: Continuation<T> ->
         computation(k.asResultHandler())
     }
-
 
 internal
 fun <T> Continuation<T>.asResultHandler(): ResultHandler<T> =
     object : ResultHandler<T> {
         override fun onComplete(result: T) =
             resume(result)
+
         override fun onFailure(failure: GradleConnectionException) =
             resumeWithException(failure)
     }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -24,7 +24,6 @@ import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.kotlin.dsl.cache.ScriptCache
 import org.gradle.kotlin.dsl.support.ImplicitImports
 
-
 internal
 object BuildServices {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtraction.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtraction.kt
@@ -17,18 +17,18 @@
 package org.gradle.kotlin.dsl.provider
 
 import org.jetbrains.kotlin.lexer.KotlinLexer
-import org.jetbrains.kotlin.lexer.KtTokens.*
-
+import org.jetbrains.kotlin.lexer.KtTokens.IDENTIFIER
+import org.jetbrains.kotlin.lexer.KtTokens.LBRACE
+import org.jetbrains.kotlin.lexer.KtTokens.RBRACE
+import org.jetbrains.kotlin.lexer.KtTokens.WHITE_SPACE_OR_COMMENT_BIT_SET
 
 internal
 class UnexpectedBlock(val identifier: String, val location: IntRange)
     : RuntimeException("Unexpected block found.")
 
-
 internal
 fun extractBuildscriptBlockFrom(script: String) =
     extractTopLevelSectionFrom(script, "buildscript")
-
 
 /**
  * Extract a top-level section from the given [script]. The section must be in the form:
@@ -56,14 +56,12 @@ fun extractTopLevelSectionFrom(script: String, identifier: String): IntRange? {
     }
 }
 
-
 private
 fun KotlinLexer.expectNoMore(identifier: String) {
     nextTopLevelSection(identifier)?.let {
         throw UnexpectedBlock(identifier, it)
     }
 }
-
 
 private
 fun KotlinLexer.nextTopLevelSection(identifier: String): IntRange? =
@@ -77,14 +75,12 @@ fun KotlinLexer.nextTopLevelSection(identifier: String): IntRange? =
         } else null
     }
 
-
 private
 fun KotlinLexer.skipWhiteSpaceAndComments() {
     while (tokenType in WHITE_SPACE_OR_COMMENT_BIT_SET) {
         advance()
     }
 }
-
 
 private
 fun KotlinLexer.findTopLevelIdentifier(identifier: String): Int? {
@@ -102,7 +98,6 @@ fun KotlinLexer.findTopLevelIdentifier(identifier: String): Int? {
     }
     return null
 }
-
 
 private
 fun KotlinLexer.findBlockEnd(): Int? {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CachingKotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CachingKotlinCompiler.kt
@@ -18,30 +18,23 @@ package org.gradle.kotlin.dsl.provider
 
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.CacheKeyBuilder.CacheKeySpec
-
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
-
 import org.gradle.kotlin.dsl.KotlinBuildScript
 import org.gradle.kotlin.dsl.cache.ScriptCache
-
-import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.ImplicitImports
 import org.gradle.kotlin.dsl.support.KotlinBuildscriptBlock
 import org.gradle.kotlin.dsl.support.KotlinPluginsBlock
 import org.gradle.kotlin.dsl.support.compileKotlinScriptToDirectory
+import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.messageCollectorFor
-
 import org.jetbrains.kotlin.script.KotlinScriptDefinition
-
 import java.io.File
-
 import kotlin.reflect.KClass
 import kotlin.script.dependencies.Environment
 import kotlin.script.dependencies.ScriptContents
 import kotlin.script.experimental.dependencies.DependenciesResolver
 import kotlin.script.experimental.dependencies.ScriptDependencies
-
 
 internal
 class CachingKotlinCompiler(

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CharSequenceExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CharSequenceExtensions.kt
@@ -18,18 +18,15 @@ package org.gradle.kotlin.dsl.provider
 
 import kotlin.coroutines.experimental.buildSequence
 
-
 internal
 fun CharSequence.linePreservingSubstring(range: IntRange): String =
     linePreservingSubstring_(range).second
-
 
 internal
 fun CharSequence.linePreservingSubstring_(range: IntRange): Pair<Int, String> {
     val lineCount = take(range.start).count { it == '\n' }
     return lineCount to "\n".repeat(lineCount) + substring(range)
 }
-
 
 /**
  * Computes the 1-based line and column numbers from the given [range].
@@ -42,7 +39,6 @@ fun CharSequence.lineAndColumnFromRange(range: IntRange): Pair<Int, Int> {
     val lastNewLineIndex = prefix.lastIndexOf('\n')
     return (lineCountBefore + 1) to (range.start - lastNewLineIndex)
 }
-
 
 internal
 fun CharSequence.splitIncluding(delimiter: Char) = buildSequence {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchy.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchy.kt
@@ -17,25 +17,21 @@
 package org.gradle.kotlin.dsl.provider
 
 import groovy.json.JsonOutput.toJson
-
 import org.gradle.api.internal.initialization.AbstractClassLoaderScope
 import org.gradle.api.internal.initialization.ClassLoaderScope
-
 import org.gradle.internal.classloader.ClassLoaderVisitor
-
 import org.gradle.kotlin.dsl.support.foldHierarchy
-
 import java.net.URL
-
-import java.util.*
-
+import java.util.ArrayDeque
+import java.util.ArrayList
+import java.util.IdentityHashMap
+import java.util.LinkedHashSet
 
 /**
  * A formatter for strings that might contain file system paths.
  */
 internal
 typealias PathStringFormatter = (String) -> String
-
 
 internal
 fun classLoaderHierarchyJsonFor(
@@ -48,10 +44,8 @@ fun classLoaderHierarchyJsonFor(
         hierarchyOf(targetScope),
         pathFormatter)
 
-
 private
 typealias ClassLoaderId = String
-
 
 private
 class ClassLoaderNode(
@@ -59,7 +53,6 @@ class ClassLoaderNode(
     val label: String,
     val classPath: MutableSet<URL> = LinkedHashSet(),
     val parents: MutableSet<ClassLoaderId> = LinkedHashSet())
-
 
 private
 fun classLoaderHierarchyJsonFor(
@@ -89,13 +82,11 @@ fun classLoaderHierarchyJsonFor(
         ))
 }
 
-
 private
 fun hierarchyOf(initialScope: ClassLoaderScope): List<ClassLoaderScope> =
     initialScope.foldHierarchy(arrayListOf<ClassLoaderScope>()) { result, scope ->
         result.apply { add(scope) }
     }
-
 
 private
 fun hierarchyOf(classLoader: ClassLoader): ArrayList<ClassLoaderNode> {
@@ -135,7 +126,6 @@ fun hierarchyOf(classLoader: ClassLoader): ArrayList<ClassLoaderNode> {
     visitor.visit(classLoader)
     return classLoaders
 }
-
 
 private
 fun idOf(classLoader: ClassLoader): String =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
@@ -16,12 +16,10 @@
 
 package org.gradle.kotlin.dsl.provider
 
-import org.gradle.kotlin.dsl.support.ProgressMonitor
-
 import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.progress.PercentageProgressFormatter
-
+import org.gradle.kotlin.dsl.support.ProgressMonitor
 import java.io.File
 
 interface JarGenerationProgressMonitorProvider {
@@ -39,6 +37,7 @@ class StandardJarGenerationProgressMonitorProvider(
             override fun onProgress() {
                 progressLogger.progress(progressFormatter.incrementAndGetProgress())
             }
+
             override fun close() {
                 progressLogger.completed()
             }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -21,31 +21,21 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.ProjectInternal
-
 import org.gradle.groovy.scripts.ScriptSource
-
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
-
-import org.gradle.plugin.use.internal.PluginRequestApplicator
-import org.gradle.plugin.use.internal.PluginRequestCollector
-import org.gradle.plugin.management.internal.PluginRequests
-
 import org.gradle.kotlin.dsl.accessors.accessorsClassPathFor
 import org.gradle.kotlin.dsl.get
-
-import org.gradle.kotlin.dsl.support.compilerMessageFor
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
+import org.gradle.kotlin.dsl.support.compilerMessageFor
 import org.gradle.kotlin.dsl.support.userHome
-
+import org.gradle.plugin.management.internal.PluginRequests
+import org.gradle.plugin.use.internal.PluginRequestApplicator
+import org.gradle.plugin.use.internal.PluginRequestCollector
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt.convertLineSeparators
-
 import java.io.File
-
 import java.lang.reflect.InvocationTargetException
-
-import java.util.*
-
+import java.util.ArrayList
 
 internal
 class KotlinBuildScriptCompiler(
@@ -201,7 +191,7 @@ class KotlinBuildScriptCompiler(
         withContextClassLoader(pluginsBlockClass.classLoader) {
             try {
                 instantiate(pluginsBlockClass, pluginDependenciesSpec)
-            } catch(e: InvocationTargetException) {
+            } catch (e: InvocationTargetException) {
                 throw e.targetException
             }
         }
@@ -269,7 +259,7 @@ class KotlinBuildScriptCompiler(
     fun executeScriptOf(scriptClass: Class<*>, target: Project) {
         try {
             instantiate(scriptClass, target)
-        } catch(e: InvocationTargetException) {
+        } catch (e: InvocationTargetException) {
             if (e.cause is Error) {
                 tryToLogClassLoaderHierarchyOf(scriptClass, target)
             }
@@ -353,16 +343,14 @@ class KotlinBuildScriptCompiler(
 
 }
 
-
 private inline
 fun ignoringErrors(block: () -> Unit) {
     try {
         block()
-    } catch(e: Exception) {
+    } catch (e: Exception) {
         e.printStackTrace()
     }
 }
-
 
 private inline
 fun withContextClassLoader(classLoader: ClassLoader, block: () -> Unit) {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptBasePlugin.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptBasePlugin.kt
@@ -25,7 +25,7 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.task
 
 class KotlinScriptBasePlugin : Plugin<Project> {
-    override fun apply(project: Project) =
+    override fun apply(project: Project) : Unit = // ktlint-disable
         project.run {
             rootProject.apply<KotlinScriptRootPlugin>()
             task<PrintAccessors>("kotlinDslAccessorsReport")

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptBasePlugin.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptBasePlugin.kt
@@ -24,15 +24,13 @@ import org.gradle.kotlin.dsl.accessors.tasks.UpdateProjectSchema
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.task
 
-
 class KotlinScriptBasePlugin : Plugin<Project> {
-    override fun apply(project: Project): Unit =
+    override fun apply(project: Project) =
         project.run {
             rootProject.apply<KotlinScriptRootPlugin>()
             task<PrintAccessors>("kotlinDslAccessorsReport")
         }
 }
-
 
 class KotlinScriptRootPlugin : Plugin<Project> {
     override fun apply(project: Project) {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -37,32 +37,25 @@ import org.gradle.util.GFileUtils.moveFile
 
 import java.io.File
 
-
 fun gradleKotlinDslOf(project: Project): List<File> =
     kotlinScriptClassPathProviderOf(project).run {
         gradleKotlinDsl.asFiles
     }
 
-
 fun kotlinScriptClassPathProviderOf(project: Project) =
     project.serviceOf<KotlinScriptClassPathProvider>()
-
 
 internal
 typealias JarCache = (String, JarGenerator) -> File
 
-
 internal
 typealias JarGenerator = (File) -> Unit
-
 
 private
 typealias JarGeneratorWithProgress = (File, () -> Unit) -> Unit
 
-
 internal
 typealias JarsProvider = () -> Collection<File>
-
 
 class KotlinScriptClassPathProvider(
     val classPathRegistry: ClassPathRegistry,
@@ -141,20 +134,16 @@ class KotlinScriptClassPathProvider(
     }
 }
 
-
 internal
 fun gradleApiJarsProviderFor(dependencyFactory: DependencyFactory): JarsProvider =
     { (dependencyFactory.gradleApi() as SelfResolvingDependency).resolve() }
-
 
 private
 fun DependencyFactory.gradleApi(): Dependency =
     createDependency(gradleApiNotation)
 
-
 private
 val gradleApiNotation = DependencyFactory.ClassPathNotation.GRADLE_API
-
 
 private
 fun isKotlinJar(name: String): Boolean =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
@@ -16,14 +16,10 @@
 
 package org.gradle.kotlin.dsl.provider
 
-import org.gradle.kotlin.dsl.support.loggerFor
-
 import org.gradle.api.Project
-
 import org.gradle.configuration.ScriptPlugin
-
 import org.gradle.groovy.scripts.ScriptSource
-
+import org.gradle.kotlin.dsl.support.loggerFor
 import java.lang.IllegalArgumentException
 
 class KotlinScriptPlugin(

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
@@ -20,17 +20,12 @@ import org.gradle.api.Project
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
-
 import org.gradle.configuration.ScriptPlugin
 import org.gradle.configuration.ScriptPluginFactory
-
 import org.gradle.groovy.scripts.ScriptSource
-
-import org.gradle.plugin.use.internal.PluginRequestApplicator
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
-
+import org.gradle.plugin.use.internal.PluginRequestApplicator
 import javax.inject.Inject
-
 
 class KotlinScriptPluginFactory @Inject internal constructor(
     val classPathProvider: KotlinScriptClassPathProvider,

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/CompactTree.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/CompactTree.kt
@@ -20,16 +20,13 @@ import org.gradle.kotlin.dsl.provider.splitIncluding
 
 import java.io.File
 
-
 internal
 fun compactStringFor(files: Iterable<java.io.File>) =
     compactStringFor(files.map { it.path }, File.separatorChar)
 
-
 internal
 fun compactStringFor(paths: Iterable<String>, separator: Char) =
     CompactTree.Companion.of(paths.map { it.splitIncluding(separator).toList() }).toString()
-
 
 private
 sealed class CompactTree {
@@ -43,21 +40,21 @@ sealed class CompactTree {
                 .map { (label, remaining) ->
                     val subTree = CompactTree.Companion.of(remaining)
                     when (subTree) {
-                        is CompactTree.Empty  -> CompactTree.Label(label)
-                        is CompactTree.Label  -> CompactTree.Label(
+                        is CompactTree.Empty -> CompactTree.Label(label)
+                        is CompactTree.Label -> CompactTree.Label(
                             label + subTree.label)
                         is CompactTree.Branch -> CompactTree.Edge(
                             Label(label), subTree)
-                        is CompactTree.Edge   -> CompactTree.Edge(
+                        is CompactTree.Edge -> CompactTree.Edge(
                             Label(label + subTree.label), subTree.tree)
                     }
                 }.let {
-                    when (it.size) {
-                        0    -> CompactTree.Empty
-                        1    -> it.first()
-                        else -> CompactTree.Branch(it)
-                    }
+                when (it.size) {
+                    0 -> CompactTree.Empty
+                    1 -> it.first()
+                    else -> CompactTree.Branch(it)
                 }
+            }
     }
 
     object Empty : CompactTree() {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -16,28 +16,19 @@
 
 package org.gradle.kotlin.dsl.resolver
 
-import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
-
 import org.gradle.kotlin.dsl.concurrent.future
-
+import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 import org.gradle.tooling.ProgressListener
-
 import java.io.File
-
 import java.net.URI
-
 import java.security.MessageDigest
-
 import java.util.Arrays.equals
-
 import kotlin.script.dependencies.KotlinScriptExternalDependencies
 import kotlin.script.dependencies.ScriptContents
 import kotlin.script.dependencies.ScriptDependenciesResolver
 
-
 internal
 typealias Environment = Map<String, Any?>
-
 
 class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
 
@@ -54,7 +45,7 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
                     log(ResolvedToPrevious(script.file, environment, previousDependencies))
                     previousDependencies
                 }
-                is ResolverAction.RequestNew     -> {
+                is ResolverAction.RequestNew -> {
                     assembleDependenciesFrom(script.file, environment!!, action.buildscriptBlockHash)
                 }
             }
@@ -136,7 +127,6 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
         ResolverEventLogger.log(event)
 }
 
-
 /**
  * The resolver can either return the previous result
  * or request new dependency information from Gradle.
@@ -146,7 +136,6 @@ sealed class ResolverAction {
     object ReturnPrevious : ResolverAction()
     class RequestNew(val buildscriptBlockHash: ByteArray?) : ResolverAction()
 }
-
 
 internal
 object ResolverCoordinator {
@@ -203,10 +192,8 @@ object ResolverCoordinator {
     }
 }
 
-
 internal
 typealias ScriptSectionTokensProvider = (CharSequence, String) -> Sequence<CharSequence>
-
 
 internal
 class KotlinBuildScriptDependencies(
@@ -214,7 +201,6 @@ class KotlinBuildScriptDependencies(
     override val sources: Iterable<File>,
     override val imports: Iterable<String>,
     val buildscriptBlockHash: ByteArray?) : KotlinScriptExternalDependencies
-
 
 internal
 fun projectRootOf(scriptFile: File, importedProjectRoot: File): File {
@@ -224,12 +210,12 @@ fun projectRootOf(scriptFile: File, importedProjectRoot: File): File {
     tailrec fun test(dir: File): File =
         when {
             dir == importedProjectRoot -> importedProjectRoot
-            isProjectRoot(dir)         -> dir
-            else                       -> {
+            isProjectRoot(dir) -> dir
+            else -> {
                 val parentDir = dir.parentFile
                 when (parentDir) {
                     null, dir -> scriptFile.parentFile // external project
-                    else      -> test(parentDir)
+                    else -> test(parentDir)
                 }
             }
         }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -101,4 +101,3 @@ fun applyGradleInstallationTo(connector: org.gradle.tooling.GradleConnector, req
             GradleInstallation.Wrapper -> connector.useBuildDistribution()
         }
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -22,7 +22,6 @@ import org.gradle.kotlin.dsl.provider.KotlinScriptPluginFactory
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 import org.gradle.tooling.ModelBuilder
 
-
 internal
 sealed class GradleInstallation {
 
@@ -35,7 +34,6 @@ sealed class GradleInstallation {
     object Wrapper : GradleInstallation()
 }
 
-
 internal
 data class KotlinBuildScriptModelRequest(
     val projectDir: java.io.File,
@@ -46,16 +44,13 @@ data class KotlinBuildScriptModelRequest(
     val options: List<String> = emptyList(),
     val jvmOptions: List<String> = emptyList())
 
-
 internal
 typealias ModelBuilderCustomization = ModelBuilder<KotlinBuildScriptModel>.() -> Unit
-
 
 internal
 suspend fun fetchKotlinBuildScriptModelFor(
     request: KotlinBuildScriptModelRequest,
-    modelBuilderCustomization: ModelBuilderCustomization = {}): KotlinBuildScriptModel
-{
+    modelBuilderCustomization: ModelBuilderCustomization = {}): KotlinBuildScriptModel {
 
     val connection = projectConnectionFor(request)
     try {
@@ -66,11 +61,9 @@ suspend fun fetchKotlinBuildScriptModelFor(
     }
 }
 
-
 private
 fun projectConnectionFor(request: KotlinBuildScriptModelRequest): org.gradle.tooling.ProjectConnection =
     connectorFor(request).connect()
-
 
 private
 fun org.gradle.tooling.ProjectConnection.modelBuilderFor(request: KotlinBuildScriptModelRequest) =
@@ -78,18 +71,15 @@ fun org.gradle.tooling.ProjectConnection.modelBuilderFor(request: KotlinBuildScr
         setJavaHome(request.javaHome)
         setJvmArguments(request.jvmOptions + modelSpecificJvmOptions)
         request.scriptFile?.let {
-            withArguments(request.options + "-P${kotlinBuildScriptModelTarget}=${it.canonicalPath}")
+            withArguments(request.options + "-P$kotlinBuildScriptModelTarget=${it.canonicalPath}")
         } ?: withArguments(request.options)
     }
-
 
 private
 val modelSpecificJvmOptions =
     listOf("-D${KotlinScriptPluginFactory.Companion.modeSystemPropertyName}=${KotlinScriptPluginFactory.Companion.classPathMode}")
 
-
 val kotlinBuildScriptModelTarget = "org.gradle.kotlin.dsl.provider.script"
-
 
 internal
 fun connectorFor(request: KotlinBuildScriptModelRequest): org.gradle.tooling.GradleConnector =
@@ -101,15 +91,14 @@ fun connectorFor(request: KotlinBuildScriptModelRequest): org.gradle.tooling.Gra
             applyGradleInstallationTo(connector, request)
         }
 
-
 private
 fun applyGradleInstallationTo(connector: org.gradle.tooling.GradleConnector, request: KotlinBuildScriptModelRequest): org.gradle.tooling.GradleConnector =
     request.gradleInstallation.run {
         when (this) {
-            is GradleInstallation.Local   -> connector.useInstallation(dir)
-            is GradleInstallation.Remote  -> connector.useDistribution(uri)
+            is GradleInstallation.Local -> connector.useInstallation(dir)
+            is GradleInstallation.Remote -> connector.useDistribution(uri)
             is GradleInstallation.Version -> connector.useGradleVersion(number)
-            GradleInstallation.Wrapper    -> connector.useBuildDistribution()
+            GradleInstallation.Wrapper -> connector.useBuildDistribution()
         }
     }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
@@ -16,28 +16,22 @@
 
 package org.gradle.kotlin.dsl.resolver
 
-import kotlin.script.dependencies.KotlinScriptExternalDependencies
-
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
-
 import java.io.File
-
+import kotlin.script.dependencies.KotlinScriptExternalDependencies
 
 internal
 sealed class ResolverEvent
-
 
 internal
 data class ResolutionFailure(
     val scriptFile: File?,
     val failure: Exception) : ResolverEvent()
 
-
 internal
 data class ResolutionProgress(
     val scriptFile: File?,
     val description: String) : ResolverEvent()
-
 
 internal
 data class ResolvedToPrevious(
@@ -45,18 +39,15 @@ data class ResolvedToPrevious(
     val environment: Map<String, Any?>?,
     val previousDependencies: KotlinScriptExternalDependencies?) : ResolverEvent()
 
-
 internal
 data class SubmittedModelRequest(
     val scriptFile: File?,
     val request: KotlinBuildScriptModelRequest) : ResolverEvent()
 
-
 internal
 data class ReceivedModelResponse(
     val scriptFile: File?,
     val response: KotlinBuildScriptModel) : ResolverEvent()
-
 
 internal
 data class ResolvedDependencies(

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -18,24 +18,19 @@ package org.gradle.kotlin.dsl.resolver
 
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.support.userHome
-
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
-
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter
 import java.io.PrintWriter
-
 import java.text.SimpleDateFormat
-
-import java.util.*
+import java.util.Date
+import java.util.GregorianCalendar
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.TimeUnit
-
 import kotlin.concurrent.thread
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
-
 
 internal
 object ResolverEventLogger {
@@ -93,9 +88,9 @@ object ResolverEventLogger {
     fun logDirForOperatingSystem() =
         OperatingSystem.current().run {
             when {
-                isMacOsX  -> "Library/Logs/gradle-kotlin-dsl"
+                isMacOsX -> "Library/Logs/gradle-kotlin-dsl"
                 isWindows -> "Application Data/gradle-kotlin-dsl/log"
-                else      -> ".gradle-kotlin-dsl/log"
+                else -> ".gradle-kotlin-dsl/log"
             }
         }
 
@@ -119,7 +114,7 @@ object ResolverEventLogger {
                         "scriptFile" to scriptFile,
                         "response" to prettyPrint(response, indentation = 2)))
 
-            else                     ->
+            else ->
                 prettyPrintAny(this)
         }
     }
@@ -162,7 +157,7 @@ object ResolverEventLogger {
     fun indentationStringFor(indentation: Int?) =
         when (indentation) {
             null, 1 -> "\t"
-            else    -> "\t\t"
+            else -> "\t\t"
         }
 }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -160,4 +160,3 @@ object ResolverEventLogger {
             else -> "\t\t"
         }
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
@@ -22,7 +22,6 @@ import org.gradle.kotlin.dsl.support.filter
 
 import java.io.File
 
-
 object SourcePathProvider {
 
     fun sourcePathFor(
@@ -54,7 +53,6 @@ object SourcePathProvider {
     private
     fun subDirsOf(dir: File): Collection<File> =
         if (dir.isDirectory)
-            dir.listFiles().filter { it.isDirectory }
-        else
+            dir.listFiles().filter { it.isDirectory } else
             emptyList()
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServiceRegistry.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServiceRegistry.kt
@@ -35,4 +35,3 @@ class KotlinScriptServiceRegistry : AbstractPluginServiceRegistry() {
         registration.addProvider(org.gradle.kotlin.dsl.support.GradleUserHomeServices)
     }
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassLoaderScopeExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassLoaderScopeExtensions.kt
@@ -21,7 +21,6 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.internal.classloader.ClasspathUtil.getClasspath
 import org.gradle.internal.classpath.ClassPath
 
-
 internal
 fun exportClassPathFromHierarchyOf(scope: ClassLoaderScope): ClassPath {
     require(scope.isLocked) {
@@ -32,10 +31,9 @@ fun exportClassPathFromHierarchyOf(scope: ClassLoaderScope): ClassPath {
     return fullClassPath - rootClassPath
 }
 
-
 private
-val ClassLoaderScope.root get() = foldHierarchy(this) { _, scope -> scope }
-
+val ClassLoaderScope.root
+    get() = foldHierarchy(this) { _, scope -> scope }
 
 internal inline
 fun <T> ClassLoaderScope.foldHierarchy(initial: T, operation: (T, ClassLoaderScope) -> T): T {
@@ -44,13 +42,11 @@ fun <T> ClassLoaderScope.foldHierarchy(initial: T, operation: (T, ClassLoaderSco
     return result
 }
 
-
 internal inline
 fun ClassLoaderScope.traverseHierarchy(action: (ClassLoaderScope) -> Unit) {
     action(this)
     traverseAncestors(action)
 }
-
 
 internal inline
 fun ClassLoaderScope.traverseAncestors(action: (ClassLoaderScope) -> Unit) {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassPathExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassPathExtensions.kt
@@ -21,11 +21,9 @@ import org.gradle.internal.classpath.DefaultClassPath
 
 import java.io.File
 
-
 internal
 fun ClassPath.filter(predicate: (File) -> Boolean): ClassPath =
     DefaultClassPath.of(asFiles.filter(predicate))
-
 
 internal
 operator fun ClassPath.minus(other: ClassPath): ClassPath =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -31,10 +31,8 @@ import java.io.File
 
 import java.net.URI
 
-
 private
 val embeddedRepositoryCacheKeyVersion = 1
-
 
 private
 data class EmbeddedKotlinModule(
@@ -46,7 +44,6 @@ data class EmbeddedKotlinModule(
     val notation = "$group:$name:$version"
     val jarRepoPath = "${group.replace(".", "/")}/$name/$version/$name-$version.jar"
 }
-
 
 private
 val embeddedKotlinModules: List<EmbeddedKotlinModule> by lazy {
@@ -62,7 +59,6 @@ val embeddedKotlinModules: List<EmbeddedKotlinModule> by lazy {
         embeddedKotlin("reflect"),
         embeddedKotlin("compiler-embeddable"))
 }
-
 
 class EmbeddedKotlinProvider constructor(
     private val cacheRepository: CacheRepository,

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Exceptions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Exceptions.kt
@@ -20,7 +20,6 @@ import org.gradle.api.NamedDomainObjectCollection
 
 import kotlin.reflect.KClass
 
-
 fun illegalElementType(container: NamedDomainObjectCollection<*>, name: String, expectedType: KClass<*>, actualType: KClass<*>) =
     IllegalStateException(
         "Element '$name' of type '${actualType.java.name}' from container '$container' cannot be cast to '${expectedType.qualifiedName}'.")

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/GlobalServices.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/GlobalServices.kt
@@ -17,7 +17,6 @@ package org.gradle.kotlin.dsl.support
 
 import org.gradle.configuration.ImportsReader
 
-
 internal
 object GlobalServices {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
@@ -20,4 +20,3 @@ import java.io.File
 
 internal
 fun userHome() = File(System.getProperty("user.home"))
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.support
 
 import org.gradle.configuration.ImportsReader
 
-
 /**
  * Holds the list of imports implicitly added to every Kotlin build script.
  */

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
@@ -16,11 +16,9 @@
 
 package org.gradle.kotlin.dsl.support
 
+import org.gradle.api.Project
 import org.gradle.kotlin.dsl.KotlinBuildScript
 import org.gradle.kotlin.dsl.ScriptHandlerScope
-
-import org.gradle.api.Project
-
 
 /**
  * Base class for `buildscript` block evaluation.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -21,40 +21,31 @@ import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.messages.MessageUtil
-
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileBunchOfSources
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileScript
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
-
 import org.jetbrains.kotlin.codegen.CompilationException
-
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer.dispose
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer.newDisposable
-
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import org.jetbrains.kotlin.config.JVMConfigurationKeys.*
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_JAR
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY
 import org.jetbrains.kotlin.config.addKotlinSourceRoots
-
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor.Companion.registerExtension
-
 import org.jetbrains.kotlin.samWithReceiver.CliSamWithReceiverComponentContributor
-
 import org.jetbrains.kotlin.script.KotlinScriptDefinition
-
 import org.jetbrains.kotlin.utils.PathUtil
-
 import org.slf4j.Logger
-
 import java.io.File
-
 
 internal
 fun compileKotlinScriptToDirectory(
@@ -86,7 +77,6 @@ fun compileKotlinScriptToDirectory(
     }
 }
 
-
 private
 object HasImplicitReceiverCompilerPlugin {
 
@@ -99,7 +89,6 @@ object HasImplicitReceiverCompilerPlugin {
             listOf("org.gradle.api.HasImplicitReceiver"))
 }
 
-
 internal
 fun compileToJar(
     outputJar: File,
@@ -109,7 +98,6 @@ fun compileToJar(
 
     compileTo(OUTPUT_JAR, outputJar, sourceFiles, logger, classPath)
 
-
 internal
 fun compileToDirectory(
     outputDirectory: File,
@@ -118,7 +106,6 @@ fun compileToDirectory(
     classPath: Iterable<File> = emptyList()): Boolean =
 
     compileTo(OUTPUT_DIRECTORY, outputDirectory, sourceFiles, logger, classPath)
-
 
 private
 fun compileTo(
@@ -142,11 +129,9 @@ fun compileTo(
     }
 }
 
-
 private
 val kotlinStdlibJar: File
     get() = PathUtil.getResourcePathForClass(Unit::class.java)
-
 
 private inline
 fun <T> withRootDisposable(action: (Disposable) -> T): T {
@@ -158,7 +143,6 @@ fun <T> withRootDisposable(action: (Disposable) -> T): T {
     }
 }
 
-
 private inline
 fun <T> withMessageCollectorFor(log: Logger, action: (MessageCollector) -> T): T {
     val messageCollector = messageCollectorFor(log)
@@ -166,7 +150,6 @@ fun <T> withMessageCollectorFor(log: Logger, action: (MessageCollector) -> T): T
         return action(messageCollector)
     }
 }
-
 
 private inline
 fun <T> withCompilationExceptionHandler(messageCollector: MessageCollector, action: () -> T): T {
@@ -182,7 +165,6 @@ fun <T> withCompilationExceptionHandler(messageCollector: MessageCollector, acti
     }
 }
 
-
 private
 fun compilerConfigurationFor(messageCollector: MessageCollector, sourceFiles: Iterable<File>): CompilerConfiguration =
     CompilerConfiguration().apply {
@@ -191,23 +173,19 @@ fun compilerConfigurationFor(messageCollector: MessageCollector, sourceFiles: It
         put<MessageCollector>(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
     }
 
-
 private
 fun CompilerConfiguration.setModuleName(name: String) {
     put(CommonConfigurationKeys.MODULE_NAME, name)
 }
-
 
 private
 fun CompilerConfiguration.addScriptDefinition(scriptDef: KotlinScriptDefinition) {
     add(JVMConfigurationKeys.SCRIPT_DEFINITIONS, scriptDef)
 }
 
-
 private
 fun kotlinCoreEnvironmentFor(configuration: CompilerConfiguration, rootDisposable: Disposable) =
     KotlinCoreEnvironment.createForProduction(rootDisposable, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES)
-
 
 internal
 fun messageCollectorFor(log: Logger, pathTranslation: (String) -> String = { it }): MessageCollector =
@@ -218,7 +196,9 @@ fun messageCollectorFor(log: Logger, pathTranslation: (String) -> String = { it 
 
         override fun hasErrors() = errors > 0
 
-        override fun clear() { errors = 0 }
+        override fun clear() {
+            errors = 0
+        }
 
         override fun report(severity: CompilerMessageSeverity, message: String, location: CompilerMessageLocation?) {
 
@@ -248,7 +228,6 @@ fun messageCollectorFor(log: Logger, pathTranslation: (String) -> String = { it 
             }
         }
     }
-
 
 internal
 fun compilerMessageFor(path: String, line: Int, column: Int, message: String) =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinPluginsBlock.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinPluginsBlock.kt
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.support
 
 import org.gradle.plugin.use.PluginDependenciesSpec
 
-
 /**
  * Base class for `plugins` block evaluation.
  */

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Logger.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Logger.kt
@@ -19,29 +19,24 @@ package org.gradle.kotlin.dsl.support
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-
 internal inline
 fun <reified T : Any> loggerFor(): Logger =
     LoggerFactory.getLogger(T::class.java)
-
 
 internal inline
 fun Logger.trace(msg: () -> String) {
     if (isTraceEnabled) trace(msg())
 }
 
-
 internal inline
 fun Logger.debug(msg: () -> String) {
     if (isDebugEnabled) debug(msg())
 }
 
-
 internal inline
 fun Logger.info(msg: () -> String) {
     if (isInfoEnabled) info(msg())
 }
-
 
 internal inline
 fun Logger.error(msg: () -> String) {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Maps.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Maps.kt
@@ -16,13 +16,11 @@
 
 package org.gradle.kotlin.dsl.support
 
-
 internal
 fun excludeMapFor(group: String?, module: String?): Map<String, String> =
     mapOfNonNullValuesOf(
         "group" to group,
         "module" to module)
-
 
 internal
 fun mapOfNonNullValuesOf(vararg entries: Pair<String, String?>): Map<String, String> =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ProjectExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ProjectExtensions.kt
@@ -19,7 +19,6 @@ package org.gradle.kotlin.dsl.support
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
 
-
 inline
 fun <reified T : Any> Project.serviceOf(): T =
     (this as ProjectInternal).services[T::class.java]!!

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zipTo.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zipTo.kt
@@ -52,4 +52,3 @@ fun zipTo(outputStream: OutputStream, entries: Sequence<Pair<String, ByteArray>>
         }
     }
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zipTo.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zipTo.kt
@@ -24,12 +24,10 @@ import java.io.OutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-
 fun zipTo(zipFile: File, baseDir: File) {
     val files = baseDir.walkTopDown().filter { it.isFile }
     zipTo(zipFile, baseDir, files)
 }
-
 
 fun zipTo(zipFile: File, baseDir: File, files: Sequence<File>) {
     val entries = files.map { file ->
@@ -40,11 +38,9 @@ fun zipTo(zipFile: File, baseDir: File, files: Sequence<File>) {
     zipTo(zipFile, entries)
 }
 
-
 fun zipTo(zipFile: File, entries: Sequence<Pair<String, ByteArray>>) {
     zipTo(zipFile.outputStream(), entries)
 }
-
 
 fun zipTo(outputStream: OutputStream, entries: Sequence<Pair<String, ByteArray>>) {
     ZipOutputStream(outputStream).use { zos ->

--- a/provider/src/main/kotlin/org/gradle/script/lang/kotlin/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/script/lang/kotlin/KotlinBuildScript.kt
@@ -16,14 +16,10 @@
 package org.gradle.script.lang.kotlin
 
 import org.gradle.api.Project
-
-import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver
-
 import org.gradle.kotlin.dsl.GradleDsl
-
+import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver
 import kotlin.script.extensions.SamWithReceiverAnnotations
 import kotlin.script.templates.ScriptTemplateDefinition
-
 
 /**
  * Base class for Kotlin build scripts.

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensionsTest.kt
@@ -10,7 +10,6 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
-
 class ConfigurableFileCollectionExtensionsTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ConfigurationExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ConfigurationExtensionsTest.kt
@@ -1,13 +1,10 @@
 package org.gradle.kotlin.dsl
 
-import org.gradle.api.artifacts.Configuration
-
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
-
+import org.gradle.api.artifacts.Configuration
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
 
 class ConfigurationExtensionsTest {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
@@ -8,7 +8,6 @@ import org.gradle.api.plugins.ExtraPropertiesExtension
 
 import org.junit.Test
 
-
 class ExtraPropertiesExtensionsTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/GroovyInteroperabilityTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/GroovyInteroperabilityTest.kt
@@ -139,4 +139,3 @@ class GroovyInteroperabilityTest {
         verify(delegate).withKeywordArguments(expectedKeywordArguments)
     }
 }
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -61,12 +61,14 @@ class NamedDomainObjectCollectionExtensionsTest {
             on { getByName("domainObject") } doReturn element
         }
 
-        container { // invoke syntax
+        container {
+            // invoke syntax
             val domainObject by getting
             assertThat(domainObject, sameInstance(element))
         }
 
-        container.apply { // regular syntax
+        container.apply {
+            // regular syntax
             val domainObject by getting
             assertThat(domainObject, sameInstance(element))
         }
@@ -80,12 +82,14 @@ class NamedDomainObjectCollectionExtensionsTest {
             on { getByName("domainObject") } doReturn element
         }
 
-        container { // invoke syntax
+        container {
+            // invoke syntax
             val domainObject: DomainObject by getting
             assertThat(domainObject, sameInstance(element))
         }
 
-        container.apply { // regular syntax
+        container.apply {
+            // regular syntax
             val domainObject: DomainObject by getting
             assertThat(domainObject, sameInstance(element))
         }
@@ -99,12 +103,14 @@ class NamedDomainObjectCollectionExtensionsTest {
             on { getByName("domainObject") } doReturn element
         }
 
-        container { // invoke syntax
+        container {
+            // invoke syntax
             val domainObject by getting(DomainObject::class)
             assertThat(domainObject, sameInstance(element))
         }
 
-        container.apply { // regular syntax
+        container.apply {
+            // regular syntax
             val domainObject by getting(DomainObject::class)
             assertThat(domainObject, sameInstance(element))
         }
@@ -118,13 +124,15 @@ class NamedDomainObjectCollectionExtensionsTest {
             on { getByName("domainObject") } doReturn element
         }
 
-        container { // invoke syntax
+        container {
+            // invoke syntax
             @Suppress("unused_variable")
             val domainObject by getting { foo = "foo" }
             assertThat(element.foo, equalTo("foo"))
         }
 
-        container.apply { // regular syntax
+        container.apply {
+            // regular syntax
             @Suppress("unused_variable")
             val domainObject by getting { foo = "bar" }
             assertThat(element.foo, equalTo("bar"))
@@ -139,13 +147,15 @@ class NamedDomainObjectCollectionExtensionsTest {
             on { getByName("domainObject") } doReturn element
         }
 
-        container { // invoke syntax
+        container {
+            // invoke syntax
             @Suppress("unused_variable")
             val domainObject by getting(DomainObject::class) { foo = "foo" }
             assertThat(element.foo, equalTo("foo"))
         }
 
-        container.apply { // regular syntax
+        container.apply {
+            // regular syntax
             @Suppress("unused_variable")
             val domainObject by getting(DomainObject::class) { foo = "bar" }
             assertThat(element.foo, equalTo("bar"))

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -17,7 +17,6 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
-
 class NamedDomainObjectContainerExtensionsTest {
 
     data class DomainObject(var foo: String? = null, var bar: Boolean? = null)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
@@ -73,4 +73,3 @@ fun plugins(block: PluginDependenciesSpecScope.() -> Unit) =
 fun plugin(id: String, version: String? = null, isApply: Boolean = true) = Plugin(id, version, isApply)
 
 data class Plugin(val id: String, val version: String?, val isApply: Boolean)
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
@@ -58,7 +58,6 @@ class PluginDependenciesSpecScopeTest {
     }
 }
 
-
 fun expecting(vararg expected: Plugin, block: PluginDependenciesSpec.() -> Unit) {
     assertThat(
         plugins(block).map { Plugin(it.id.id, it.version, it.isApply) },

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ProjectExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ProjectExtensionsTest.kt
@@ -13,7 +13,6 @@ import org.gradle.api.publish.PublishingExtension
 import org.junit.Assert.fail
 import org.junit.Test
 
-
 class ProjectExtensionsTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
@@ -1,12 +1,13 @@
 package org.gradle.kotlin.dsl
 
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.only
+import com.nhaarman.mockito_kotlin.verify
 import org.gradle.api.Action
-
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-
 import org.junit.Test
 import org.mockito.invocation.InvocationOnMock
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/GenerateProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/GenerateProjectSchemaTest.kt
@@ -24,18 +24,18 @@ class GenerateProjectSchemaTest : AbstractIntegrationTest() {
         val expectedSchema =
             mapOf(
                 ":" to ProjectSchema(
-                        extensions = mapOf(
-                            "defaultArtifacts" to "org.gradle.api.internal.plugins.DefaultArtifactPublicationSet",
-                            "ext" to "org.gradle.api.plugins.ExtraPropertiesExtension",
-                            "reporting" to "org.gradle.api.reporting.ReportingExtension"),
-                        conventions = mapOf(
-                            "base" to "org.gradle.api.plugins.BasePluginConvention",
-                            "java" to "org.gradle.api.plugins.JavaPluginConvention"),
-                        configurations = listOf(
-                            "apiElements", "archives", "compile", "compileClasspath", "compileOnly", "default",
-                            "implementation", "runtime", "runtimeClasspath", "runtimeElements", "runtimeOnly",
-                            "testCompile", "testCompileClasspath", "testCompileOnly", "testImplementation",
-                            "testRuntime", "testRuntimeClasspath", "testRuntimeOnly")))
+                    extensions = mapOf(
+                        "defaultArtifacts" to "org.gradle.api.internal.plugins.DefaultArtifactPublicationSet",
+                        "ext" to "org.gradle.api.plugins.ExtraPropertiesExtension",
+                        "reporting" to "org.gradle.api.reporting.ReportingExtension"),
+                    conventions = mapOf(
+                        "base" to "org.gradle.api.plugins.BasePluginConvention",
+                        "java" to "org.gradle.api.plugins.JavaPluginConvention"),
+                    configurations = listOf(
+                        "apiElements", "archives", "compile", "compileClasspath", "compileOnly", "default",
+                        "implementation", "runtime", "runtimeClasspath", "runtimeElements", "runtimeOnly",
+                        "testCompile", "testCompileClasspath", "testCompileOnly", "testImplementation",
+                        "testRuntime", "testRuntimeClasspath", "testRuntimeOnly")))
 
         assertThat(
             generatedSchema,

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaAccessorsIntegrationTest.kt
@@ -1,18 +1,17 @@
 package org.gradle.kotlin.dsl.accessors
 
-import org.gradle.kotlin.dsl.integration.kotlinBuildScriptModelFor
-
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.fileByName
 import org.gradle.kotlin.dsl.fixtures.matching
-
-import org.hamcrest.CoreMatchers.*
+import org.gradle.kotlin.dsl.integration.kotlinBuildScriptModelFor
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.hasItem
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
-
 import java.io.File
-
 
 class ProjectSchemaAccessorsIntegrationTest : AbstractIntegrationTest() {
 
@@ -79,10 +78,8 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractIntegrationTest() {
 
         """)
 
-
         println(
             build("kotlinDslAccessorsSnapshot").output)
-
 
         buildFile.appendText("""
 
@@ -144,7 +141,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractIntegrationTest() {
             repositories { jcenter() }
         """)
 
-        withFile("c/build.gradle.kts","""
+        withFile("c/build.gradle.kts", """
             plugins { `java-library` }
 
             dependencies {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -1,18 +1,16 @@
 package org.gradle.kotlin.dsl.accessors
 
 import org.gradle.internal.classpath.ClassPath
-
 import org.hamcrest.CoreMatchers.equalTo
-
-import org.junit.Assert.assertThat
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThat
 import org.junit.Test
-
-import org.objectweb.asm.Opcodes.*
-
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
+import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 
 @Suppress("unused")
 class PublicGenericType<T>
+
 class PublicComponentType
 private class PrivateComponentType
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
@@ -2,18 +2,18 @@ package org.gradle.kotlin.dsl.accessors
 
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
-
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.classEntriesFor
 import org.gradle.kotlin.dsl.support.zipTo
-
-import org.objectweb.asm.*
-import org.objectweb.asm.Opcodes.*
-
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes.ACC_PRIVATE
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
+import org.objectweb.asm.Opcodes.ALOAD
+import org.objectweb.asm.Opcodes.INVOKESPECIAL
+import org.objectweb.asm.Opcodes.RETURN
+import org.objectweb.asm.Opcodes.V1_7
 import java.io.File
-
 import kotlin.reflect.KClass
-
 
 open class TestWithClassPath : TestWithTempFiles() {
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
@@ -1,12 +1,9 @@
 package org.gradle.kotlin.dsl.accessors
 
 import org.gradle.internal.classpath.ClassPath
-
-import org.hamcrest.CoreMatchers.*
-
-import org.junit.Assert.*
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
 import org.junit.Test
-
 
 class TypeAccessibilityProviderTest : TestWithClassPath() {
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/UserGuideLinkTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/UserGuideLinkTest.kt
@@ -6,7 +6,6 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
-
 class UserGuideLinkTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -355,4 +355,3 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
     val fixturesRepository: File
         get() = File(rootProjectDir, "fixtures/repository").absoluteFile
 }
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
@@ -2,28 +2,26 @@ package org.gradle.kotlin.dsl.integration
 
 import org.gradle.kotlin.dsl.concurrent.future
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
-
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
 import org.gradle.kotlin.dsl.fixtures.customDaemonRegistry
 import org.gradle.kotlin.dsl.fixtures.customInstallation
+import org.gradle.kotlin.dsl.fixtures.matching
 import org.gradle.kotlin.dsl.fixtures.withDaemonIdleTimeout
 import org.gradle.kotlin.dsl.fixtures.withDaemonRegistry
-import org.gradle.kotlin.dsl.fixtures.matching
-
 import org.gradle.kotlin.dsl.resolver.GradleInstallation
 import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptModelRequest
 import org.gradle.kotlin.dsl.resolver.fetchKotlinBuildScriptModelFor
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
-
 import org.gradle.util.TextUtil.normaliseFileSeparators
-
-import org.hamcrest.CoreMatchers.*
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.hasItem
+import org.hamcrest.CoreMatchers.hasItems
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
-
 import java.io.File
 
 class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
@@ -95,8 +93,8 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
             withClassJar("libs/$fixture.jar", DeepThought::class.java)
 
         val parentJar = withFixture("parent")
-        val fooJar    = withFixture("foo")
-        val barJar    = withFixture("bar")
+        val fooJar = withFixture("foo")
+        val barJar = withFixture("bar")
 
         fun String.withBuildscriptDependencyOn(fixture: File) =
             withFile(this, """
@@ -106,8 +104,8 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
             """)
 
         val parentBuildScript = "build.gradle".withBuildscriptDependencyOn(parentJar)
-        val fooBuildScript    = "foo/build.gradle.kts".withBuildscriptDependencyOn(fooJar)
-        val barBuildScript    = "bar/build.gradle.kts".withBuildscriptDependencyOn(barJar)
+        val fooBuildScript = "foo/build.gradle.kts".withBuildscriptDependencyOn(fooJar)
+        val barBuildScript = "bar/build.gradle.kts".withBuildscriptDependencyOn(barJar)
 
         assertClassPathFor(
             parentBuildScript,
@@ -184,7 +182,7 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
 
         assertSourcePathIncludesKotlinPluginSourcesGiven(
             rootProjectScript = "",
-            subProjectScript ="""
+            subProjectScript = """
                 buildscript {
                     dependencies { classpath(kotlin("gradle-plugin")) }
                     repositories { jcenter() }
@@ -292,16 +290,13 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
         canonicalClassPathFor(projectRoot)
 }
 
-
 internal
 fun canonicalClassPathFor(projectDir: File, scriptFile: File? = null) =
     classPathFor(projectDir, scriptFile).map(File::getCanonicalFile)
 
-
 private
 fun classPathFor(projectDir: File, scriptFile: File?) =
     kotlinBuildScriptModelFor(projectDir, scriptFile).classPath
-
 
 internal
 fun kotlinBuildScriptModelFor(projectDir: File, scriptFile: File? = null): KotlinBuildScriptModel =

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtractionTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtractionTest.kt
@@ -105,4 +105,3 @@ class BuildscriptBlockExtractionTest {
         assertNull(extractBuildscriptBlockFrom(script))
     }
 }
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchyTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchyTest.kt
@@ -5,20 +5,15 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.gradle.api.internal.initialization.AbstractClassLoaderScope
-
 import org.gradle.internal.classpath.DefaultClassPath
-
-import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.DeepThought
+import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.classEntriesFor
 import org.gradle.kotlin.dsl.support.zipTo
-
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
-
 import java.lang.ClassLoader.getSystemClassLoader
 
 class ClassLoaderHierarchyTest : TestWithTempFiles() {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -1,20 +1,15 @@
 package org.gradle.kotlin.dsl.provider
 
-import org.gradle.kotlin.dsl.support.ProgressMonitor
-
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.GRADLE_API
 import org.gradle.internal.classpath.ClassPath
-
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
-
+import org.gradle.kotlin.dsl.support.ProgressMonitor
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
 
 class KotlinScriptClassPathProviderTest : TestWithTempFiles() {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/LineAndColumnFromRangeTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/LineAndColumnFromRangeTest.kt
@@ -17,7 +17,8 @@ class LineAndColumnFromRangeTest(val given: LineAndColumnFromRangeTest.Given) {
         const val text = "line 1\nline 2\nline 3"
 
         @Parameterized.Parameters(name = "{0}")
-        @JvmStatic fun testCases(): Iterable<LineAndColumnFromRangeTest.Given> =
+        @JvmStatic
+        fun testCases(): Iterable<LineAndColumnFromRangeTest.Given> =
             listOf(
                 LineAndColumnFromRangeTest.Given(0..0, 1 to 1),
                 LineAndColumnFromRangeTest.Given(1..1, 1 to 2),

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
@@ -59,12 +59,12 @@ class ResolverCoordinatorTest {
     private
     fun resolverActionFor(environment: Map<String, Any?>, previousDependencies: kotlin.script.dependencies.KotlinScriptExternalDependencies?) =
         ResolverCoordinator.selectNextActionFor(EmptyScriptContents, environment,
-                                                previousDependencies)
+            previousDependencies)
 
     private
     fun ResolverAction.RequestNew.scriptDependencies() =
         KotlinBuildScriptDependencies(emptyList(), emptyList(), emptyList(),
-                                                                             buildscriptBlockHash)
+            buildscriptBlockHash)
 
     private
     fun environmentWithGetScriptSectionTokensReturning(vararg sections: Pair<String, Sequence<String>>) =
@@ -76,8 +76,7 @@ class ResolverCoordinatorTest {
 }
 
 private
-object EmptyScriptContents : kotlin.script.dependencies.ScriptContents
-{
+object EmptyScriptContents : kotlin.script.dependencies.ScriptContents {
     override val file: java.io.File? = null
     override val text: CharSequence? = ""
     override val annotations: Iterable<Annotation> = emptyList()

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProviderTest.kt
@@ -1,14 +1,10 @@
 package org.gradle.kotlin.dsl.resolver
 
 import org.gradle.internal.classpath.ClassPath
-
-import org.gradle.kotlin.dsl.resolver.SourcePathProvider.sourcePathFor
-
 import org.gradle.kotlin.dsl.fixtures.FolderBasedTest
-
+import org.gradle.kotlin.dsl.resolver.SourcePathProvider.sourcePathFor
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
 
 class SourcePathProviderTest : FolderBasedTest() {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -3,7 +3,6 @@ package org.gradle.kotlin.dsl.support
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 
-
 class EmbeddedKotlinProviderTest : org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest() {
 
     @org.junit.Test
@@ -11,7 +10,7 @@ class EmbeddedKotlinProviderTest : org.gradle.kotlin.dsl.fixtures.AbstractIntegr
 
         val result = build("buildEnvironment")
 
-        assertThat(result.output, containsString("No dependencies"));
+        assertThat(result.output, containsString("No dependencies"))
     }
 
     @org.junit.Test

--- a/samples-tests/build.gradle.kts
+++ b/samples-tests/build.gradle.kts
@@ -1,4 +1,5 @@
-import build.*
+import build.withParallelTests
+import build.withTestWorkersMemoryLimits
 
 apply<plugins.KotlinLibrary>()
 

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/AbstractSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/AbstractSampleTest.kt
@@ -5,7 +5,6 @@ import org.junit.Before
 
 import java.io.File
 
-
 abstract class AbstractSampleTest(val sampleName: String) : AbstractIntegrationTest() {
 
     @Before

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/AntSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/AntSampleTest.kt
@@ -3,7 +3,6 @@ package org.gradle.kotlin.dsl.samples
 import org.junit.Test
 import java.io.File
 
-
 class AntSampleTest : AbstractSampleTest("ant") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/CodeQualitySampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/CodeQualitySampleTest.kt
@@ -7,7 +7,6 @@ import org.junit.Assert.assertThat
 
 import org.junit.Test
 
-
 class CodeQualitySampleTest : AbstractSampleTest("code-quality") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/CompositeBuildsSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/CompositeBuildsSampleTest.kt
@@ -4,7 +4,6 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class CompositeBuildsSampleTest : AbstractSampleTest("composite-builds") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/CopySampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/CopySampleTest.kt
@@ -4,7 +4,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-
 class CopySampleTest : AbstractSampleTest("copy") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/DomainObjectsSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/DomainObjectsSampleTest.kt
@@ -7,7 +7,6 @@ import org.junit.Test
 
 import java.io.File
 
-
 class DomainObjectsSampleTest : AbstractSampleTest("domain-objects") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ExtraPropertiesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ExtraPropertiesSampleTest.kt
@@ -5,14 +5,14 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class ExtraPropertiesSampleTest : AbstractSampleTest("extra-properties") {
 
     @Test
     fun `extra properties`() {
         assertThat(
             build("myTask").output,
-            allOf(containsString("myTask.foo = 42"),
-                  containsString("Extra property value: 42")))
+            allOf(
+                containsString("myTask.foo = 42"),
+                containsString("Extra property value: 42")))
     }
 }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/GradlePluginSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/GradlePluginSampleTest.kt
@@ -5,7 +5,6 @@ import org.junit.Assert.assertTrue
 
 import java.io.File
 
-
 class GradlePluginSampleTest : AbstractSampleTest("gradle-plugin") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/GroovyInteropSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/GroovyInteropSampleTest.kt
@@ -4,7 +4,6 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class GroovyInteropSampleTest : AbstractSampleTest("groovy-interop") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/HelloCoroutinesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/HelloCoroutinesSampleTest.kt
@@ -5,7 +5,6 @@ import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class HelloCoroutinesSampleTest : AbstractSampleTest("hello-coroutines") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/HelloKotlinSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/HelloKotlinSampleTest.kt
@@ -4,7 +4,6 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class HelloKotlinSampleTest : AbstractSampleTest("hello-kotlin") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/HelloWorldSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/HelloWorldSampleTest.kt
@@ -2,7 +2,6 @@ package org.gradle.kotlin.dsl.samples
 
 import org.junit.Test
 
-
 class HelloWorldSampleTest : AbstractSampleTest("hello-world") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ModelRulesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ModelRulesSampleTest.kt
@@ -2,7 +2,6 @@ package org.gradle.kotlin.dsl.samples
 
 import org.junit.Test
 
-
 class ModelRulesSampleTest : AbstractSampleTest("model-rules") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ModularitySampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ModularitySampleTest.kt
@@ -5,14 +5,14 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class ModularitySampleTest : AbstractSampleTest("modularity") {
 
     @Test
     fun `modularity`() {
         assertThat(
             build("foo", "bar").output,
-            allOf(containsString("Foo!"),
-                  containsString("Bar!")))
+            allOf(
+                containsString("Foo!"),
+                containsString("Bar!")))
     }
 }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectConfigInjectionSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectConfigInjectionSampleTest.kt
@@ -4,7 +4,6 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class MultiKotlinProjectConfigInjectionSampleTest : AbstractSampleTest("multi-kotlin-project-config-injection") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectSampleTest.kt
@@ -4,7 +4,6 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class MultiKotlinProjectSampleTest : AbstractSampleTest("multi-kotlin-project") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectWithBuildSrcSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectWithBuildSrcSampleTest.kt
@@ -3,7 +3,6 @@ package org.gradle.kotlin.dsl.samples
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 
-
 class MultiKotlinProjectWithBuildSrcSampleTest : AbstractSampleTest("multi-kotlin-project-with-buildSrc") {
 
     @org.junit.Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiProjectWithBuildSrcSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiProjectWithBuildSrcSampleTest.kt
@@ -5,7 +5,6 @@ import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class MultiProjectWithBuildSrcSampleTest : AbstractSampleTest("multi-project-with-buildSrc") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ProjectPropertiesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ProjectPropertiesSampleTest.kt
@@ -4,7 +4,6 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class ProjectPropertiesSampleTest : AbstractSampleTest("project-properties") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ProviderPropertiesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ProviderPropertiesSampleTest.kt
@@ -6,7 +6,6 @@ import org.junit.Assert.assertThat
 import org.junit.Test
 import java.io.File
 
-
 class ProviderPropertiesSampleTest : AbstractSampleTest("provider-properties") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SamplesSmokeTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SamplesSmokeTest.kt
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.io.File
 
-
 @RunWith(Parameterized::class)
 class SamplesSmokeTest(val sampleDir: File) : AbstractIntegrationTest() {
 

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/TaskDependenciesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/TaskDependenciesSampleTest.kt
@@ -5,7 +5,6 @@ import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
-
 class TaskDependenciesSampleTest : AbstractSampleTest("task-dependencies") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
@@ -4,10 +4,8 @@ import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 
 import java.io.File
 
-
 internal
 val samplesRootDir = File(rootProjectDir, "samples")
-
 
 internal
 fun copySampleProject(from: File, to: File) {

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
@@ -11,10 +11,8 @@ import org.junit.rules.TemporaryFolder
 import org.junit.rules.TestName
 import java.io.File
 
-
 internal
 val isCI by lazy { !System.getenv("CI").isNullOrEmpty() }
-
 
 open class AbstractIntegrationTest {
 
@@ -120,7 +118,6 @@ open class AbstractIntegrationTest {
         gradleRunnerFor(projectRoot, *arguments)
 }
 
-
 private
 fun gradleRunnerFor(projectDir: File, vararg arguments: String): GradleRunner = GradleRunner.create().run {
     withGradleInstallation(customInstallation())
@@ -132,10 +129,8 @@ fun gradleRunnerFor(projectDir: File, vararg arguments: String): GradleRunner = 
     return this
 }
 
-
 fun customDaemonRegistry() =
     File(customInstallationBuildDir, "daemon-registry")
-
 
 fun customInstallation() =
     customInstallationBuildDir.listFiles()?.let {
@@ -144,22 +139,17 @@ fun customInstallation() =
                 "Expected 1 custom installation but found ${it.size}. Run `./gradlew clean customInstallation`.")
     } ?: throw IllegalStateException("Custom installation not found. Run `./gradlew customInstallation`.")
 
-
 val rootProjectDir = File("..").canonicalFile!!
 
-
 val customInstallationBuildDir = File(rootProjectDir, "build/custom")
-
 
 inline
 fun <T> withDaemonRegistry(registryBase: File, block: () -> T) =
     withSystemProperty("org.gradle.daemon.registry.base", registryBase.absolutePath, block)
 
-
 inline
 fun <T> withDaemonIdleTimeout(seconds: Int, block: () -> T) =
     withSystemProperty("org.gradle.daemon.idletimeout", (seconds * 1000).toString(), block)
-
 
 inline
 fun <T> withSystemProperty(key: String, value: String, block: () -> T): T {
@@ -171,7 +161,6 @@ fun <T> withSystemProperty(key: String, value: String, block: () -> T): T {
         setOrClearProperty(key, originalValue)
     }
 }
-
 
 fun setOrClearProperty(key: String, value: String?) {
     when (value) {

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/PatternMatcher.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/PatternMatcher.kt
@@ -6,26 +6,21 @@ import java.io.File
 
 import java.util.regex.Pattern
 
-
 fun matches(pattern: String) =
     matching(pattern)
 
-
 fun matching(pattern: String) =
     matching(pattern.toPattern())
-
 
 fun matching(pattern: Pattern) =
     matching<String>({ appendText("a string matching the pattern ").appendValue(pattern) }) {
         pattern.matcher(this).matches()
     }
 
-
 fun fileByName(fileName: String) =
     matching<File>({ appendText("a file by the name ").appendValue(fileName) }) {
         isFile && name == fileName
     }
-
 
 fun <T> matching(describe: Description.() -> Unit, match: T.() -> Boolean) =
     object : TypeSafeMatcher<T>() {

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
@@ -29,4 +29,3 @@ fun <reified T> assertInstanceOf(o: Any): T {
     assertThat(o, instanceOf(T::class.java))
     return o as T
 }
-

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/matchers.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/matchers.kt
@@ -3,6 +3,5 @@ package org.gradle.kotlin.dsl.fixtures
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
 
-
 fun containsMultiLineString(string: String): Matcher<String> =
     containsString(string.trimIndent().toPlatformLineSeparators())

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/string.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/string.kt
@@ -2,5 +2,4 @@ package org.gradle.kotlin.dsl.fixtures
 
 import org.gradle.util.TextUtil
 
-
 fun String.toPlatformLineSeparators() = TextUtil.toPlatformLineSeparators(this)

--- a/tooling-builders/build.gradle.kts
+++ b/tooling-builders/build.gradle.kts
@@ -1,4 +1,4 @@
-import build.*
+import build.withParallelTests
 
 plugins {
     base

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -37,7 +37,6 @@ import org.gradle.tooling.provider.model.ToolingModelBuilder
 import java.io.File
 import java.io.Serializable
 
-
 internal
 object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
 
@@ -51,7 +50,7 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
                 when (it) {
                     is ScriptModelRequest.ForProjectScript ->
                         it.enclosingProject to projectScriptClassPathOf(it.enclosingProject)
-                    is ScriptModelRequest.ForScriptPlugin  ->
+                    is ScriptModelRequest.ForScriptPlugin ->
                         project to scriptPluginClassPathOf(project)
                 }
             }
@@ -138,7 +137,6 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
             .asFiles
             .filter { it.name == "buildSrc.jar" }
 }
-
 
 internal
 data class StandardKotlinBuildScriptModel(

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelBuilder.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelBuilder.kt
@@ -15,18 +15,14 @@
  */
 package org.gradle.kotlin.dsl.tooling.builders
 
-import org.gradle.tooling.provider.model.ToolingModelBuilder
-import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptTemplateModel
-
 import org.gradle.api.Project
-
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.kotlin.dsl.support.serviceOf
-
+import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptTemplateModel
+import org.gradle.tooling.provider.model.ToolingModelBuilder
 import java.io.File
 import java.io.Serializable
-
 
 internal
 object KotlinBuildScriptTemplateModelBuilder : ToolingModelBuilder {
@@ -47,7 +43,6 @@ object KotlinBuildScriptTemplateModelBuilder : ToolingModelBuilder {
                     .asFiles)
         }
 }
-
 
 internal
 data class StandardKotlinBuildScriptTemplateModel(

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
@@ -42,7 +42,6 @@ import org.gradle.plugins.ide.internal.resolver.DefaultIdeDependencyResolver
 
 import kotlin.coroutines.experimental.buildSequence
 
-
 internal
 fun sourcePathFor(project: Project): ClassPath {
 
@@ -52,7 +51,7 @@ fun sourcePathFor(project: Project): ClassPath {
     for (buildscript in reversedBuildscriptHierarchyOf(project)) {
         val classpathDependencies = classpathDependenciesOf(buildscript).filter { it !in resolvedDependencies }
         if (resolvedDependencies.addAll(classpathDependencies)) {
-           sourcePath += resolveSourcesUsing(buildscript.dependencies, classpathDependencies.map { it.toModuleId() })
+            sourcePath += resolveSourcesUsing(buildscript.dependencies, classpathDependencies.map { it.toModuleId() })
         }
     }
 
@@ -63,22 +62,18 @@ fun sourcePathFor(project: Project): ClassPath {
     return sourcePath
 }
 
-
 private
 fun reversedBuildscriptHierarchyOf(project: Project) =
     reversedHierarchyOf(project).map { it.buildscript }
-
 
 private
 fun reversedHierarchyOf(project: Project) =
     project.hierarchy.toList().asReversed()
 
-
 private
 fun containsBuiltinKotlinModules(resolvedDependencies: HashSet<ModuleVersionIdentifier>) =
     resolvedDependencies.containsAll(
         builtinKotlinModules.map(::kotlinModuleVersionIdentifier))
-
 
 private
 fun classpathDependenciesOf(buildscript: ScriptHandler): List<ModuleVersionIdentifier> =
@@ -86,10 +81,8 @@ fun classpathDependenciesOf(buildscript: ScriptHandler): List<ModuleVersionIdent
         .getIdeRepoFileDependencies(buildscript.configurations[CLASSPATH_CONFIGURATION])
         .map { it.id }
 
-
 private
 fun ModuleVersionIdentifier.toModuleId() = moduleId(group, name, version)
-
 
 internal
 fun kotlinLibSourcesFor(project: Project): ClassPath =
@@ -98,7 +91,6 @@ fun kotlinLibSourcesFor(project: Project): ClassPath =
         .filter { it.buildscript.repositories.isNotEmpty() }
         .map { resolveKotlinLibSourcesUsing(it.buildscript.dependencies) }
         .find { !it.isEmpty } ?: ClassPath.EMPTY
-
 
 private
 fun resolveKotlinLibSourcesUsing(dependencyHandler: DependencyHandler): ClassPath =
@@ -117,26 +109,21 @@ fun resolveSourcesUsing(dependencyHandler: DependencyHandler, components: List<C
             .filterIsInstance<ResolvedArtifactResult>()
             .map { it.file })
 
-
 private
 val builtinKotlinModules = listOf("kotlin-stdlib", "kotlin-reflect")
-
 
 private
 val kotlinComponentIdentifiers by lazy {
     builtinKotlinModules.map(::kotlinComponent)
 }
 
-
 private
 fun kotlinComponent(module: String): ComponentIdentifier =
     moduleId("org.jetbrains.kotlin", module, embeddedKotlinVersion)
 
-
 private
 fun kotlinModuleVersionIdentifier(module: String): ModuleVersionIdentifier =
     DefaultModuleVersionIdentifier("org.jetbrains.kotlin", module, embeddedKotlinVersion)
-
 
 private
 fun moduleId(group: String, module: String, version: String) =
@@ -146,7 +133,6 @@ fun moduleId(group: String, module: String, version: String) =
         override fun getVersion() = version
         override fun getDisplayName() = "$group:$module:$version"
     }
-
 
 private
 val org.gradle.api.Project.hierarchy: Sequence<Project>

--- a/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelIntegrationTest.kt
+++ b/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelIntegrationTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 
 import java.io.File
 
-
 class KotlinBuildScriptTemplateModelIntegrationTest : AbstractIntegrationTest() {
 
     @Test
@@ -35,7 +34,6 @@ class KotlinBuildScriptTemplateModelIntegrationTest : AbstractIntegrationTest() 
             KotlinBuildScript::class.qualifiedName!!,
             KotlinBuildScriptDependenciesResolver::class.qualifiedName!!)
     }
-
 
     private
     fun fetchKotlinScriptTemplateClassPathModelFor(projectDir: File) =
@@ -53,7 +51,6 @@ class KotlinBuildScriptTemplateModelIntegrationTest : AbstractIntegrationTest() 
                 }
             }
         }
-
 
     private
     fun loadClassesFrom(classPath: List<File>, vararg classNames: String) {

--- a/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -17,7 +17,6 @@ package org.gradle.kotlin.dsl.tooling.models
 
 import java.io.File
 
-
 interface KotlinBuildScriptModel {
 
     val classPath: List<File>


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Any project that has many contributors should have a consistent style guide and style guide linter.
Lacking such tends to lead to diffs with white space changes all over because developers have different editors with different settings.

This adds kotlin code linting with [Ktlint](https://ktlint.github.io/) currently the only code linter/formatter for kotlin that I know about.

Ktlint is driven with the [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle) plugin that simply checks to see if running the various formatters you configure on it will create a diff. If a diff will happen then the spotless task fails.
By default this plugin runs source linting as part of the `check` phase. However, for build file linting you need to explicitly call the `spotlessCheck` task.

Now, there is no more need to setup your editor in the same way as other developers.
Simply run `./gradlew spotlessApply` before committing and spotless will make your code Spotless!

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`

### Notes
Although this looks like a large diff it's really not. Mostly imports and some minor indentation things.
If you are interested in this PR try to get it in before other changes get pulled in as there is a higher likelihood for merge conflicts.