### PR TITLE
`embedded-kotlin` plugins adds stdlib & reflect to compileOnly

### DIFF
--- a/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
  * The `embedded-kotlin` plugin.
  *
  * Applies the `org.jetbrains.kotlin.jvm` plugin,
- * adds compile dependencies on `kotlin-stdlib` and `kotlin-reflect`,
+ * adds compile only dependencies on `kotlin-stdlib` and `kotlin-reflect`,
  * configures an embedded repository that contains all embedded Kotlin libraries,
  * and pins them to the embedded Kotlin version.
  */
@@ -48,7 +48,10 @@ open class EmbeddedKotlinPlugin @Inject internal constructor(
                 dependencies,
                 embeddedKotlinConfiguration.name,
                 "stdlib", "reflect")
-            configurations.getByName("compile").extendsFrom(embeddedKotlinConfiguration)
+
+            listOf("compileOnly", "testCompileOnly").forEach {
+                configurations.getByName(it).extendsFrom(embeddedKotlinConfiguration)
+            }
 
             configurations.all {
                 embeddedKotlin.pinDependenciesOn(it, "stdlib", "reflect", "compiler-embeddable")

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -56,7 +56,6 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
             tasks {
                 "assertions" {
                     doLast {
-                        repositories["Embedded Kotlin Repository"]
                         val requiredLibs = listOf("kotlin-stdlib-$embeddedKotlinVersion.jar", "kotlin-reflect-$embeddedKotlinVersion.jar")
                         listOf("compileOnly", "testCompileOnly").forEach { configuration ->
                             require(configurations[configuration].files.map { it.name }.containsAll(requiredLibs), {

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -46,24 +46,30 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
     }
 
     @Test
-    fun `adds stdlib and reflect as compile dependencies`() {
+    fun `adds stdlib and reflect as compile only dependencies`() {
         withBuildScript("""
 
             plugins {
                 `embedded-kotlin`
             }
 
-            println(repositories.map { it.name })
-            configurations["compileClasspath"].files.map { println(it) }
+            tasks {
+                "assertions" {
+                    doLast {
+                        repositories["Embedded Kotlin Repository"]
+                        val requiredLibs = listOf("kotlin-stdlib-$embeddedKotlinVersion.jar", "kotlin-reflect-$embeddedKotlinVersion.jar")
+                        listOf("compileOnly", "testCompileOnly").forEach { configuration ->
+                            require(configurations[configuration].files.map { it.name }.containsAll(requiredLibs), {
+                                "Embedded Kotlin libraries not found in ${'$'}configuration"
+                            })
+                        }
+                    }
+                }
+            }
 
         """)
 
-        val result = buildWithPlugin("dependencies")
-
-        assertThat(result.output, containsString("Embedded Kotlin Repository"))
-        listOf("stdlib", "reflect").forEach {
-            assertThat(result.output, containsString("kotlin-$it-$embeddedKotlinVersion.jar"))
-        }
+        buildWithPlugin("assertions")
     }
 
     @Test


### PR DESCRIPTION
and testCompileOnly instead of compile

See #509
