### PR TITLE
Restore extra properties type info & allow nullability

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
@@ -34,18 +34,11 @@ val ExtensionAware.extra: ExtraPropertiesExtension
     get() = extensions.extraProperties
 
 
-operator fun ExtraPropertiesExtension.setValue(receiver: Any?, property: KProperty<*>, value: Any) =
+operator fun ExtraPropertiesExtension.setValue(receiver: Any?, property: KProperty<*>, value: Any?) =
     set(property.name, value)
 
 
-operator fun <T> ExtraPropertiesExtension.getValue(receiver: Any?, property: KProperty<*>): T =
-    /* We would like to be able to express optional properties via nullability of the return type
-       but Kotlin won't let us reflect on `property.returnType` here and complain with:
-           Not supported for local property reference.
-    uncheckedCast(
-        if (property.returnType.isMarkedNullable && !has(property.name)) null
-        else get(property.name))
-    */
+operator fun <T : Any?> ExtraPropertiesExtension.getValue(receiver: Any?, property: KProperty<*>): T =
     uncheckedCast(get(property.name))
 
 
@@ -56,7 +49,7 @@ operator fun <T> ExtraPropertiesExtension.getValue(receiver: Any?, property: KPr
  * Usage: `val answer by extra { 42 }`
  */
 inline
-operator fun <T : Any> ExtraPropertiesExtension.invoke(initialValueProvider: () -> T): ExtraPropertyDelegateProvider<T> =
+operator fun <T : Any?> ExtraPropertiesExtension.invoke(initialValueProvider: () -> T): ExtraPropertyDelegateProvider<T> =
     invoke(initialValueProvider())
 
 
@@ -65,11 +58,11 @@ operator fun <T : Any> ExtraPropertiesExtension.invoke(initialValueProvider: () 
  *
  * Usage: `val answer by extra(42)`
  */
-operator fun <T : Any> ExtraPropertiesExtension.invoke(initialValue: T): ExtraPropertyDelegateProvider<T> =
+operator fun <T : Any?> ExtraPropertiesExtension.invoke(initialValue: T): ExtraPropertyDelegateProvider<T> =
     ExtraPropertyDelegateProvider(this, initialValue)
 
 
-class ExtraPropertyDelegateProvider<T : Any>(
+class ExtraPropertyDelegateProvider<T : Any?>(
     val extra: ExtraPropertiesExtension,
     val initialValue: T) {
 
@@ -83,7 +76,7 @@ class ExtraPropertyDelegateProvider<T : Any>(
 /**
  * Enables typed access to extra properties.
  */
-class ExtraPropertyDelegate<T : Any>(val extra: ExtraPropertiesExtension) {
+class ExtraPropertyDelegate<T : Any?>(val extra: ExtraPropertiesExtension) {
 
     operator fun setValue(receiver: Any?, property: kotlin.reflect.KProperty<*>, value: T) =
         extra.set(property.name, value)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
@@ -34,11 +34,11 @@ val ExtensionAware.extra: ExtraPropertiesExtension
     get() = extensions.extraProperties
 
 
-operator fun ExtraPropertiesExtension.setValue(receiver: Any?, property: KProperty<*>, value: Any?) =
+operator fun <T> ExtraPropertiesExtension.setValue(receiver: Any?, property: KProperty<*>, value: T) =
     set(property.name, value)
 
 
-operator fun <T : Any?> ExtraPropertiesExtension.getValue(receiver: Any?, property: KProperty<*>): T =
+operator fun <T> ExtraPropertiesExtension.getValue(receiver: Any?, property: KProperty<*>): T =
     uncheckedCast(get(property.name))
 
 
@@ -49,7 +49,7 @@ operator fun <T : Any?> ExtraPropertiesExtension.getValue(receiver: Any?, proper
  * Usage: `val answer by extra { 42 }`
  */
 inline
-operator fun <T : Any?> ExtraPropertiesExtension.invoke(initialValueProvider: () -> T): ExtraPropertyDelegateProvider<T> =
+operator fun <T> ExtraPropertiesExtension.invoke(initialValueProvider: () -> T): ExtraPropertyDelegateProvider<T> =
     invoke(initialValueProvider())
 
 
@@ -58,11 +58,11 @@ operator fun <T : Any?> ExtraPropertiesExtension.invoke(initialValueProvider: ()
  *
  * Usage: `val answer by extra(42)`
  */
-operator fun <T : Any?> ExtraPropertiesExtension.invoke(initialValue: T): ExtraPropertyDelegateProvider<T> =
+operator fun <T> ExtraPropertiesExtension.invoke(initialValue: T): ExtraPropertyDelegateProvider<T> =
     ExtraPropertyDelegateProvider(this, initialValue)
 
 
-class ExtraPropertyDelegateProvider<T : Any?>(
+class ExtraPropertyDelegateProvider<T>(
     val extra: ExtraPropertiesExtension,
     val initialValue: T) {
 
@@ -76,7 +76,7 @@ class ExtraPropertyDelegateProvider<T : Any?>(
 /**
  * Enables typed access to extra properties.
  */
-class ExtraPropertyDelegate<T : Any?>(val extra: ExtraPropertiesExtension) {
+class ExtraPropertyDelegate<T>(val extra: ExtraPropertiesExtension) {
 
     operator fun setValue(receiver: Any?, property: kotlin.reflect.KProperty<*>, value: T) =
         extra.set(property.name, value)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
@@ -62,11 +62,9 @@ class ExtraPropertiesExtensionsTest {
     @Test
     fun `can initialize extra property to null using lambda expression`() {
 
-        val extra = mock<ExtraPropertiesExtension> {
-            on { get("property") } doReturn (null as Int?)
-        }
+        val extra = mock<ExtraPropertiesExtension>()
 
-        val property by extra { null }
+        val property by extra { null as Int? }
 
         // property is set eagerly
         verify(extra).set("property", null)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
@@ -43,6 +43,38 @@ class ExtraPropertiesExtensionsTest {
         use(property)
     }
 
+    @Test
+    fun `can initialize extra property to null via delegate provider`() {
+
+        val extra = mock<ExtraPropertiesExtension> {
+            on { get("property") } doReturn (null as Int?)
+        }
+
+        val property by extra<Int?>(null)
+
+        // property is set eagerly
+        verify(extra).set("property", null)
+
+        // And to prove the type is inferred correctly
+        use(property)
+    }
+
+    @Test
+    fun `can initialize extra property to null using lambda expression`() {
+
+        val extra = mock<ExtraPropertiesExtension> {
+            on { get("property") } doReturn (null as Int?)
+        }
+
+        val property by extra { null }
+
+        // property is set eagerly
+        verify(extra).set("property", null)
+
+        // And to prove the type is inferred correctly
+        use(property)
+    }
+
     private
-    fun use(@Suppress("unused_parameter") property: Int) = Unit
+    fun use(@Suppress("unused_parameter") property: Int?) = Unit
 }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ExtraPropertiesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ExtraPropertiesSampleTest.kt
@@ -2,7 +2,6 @@ package org.gradle.kotlin.dsl.samples
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
-import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertThat
 import org.junit.Test
 
@@ -17,8 +16,6 @@ class ExtraPropertiesSampleTest : AbstractSampleTest("extra-properties") {
                 containsString("myTask.foo = 42"),
                 containsString("Extra foo property value: 42"),
                 containsString("myTask.bar = null"),
-                containsString("Optional extra bar property value: null"),
-                not(containsString("myTask.bazar")),
-                containsString("Optional extra bazar property value: null")))
+                containsString("Optional extra bar property value: null")))
     }
 }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ExtraPropertiesSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ExtraPropertiesSampleTest.kt
@@ -2,6 +2,7 @@ package org.gradle.kotlin.dsl.samples
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertThat
 import org.junit.Test
 
@@ -12,7 +13,12 @@ class ExtraPropertiesSampleTest : AbstractSampleTest("extra-properties") {
     fun `extra properties`() {
         assertThat(
             build("myTask").output,
-            allOf(containsString("myTask.foo = 42"),
-                  containsString("Extra property value: 42")))
+            allOf(
+                containsString("myTask.foo = 42"),
+                containsString("Extra foo property value: 42"),
+                containsString("myTask.bar = null"),
+                containsString("Optional extra bar property value: null"),
+                not(containsString("myTask.bazar")),
+                containsString("Optional extra bazar property value: null")))
     }
 }

--- a/samples/extra-properties/build.gradle.kts
+++ b/samples/extra-properties/build.gradle.kts
@@ -2,28 +2,19 @@ val myTask = task("myTask") {
 
     val foo by extra { 42 }
     val bar by extra<Int?>(null)
-    val bazar: Int? by extra { null }
 
     doLast {
         println("Extra foo property value: $foo")
         println("Optional extra bar property value: $bar")
-        println("Optional extra bazar property value: $bazar")
     }
 }
 
 val foo: Int by myTask.extra
 val bar: Int? by myTask.extra
-val bazar: Int by myTask.extra
 
 afterEvaluate {
     println("myTask.foo = $foo")
     println("myTask.bar = $bar")
-    try {
-        println("myTask.bazar = $bazar")
-        require(false, { "Should not happen as `bazar`, requested as a Int is effectively null" })
-    } catch (ex: NullPointerException) {
-        // expected
-    }
 }
 
 defaultTasks(myTask.name)

--- a/samples/extra-properties/build.gradle.kts
+++ b/samples/extra-properties/build.gradle.kts
@@ -1,15 +1,29 @@
 val myTask = task("myTask") {
 
     val foo by extra { 42 }
+    val bar by extra<Int?>(null)
+    val bazar: Int? by extra { null }
 
     doLast {
-        println("Extra property value: $foo")
+        println("Extra foo property value: $foo")
+        println("Optional extra bar property value: $bar")
+        println("Optional extra bazar property value: $bazar")
     }
 }
 
 val foo: Int by myTask.extra
+val bar: Int? by myTask.extra
+val bazar: Int by myTask.extra
+
 afterEvaluate {
     println("myTask.foo = $foo")
+    println("myTask.bar = $bar")
+    try {
+        println("myTask.bazar = $bazar")
+        require(false, { "Should not happen as `bazar`, requested as a Int is effectively null" })
+    } catch (ex: NullPointerException) {
+        // expected
+    }
 }
 
 defaultTasks(myTask.name)


### PR DESCRIPTION
Optional extra properties can now be expressed via nullability of the property type.

```kotlin
val name by extra { null } // creates null extra property

val name: String by extra  // throws NPE on property usage
val name: String? by extra // works as expected
```

This PR also enhances the `extra-properties` sample to demonstrate this.

See #512
