### PR TITLE
Set JVMConfigurationKeys.JDK_HOME in KotlinCompiler for JDK 9 support

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -188,6 +188,12 @@ fun compilerConfigurationFor(messageCollector: MessageCollector, sourceFiles: It
     CompilerConfiguration().apply {
         addKotlinSourceRoots(sourceFiles.map { it.canonicalPath })
         addJvmClasspathRoots(PathUtil.getJdkClassesRootsFromCurrentJre())
+        /*
+         * Without this the compiler won't work with JDK 9.
+         * See the discussion here:
+         * https://youtrack.jetbrains.com/issue/KT-20167
+         */
+        put(JVMConfigurationKeys.JDK_HOME, File(System.getProperty("java.home")))
         put<MessageCollector>(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
     }
 


### PR DESCRIPTION
### Context
Setting the JDK_HOME configuration key explicitly for the Kotlin compiler
means that it can find the JDK 9 objects to compile against.

This may just be a stopgap fix and not the long term solution.

Related https://youtrack.jetbrains.com/issue/KT-20167
Related #454
Related #455

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests to verify changes from a user perspective
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
- [ ] Provide unit tests to verify logic (see #455 which should be merged after a release with this fix)
