### PR TITLE
Escape string template dollar sign in generated project accessor names

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -22,142 +22,143 @@ import org.jetbrains.kotlin.lexer.KtTokens
 
 internal
 fun ProjectSchema<TypeAccessibility>.forEachAccessor(action: (String) -> Unit) {
-    extensions.map(::typedAccessorSpecFor).forEach { spec ->
+    extensions.map(::typedAccessorSpec).forEach { spec ->
         extensionAccessorFor(spec)?.let(action)
     }
-    conventions.map(::typedAccessorSpecFor).forEach { spec ->
-        if (spec.name.original !in extensions) {
-            conventionAccessorFor(spec)?.let(action)
-        }
+    conventions.filterKeys { it !in extensions }.map(::typedAccessorSpec).forEach { spec ->
+        conventionAccessorFor(spec)?.let(action)
     }
-    configurations.map(::accessorNameSpecFor).forEach { spec ->
+    configurations.map(::accessorNameSpec).forEach { spec ->
         configurationAccessorFor(spec)?.let(action)
     }
 }
 
 private
-fun extensionAccessorFor(spec: TypedAccessorSpec): String? =
-    codeForAccessor(spec.name) {
-        when (spec.typeAccess) {
-            is TypeAccessibility.Accessible -> accessibleExtensionAccessorFor(spec.name, spec.typeAccess.type)
-            is TypeAccessibility.Inaccessible -> inaccessibleExtensionAccessorFor(spec.name, spec.typeAccess)
+fun extensionAccessorFor(spec: TypedAccessorSpec): String? = spec.run {
+    codeForAccessor(name) {
+        when (typeAccess) {
+            is TypeAccessibility.Accessible -> accessibleExtensionAccessorFor(name, typeAccess.type)
+            is TypeAccessibility.Inaccessible -> inaccessibleExtensionAccessorFor(name, typeAccess)
         }
     }
+}
 
 
 private
-fun accessibleExtensionAccessorFor(name: AccessorNameSpec, type: String): String =
+fun accessibleExtensionAccessorFor(name: AccessorNameSpec, type: String): String = name.run {
     """
         /**
-         * Retrieves the [${name.original}][$type] project extension.
+         * Retrieves the [$original][$type] project extension.
          */
-        val Project.`${name.kotlinIdentifier}`: $type get() =
-            extensions.getByName("${name.stringLiteral}") as $type
+        val Project.`$kotlinIdentifier`: $type get() =
+            extensions.getByName("$stringLiteral") as $type
 
         /**
-         * Configures the [${name.original}][$type] project extension.
+         * Configures the [$original][$type] project extension.
          */
-        fun Project.`${name.kotlinIdentifier}`(configure: $type.() -> Unit): Unit =
-            extensions.configure("${name.stringLiteral}", configure)
+        fun Project.`$kotlinIdentifier`(configure: $type.() -> Unit): Unit =
+            extensions.configure("$stringLiteral", configure)
 
     """
+}
 
 
 private
-fun inaccessibleExtensionAccessorFor(name: AccessorNameSpec, typeAccess: TypeAccessibility.Inaccessible): String =
+fun inaccessibleExtensionAccessorFor(name: AccessorNameSpec, typeAccess: TypeAccessibility.Inaccessible): String = name.run {
     """
         /**
-         * Retrieves the [${name.original}][${typeAccess.type}] project extension.
+         * Retrieves the [$original][${typeAccess.type}] project extension.
          *
          * ${documentInaccessibilityReasons(name, typeAccess)}
          */
-        val Project.`${name.kotlinIdentifier}`: Any get() =
-            extensions.getByName("${name.stringLiteral}")
+        val Project.`$kotlinIdentifier`: Any get() =
+            extensions.getByName("$stringLiteral")
 
         /**
-         * Configures the [${name.original}][${typeAccess.type}] project extension.
+         * Configures the [$original][${typeAccess.type}] project extension.
          *
          * ${documentInaccessibilityReasons(name, typeAccess)}
          */
-        fun Project.`${name.kotlinIdentifier}`(configure: Any.() -> Unit): Unit =
-            extensions.configure("${name.stringLiteral}", configure)
+        fun Project.`$kotlinIdentifier`(configure: Any.() -> Unit): Unit =
+            extensions.configure("$stringLiteral", configure)
 
     """
-
+}
 
 private
-fun conventionAccessorFor(spec: TypedAccessorSpec): String? =
-    codeForAccessor(spec.name) {
-        when (spec.typeAccess) {
-            is TypeAccessibility.Accessible -> accessibleConventionAccessorFor(spec.name, spec.typeAccess.type)
-            is TypeAccessibility.Inaccessible -> inaccessibleConventionAccessorFor(spec.name, spec.typeAccess)
+fun conventionAccessorFor(spec: TypedAccessorSpec): String? = spec.run {
+    codeForAccessor(name) {
+        when (typeAccess) {
+            is TypeAccessibility.Accessible -> accessibleConventionAccessorFor(name, typeAccess.type)
+            is TypeAccessibility.Inaccessible -> inaccessibleConventionAccessorFor(name, typeAccess)
         }
     }
+}
 
 
 private
-fun accessibleConventionAccessorFor(name: AccessorNameSpec, type: String): String =
+fun accessibleConventionAccessorFor(name: AccessorNameSpec, type: String): String = name.run {
     """
         /**
-         * Retrieves the [${name.original}][$type] project convention.
+         * Retrieves the [$original][$type] project convention.
          */
-        val Project.`${name.kotlinIdentifier}`: $type get() =
-            convention.getPluginByName<$type>("${name.stringLiteral}")
+        val Project.`$kotlinIdentifier`: $type get() =
+            convention.getPluginByName<$type>("$stringLiteral")
 
         /**
-         * Configures the [${name.original}][$type] project convention.
+         * Configures the [$original][$type] project convention.
          */
-        fun Project.`${name.kotlinIdentifier}`(configure: $type.() -> Unit): Unit =
-            configure(`${name.stringLiteral}`)
+        fun Project.`$kotlinIdentifier`(configure: $type.() -> Unit): Unit =
+            configure(`$stringLiteral`)
 
     """
-
+}
 
 private
-fun inaccessibleConventionAccessorFor(name: AccessorNameSpec, typeAccess: TypeAccessibility.Inaccessible): String =
+fun inaccessibleConventionAccessorFor(name: AccessorNameSpec, typeAccess: TypeAccessibility.Inaccessible): String = name.run {
     """
         /**
-         * Retrieves the [${name.original}][${typeAccess.type}] project convention.
+         * Retrieves the [$original][${typeAccess.type}] project convention.
          *
          * ${documentInaccessibilityReasons(name, typeAccess)}
          */
-        val Project.`${name.kotlinIdentifier}`: Any get() =
-            convention.getPluginByName<Any>("${name.stringLiteral}")
+        val Project.`$kotlinIdentifier`: Any get() =
+            convention.getPluginByName<Any>("$stringLiteral")
 
         /**
-         * Configures the [${name.original}][${typeAccess.type}] project convention.
+         * Configures the [$original][${typeAccess.type}] project convention.
          *
          * ${documentInaccessibilityReasons(name, typeAccess)}
          */
-        fun Project.`${name.kotlinIdentifier}`(configure: Any.() -> Unit): Unit =
-            configure(`${name.stringLiteral}`)
+        fun Project.`$kotlinIdentifier`(configure: Any.() -> Unit): Unit =
+            configure(`$stringLiteral`)
 
     """
-
+}
 
 private
-fun configurationAccessorFor(name: AccessorNameSpec): String? =
+fun configurationAccessorFor(name: AccessorNameSpec): String? = name.run {
     codeForAccessor(name) {
         """
             /**
-             * The '${name.original}' configuration.
+             * The '$original' configuration.
              */
-            val ConfigurationContainer.`${name.kotlinIdentifier}`: Configuration
-                get() = getByName("${name.stringLiteral}")
+            val ConfigurationContainer.`$kotlinIdentifier`: Configuration
+                get() = getByName("$stringLiteral")
 
             /**
-             * Adds a dependency to the '${name.original}' configuration.
+             * Adds a dependency to the '$original' configuration.
              *
              * @param dependencyNotation notation for the dependency to be added.
              * @return The dependency.
              *
              * @see DependencyHandler.add
              */
-            fun DependencyHandler.`${name.kotlinIdentifier}`(dependencyNotation: Any): Dependency =
-                add("${name.stringLiteral}", dependencyNotation)
+            fun DependencyHandler.`$kotlinIdentifier`(dependencyNotation: Any): Dependency =
+                add("$stringLiteral", dependencyNotation)
 
             /**
-             * Adds a dependency to the '${name.original}' configuration.
+             * Adds a dependency to the '$original' configuration.
              *
              * @param dependencyNotation notation for the dependency to be added.
              * @param dependencyConfiguration expression to use to configure the dependency.
@@ -166,13 +167,13 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? =
              * @see DependencyHandler.add
              */
             inline
-            fun DependencyHandler.`${name.kotlinIdentifier}`(
+            fun DependencyHandler.`$kotlinIdentifier`(
                 dependencyNotation: String,
                 dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
-                add("${name.stringLiteral}", dependencyNotation, dependencyConfiguration)
+                add("$stringLiteral", dependencyNotation, dependencyConfiguration)
 
             /**
-             * Adds a dependency to the '${name.original}' configuration.
+             * Adds a dependency to the '$original' configuration.
              *
              * @param group the group of the module to be added as a dependency.
              * @param name the name of the module to be added as a dependency.
@@ -184,17 +185,17 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? =
              *
              * @see DependencyHandler.add
              */
-            fun DependencyHandler.`${name.kotlinIdentifier}`(
+            fun DependencyHandler.`$kotlinIdentifier`(
                 group: String,
                 name: String,
                 version: String? = null,
                 configuration: String? = null,
                 classifier: String? = null,
                 ext: String? = null): ExternalModuleDependency =
-                create(group, name, version, configuration, classifier, ext).apply { add("${name.stringLiteral}", this) }
+                create(group, name, version, configuration, classifier, ext).apply { add("$stringLiteral", this) }
 
             /**
-             * Adds a dependency to the '${name.original}' configuration.
+             * Adds a dependency to the '$original' configuration.
              *
              * @param group the group of the module to be added as a dependency.
              * @param name the name of the module to be added as a dependency.
@@ -209,7 +210,7 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? =
              * @see DependencyHandler.add
              */
             inline
-            fun DependencyHandler.`${name.kotlinIdentifier}`(
+            fun DependencyHandler.`$kotlinIdentifier`(
                 group: String,
                 name: String,
                 version: String? = null,
@@ -217,10 +218,10 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? =
                 classifier: String? = null,
                 ext: String? = null,
                 dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
-                add("${name.stringLiteral}", create(group, name, version, configuration, classifier, ext), dependencyConfiguration)
+                add("$stringLiteral", create(group, name, version, configuration, classifier, ext), dependencyConfiguration)
 
             /**
-             * Adds a dependency to the '${name.original}' configuration.
+             * Adds a dependency to the '$original' configuration.
              *
              * @param dependency dependency to be added.
              * @param dependencyConfiguration expression to use to configure the dependency.
@@ -229,17 +230,20 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? =
              * @see DependencyHandler.add
              */
             inline
-            fun <T : ModuleDependency> DependencyHandler.`${name.kotlinIdentifier}`(dependency: T, dependencyConfiguration: T.() -> Unit): T =
-                add("${name.stringLiteral}", dependency, dependencyConfiguration)
+            fun <T : ModuleDependency> DependencyHandler.`$kotlinIdentifier`(dependency: T, dependencyConfiguration: T.() -> Unit): T =
+                add("$stringLiteral", dependency, dependencyConfiguration)
 
         """
     }
+}
 
 
 private
-data class AccessorNameSpec(val original: String,
-                            val kotlinIdentifier: String = original,
-                            val stringLiteral: String = stringLiteralFor(original))
+data class AccessorNameSpec(val original: String) {
+
+    val kotlinIdentifier get() = original
+    val stringLiteral by lazy { stringLiteralFor(original) }
+}
 
 private
 data class TypedAccessorSpec(val name: AccessorNameSpec, val typeAccess: TypeAccessibility)
@@ -256,13 +260,13 @@ fun escapeStringTemplateDollarSign(string: String) =
 
 
 private
-fun accessorNameSpecFor(originalName: String) =
+fun accessorNameSpec(originalName: String) =
     AccessorNameSpec(originalName)
 
 
 private
-fun typedAccessorSpecFor(nameAndType: Map.Entry<String, TypeAccessibility>) =
-    TypedAccessorSpec(accessorNameSpecFor(nameAndType.key), nameAndType.value)
+fun typedAccessorSpec(nameAndType: Map.Entry<String, TypeAccessibility>) =
+    TypedAccessorSpec(accessorNameSpec(nameAndType.key), nameAndType.value)
 
 
 private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -238,7 +238,7 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? = name.run {
 }
 
 
-private
+internal
 data class AccessorNameSpec(val original: String) {
 
     val kotlinIdentifier get() = original

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaAccessorsIntegrationTest.kt
@@ -282,62 +282,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractIntegrationTest() {
         assertThat(result.output, containsString("Type of `buildScan` receiver is Any"))
     }
 
-    @Test
-    fun `given configuration and extension with string template dollar sign in name, accessors are usable`() {
-
-        withKotlinBuildSrc()
-
-        // Plugin that creates a configuration named $$my$$config$$ and an extension named $$my$$ext$$
-        withFile("buildSrc/src/main/kotlin/my/MyPlugin.kt", """
-            package my
-
-            import org.gradle.api.*
-
-            class MyPlugin : Plugin<Project> {
-
-                override fun apply(project: Project) {
-                    val configName = "${'$'}{'${'$'}'}${'$'}{'${'$'}'}my${'$'}{'${'$'}'}${'$'}{'${'$'}'}config${'$'}{'${'$'}'}${'$'}{'${'$'}'}"
-                    project.configurations.create(configName)
-
-                    val extName = "${'$'}{'${'$'}'}${'$'}{'${'$'}'}my${'$'}{'${'$'}'}${'$'}{'${'$'}'}ext${'$'}{'${'$'}'}${'$'}{'${'$'}'}"
-                    val container = project.container(MyType::class.java, ::MyType)
-                    container.create(extName)
-                    project.extensions.add(extName, container)
-                }
-            }
-
-            data class MyType(val name: String)
-        """)
-
-        val buildFile = withBuildScript("""
-
-            apply<my.MyPlugin>()
-        """)
-
-        println(
-            build("kotlinDslAccessorsSnapshot").output)
-
-        buildFile.appendText("""
-            tasks {
-                "showme" {
-                    doLast {
-                        println("**" + configurations.`${'$'}${'$'}my${'$'}${'$'}config${'$'}${'$'}`.name + "**")
-                        println("**" + `${'$'}${'$'}my${'$'}${'$'}ext${'$'}${'$'}`.names.first() + "**")
-                    }
-                }
-            }
-        """)
-
-        val result = build("showme")
-        assertThat(
-            result.output,
-            containsString("**${'$'}${'$'}my${'$'}${'$'}config${'$'}${'$'}**"))
-        assertThat(
-            result.output,
-            containsString("**${'$'}${'$'}my${'$'}${'$'}ext${'$'}${'$'}**"))
-    }
-
-
     private
     fun setOfAutomaticAccessorsFor(plugins: Set<String>): File {
         val script = "plugins {\n${plugins.joinToString(separator = "\n")}\n}"

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -34,6 +34,16 @@ class ProjectSchemaTest : TestWithClassPath() {
     }
 
     @Test
+    fun `accessor name spec escapes string template dollar signs`() {
+        val original = "foo${'$'}${'$'}bar"
+        val spec = AccessorNameSpec(original)
+
+        assertThat(spec.original, equalTo(original))
+        assertThat(spec.kotlinIdentifier, equalTo(original))
+        assertThat(spec.stringLiteral, equalTo("foo${'$'}{'${'$'}'}${'$'}{'${'$'}'}bar"))
+    }
+
+    @Test
     fun `non existing type is represented as Inaccessible because NonAvailable`() {
 
         val typeString = "non.existing.Type"

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -19,16 +19,18 @@ private class PrivateComponentType
 class ProjectSchemaTest : TestWithClassPath() {
 
     @Test
-    fun `#isLegalExtensionName rejects illegal Kotlin extension names`() {
+    fun `#isLegalAccessorName rejects illegal Kotlin extension names`() {
 
-        assert(isLegalExtensionName("foo_bar"))
-        assert(isLegalExtensionName("foo-bar"))
-        assert(isLegalExtensionName("foo bar"))
+        assert(isLegalAccessorName("foo_bar"))
+        assert(isLegalAccessorName("foo-bar"))
+        assert(isLegalAccessorName("foo bar"))
+        assert(isLegalAccessorName("'foo'bar'"))
+        assert(isLegalAccessorName("foo${'$'}${'$'}bar"))
 
-        assertFalse(isLegalExtensionName("foo`bar"))
-        assertFalse(isLegalExtensionName("foo.bar"))
-        assertFalse(isLegalExtensionName("foo/bar"))
-        assertFalse(isLegalExtensionName("foo\\bar"))
+        assertFalse(isLegalAccessorName("foo`bar"))
+        assertFalse(isLegalAccessorName("foo.bar"))
+        assertFalse(isLegalAccessorName("foo/bar"))
+        assertFalse(isLegalAccessorName("foo\\bar"))
     }
 
     @Test


### PR DESCRIPTION
By distinguishing original name, kotlin identifier and string literal.

