### PR TITLE
Implicit imports comply with the Gradle core public API definition

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
@@ -29,7 +29,8 @@ class ImplicitImports(private val importsReader: ImportsReader) {
     }
 
     private
-    fun gradleImports() = importsReader.importPackages.map { "$it.*" }
+    fun gradleImports() =
+        importsReader.simpleNameToFullClassNamesMapping.values.map { it.first() }
 
     private
     fun gradleKotlinDslImports() =

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
@@ -1,11 +1,9 @@
 package org.gradle.kotlin.dsl.support
 
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
-import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
-import java.io.File
-import java.util.jar.JarFile
 
 class ImplicitImportsTest : AbstractIntegrationTest() {
 
@@ -13,30 +11,16 @@ class ImplicitImportsTest : AbstractIntegrationTest() {
     fun `implicit imports are fully qualified to allow use of the preferred type amongst those with same simple name in different Gradle API packages`() {
 
         // given:
-        existing("settings.gradle").appendText("""
-            rootProject.name = "some-project"
-        """)
         withBuildScript("""
 
-            plugins {
-                java
-            }
-
-            // Prefer org.gradle.api.tasks.bundling.Jar over org.gradle.jvm.tasks.Jar
-            tasks.withType<Jar> {
-                manifest {
-                    attributes(mapOf("Foo" to "Bar"))
-                }
-            }
+            println("*" + Jar::class.qualifiedName + "*")
 
         """)
 
         // when:
-        build("jar")
+        val result = build("help")
 
         // then:
-        JarFile(File(projectRoot, "build/libs/some-project.jar")).use { jar ->
-            assertThat(jar.manifest.mainAttributes.getValue("Foo"), equalTo("Bar"))
-        }
+        assertThat(result.output, containsString("*org.gradle.jvm.tasks.Jar*"))
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
@@ -1,0 +1,42 @@
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+import java.io.File
+import java.util.jar.JarFile
+
+class ImplicitImportsTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `implicit imports are fully qualified to allow use of the preferred type amongst those with same simple name in different Gradle API packages`() {
+
+        // given:
+        existing("settings.gradle").appendText("""
+            rootProject.name = "some-project"
+        """)
+        withBuildScript("""
+
+            plugins {
+                java
+            }
+
+            // Prefer org.gradle.api.tasks.bundling.Jar over org.gradle.jvm.tasks.Jar
+            tasks.withType<Jar> {
+                manifest {
+                    attributes(mapOf("Foo" to "Bar"))
+                }
+            }
+
+        """)
+
+        // when:
+        build("jar")
+
+        // then:
+        JarFile(File(projectRoot, "build/libs/some-project.jar")).use { jar ->
+            assertThat(jar.manifest.mainAttributes.getValue("Foo"), equalTo("Bar"))
+        }
+    }
+}


### PR DESCRIPTION
Comply with Gradle core definition of the default imports by
disambiguating simple type names amongst types with same simple name in
different Gradle API packages.

Use ImportsReader.simpleNameToFullClassNamesMapping instead of
ImportsReader.importPackages.

See #483
