### PR TITLE
Move to the new PluginDependencySpec API

### DIFF
--- a/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
+++ b/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
@@ -52,8 +52,8 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 
-import org.gradle.plugin.use.PluginDependenciesSpec
-import org.gradle.plugin.use.PluginDependencySpec
+import org.gradle.plugin.dsl.BinaryPluginDependencySpec
+import org.gradle.plugin.dsl.PluginDependenciesSpec
 
 
 /**
@@ -95,7 +95,7 @@ fun DependencyHandler.kotlinModule(module: String, version: String? = null): Any
  * @param module simple name of the Kotlin Gradle plugin module, for example "jvm", "android", "kapt", "plugin.allopen" etc...
  * @param version optional desired version, null implies [embeddedKotlinVersion].
  */
-fun PluginDependenciesSpec.kotlin(module: String, version: String? = null): PluginDependencySpec =
+fun PluginDependenciesSpec.kotlin(module: String, version: String? = null): BinaryPluginDependencySpec =
     id("org.jetbrains.kotlin.${'$'}module") version (version ?: embeddedKotlinVersion)
 
 
@@ -108,7 +108,7 @@ fun PluginDependenciesSpec.kotlin(module: String, version: String? = null): Plug
  *
  * @see org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
  */
-val PluginDependenciesSpec.`embedded-kotlin`: PluginDependencySpec
+val PluginDependenciesSpec.`embedded-kotlin`: BinaryPluginDependencySpec
     get() = id("org.gradle.kotlin.embedded-kotlin") version "$kotlinDslPluginsVersion"
 
 /**
@@ -120,7 +120,7 @@ val PluginDependenciesSpec.`embedded-kotlin`: PluginDependencySpec
  *
  * @see org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPlugin
  */
-val PluginDependenciesSpec.`kotlin-dsl`: PluginDependencySpec
+val PluginDependenciesSpec.`kotlin-dsl`: BinaryPluginDependencySpec
     get() = id("org.gradle.kotlin.kotlin-dsl") version "$kotlinDslPluginsVersion"
 
 """)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -18,7 +18,7 @@ package org.gradle.kotlin.dsl
 
 import org.gradle.api.Project
 
-import org.gradle.plugin.use.PluginDependenciesSpec
+import org.gradle.plugin.dsl.PluginDependenciesSpec
 
 import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -15,8 +15,8 @@
  */
 package org.gradle.kotlin.dsl
 
-import org.gradle.plugin.use.PluginDependenciesSpec
-import org.gradle.plugin.use.PluginDependencySpec
+import org.gradle.plugin.dsl.BinaryPluginDependencySpec
+import org.gradle.plugin.dsl.PluginDependenciesSpec
 
 
 /**
@@ -28,5 +28,5 @@ import org.gradle.plugin.use.PluginDependencySpec
  *
  * You can also use e.g. `` `build-scan` version "1.7.1" `` if you want to use a different version.
  */
-val PluginDependenciesSpec.`build-scan`: PluginDependencySpec
+val PluginDependenciesSpec.`build-scan`: BinaryPluginDependencySpec
     get() = id("com.gradle.build-scan") version "1.8"

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.kotlin.dsl
 
-import org.gradle.plugin.use.PluginDependenciesSpec
-import org.gradle.plugin.use.PluginDependencySpec
+import org.gradle.plugin.dsl.PluginDependenciesSpec
+import org.gradle.plugin.dsl.BinaryPluginDependencySpec
 
 
 /**
@@ -35,9 +35,9 @@ class PluginDependenciesSpecScope(plugins: PluginDependenciesSpec) : PluginDepen
 /**
  * Specify the version of the plugin to depend on.
  *
- * Infix version of [PluginDependencySpec.version].
+ * Infix version of [BinaryPluginDependencySpec.version].
  */
-infix fun PluginDependencySpec.version(version: String?): PluginDependencySpec = version(version)
+infix fun BinaryPluginDependencySpec.version(version: String?): BinaryPluginDependencySpec = version(version)
 
 
 /**
@@ -46,4 +46,4 @@ infix fun PluginDependencySpec.version(version: String?): PluginDependencySpec =
  *
  * Infix version of [PluginDependencySpec.apply].
  */
-infix fun PluginDependencySpec.apply(apply: Boolean): PluginDependencySpec = apply(apply)
+infix fun BinaryPluginDependencySpec.apply(apply: Boolean): BinaryPluginDependencySpec = apply(apply)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.kotlin.dsl.codegen
 
-import org.gradle.plugin.use.PluginDependenciesSpec
-import org.gradle.plugin.use.PluginDependencySpec
+import org.gradle.plugin.dsl.BinaryPluginDependencySpec
+import org.gradle.plugin.dsl.PluginDependenciesSpec
 
 import java.io.File
 
@@ -31,7 +31,7 @@ fun writeBuiltinPluginIdExtensionsTo(file: File, gradleJars: Iterable<File>) {
         write(fileHeader)
         write("\n")
         write("import ${PluginDependenciesSpec::class.qualifiedName}\n")
-        write("import ${PluginDependencySpec::class.qualifiedName}\n")
+        write("import ${BinaryPluginDependencySpec::class.qualifiedName}\n")
         pluginIdExtensionDeclarationsFor(gradleJars).forEach {
             write("\n")
             write(it)
@@ -44,7 +44,7 @@ fun writeBuiltinPluginIdExtensionsTo(file: File, gradleJars: Iterable<File>) {
 private
 fun pluginIdExtensionDeclarationsFor(jars: Iterable<File>): Sequence<String> {
     val extendedType = PluginDependenciesSpec::class.simpleName
-    val extensionType = PluginDependencySpec::class.simpleName
+    val extensionType = BinaryPluginDependencySpec::class.simpleName
     return pluginExtensionsFrom(jars)
         .map { (memberName, pluginId, website, implementationClass) ->
             """

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -197,7 +197,7 @@ class KotlinBuildScriptCompiler(
 
         val (lineNumber, compiledScript) = compiledPluginsBlock
         val pluginsBlockClass = classFrom(compiledScript, baseScope.createChild("plugins"))
-        val pluginDependenciesSpec = pluginRequestCollector.createSpec(lineNumber)
+        val pluginDependenciesSpec = pluginRequestCollector.createPluginDependencySpec(lineNumber)
         withContextClassLoader(pluginsBlockClass.classLoader) {
             try {
                 instantiate(pluginsBlockClass, pluginDependenciesSpec)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -197,7 +197,7 @@ class KotlinBuildScriptCompiler(
 
         val (lineNumber, compiledScript) = compiledPluginsBlock
         val pluginsBlockClass = classFrom(compiledScript, baseScope.createChild("plugins"))
-        val pluginDependenciesSpec = pluginRequestCollector.createPluginDependencySpec(lineNumber)
+        val pluginDependenciesSpec = pluginRequestCollector.createPluginDependenciesSpec(lineNumber)
         withContextClassLoader(pluginsBlockClass.classLoader) {
             try {
                 instantiate(pluginsBlockClass, pluginDependenciesSpec)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -64,6 +64,12 @@ internal
 typealias JarsProvider = () -> Collection<File>
 
 
+var extensionsJarCacheVersion = 2
+
+
+var extensionsJarCacheId = "kotlin-dsl-extensions-$extensionsJarCacheVersion"
+
+
 class KotlinScriptClassPathProvider(
     val classPathRegistry: ClassPathRegistry,
     val gradleApiJarsProvider: JarsProvider,
@@ -100,7 +106,7 @@ class KotlinScriptClassPathProvider(
 
     private
     fun gradleKotlinDslExtensions(): File =
-        produceFrom("kotlin-dsl-extensions") { outputFile, onProgress ->
+        produceFrom(extensionsJarCacheId) { outputFile, onProgress ->
             generateApiExtensionsJar(outputFile, gradleJars, onProgress)
         }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -64,10 +64,12 @@ internal
 typealias JarsProvider = () -> Collection<File>
 
 
-var extensionsJarCacheVersion = 2
+private
+val extensionsJarCacheVersion = 2
 
 
-var extensionsJarCacheId = "kotlin-dsl-extensions-$extensionsJarCacheVersion"
+internal
+val extensionsJarCacheId = "kotlin-dsl-extensions-$extensionsJarCacheVersion"
 
 
 class KotlinScriptClassPathProvider(

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinPluginsBlock.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinPluginsBlock.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.kotlin.dsl.support
 
-import org.gradle.plugin.use.PluginDependenciesSpec
+import org.gradle.plugin.dsl.PluginDependenciesSpec
 
 
 /**

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
@@ -2,7 +2,7 @@ package org.gradle.kotlin.dsl
 
 import org.gradle.groovy.scripts.StringScriptSource
 
-import org.gradle.plugin.use.PluginDependenciesSpec
+import org.gradle.plugin.dsl.PluginDependenciesSpec
 import org.gradle.plugin.use.internal.PluginRequestCollector
 
 import org.hamcrest.CoreMatchers.equalTo
@@ -67,7 +67,7 @@ fun expecting(vararg expected: Plugin, block: PluginDependenciesSpec.() -> Unit)
 
 fun plugins(block: PluginDependenciesSpecScope.() -> Unit) =
     PluginRequestCollector(StringScriptSource("script", "")).run {
-        PluginDependenciesSpecScope(createSpec(1)).block()
+        PluginDependenciesSpecScope(createPluginDependencySpec(1)).block()
         listPluginRequests()
     }
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -24,7 +24,7 @@ class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
 
         val gradleApiJar = file("gradle-api-3.1.jar")
 
-        val generatedKotlinExtensions = file("kotlin-dsl-extensions.jar")
+        val generatedKotlinExtensions = file("$extensionsJarCacheId.jar")
 
         val kotlinExtensionsMonitor = mock<ProgressMonitor>(name = "kotlinExtensionsMonitor")
         val progressMonitorProvider = mock<JarGenerationProgressMonitorProvider> {


### PR DESCRIPTION
By using `org.gradle.plugin.dsl.PluginDependenciesSpec` from https://github.com/gradle/gradle/pull/2825.

Step for #424