### PR TITLE
Clarify backwards and forward compatibility wrt. Kotlin versions

### DIFF
--- a/doc/getting-started/Kotlin-Versions.md
+++ b/doc/getting-started/Kotlin-Versions.md
@@ -1,15 +1,26 @@
 ## Kotlin versions and the Gradle Kotlin DSL 
 
-Gradle ships with Kotlin DSL support which uses embedded Kotlin compiler, plus fixed Kotlin `stdlib` and `reflect` dependencies. For example, Gradle 4.3 ships with Kotlin 1.1.51, as well as `stdlib` and `reflect` with the same version. The `kotlin` package from those modules is visible through the Gradle classpath.
+Gradle ships with Kotlin DSL support which uses embedded Kotlin compiler, plus fixed Kotlin `stdlib` and `reflect`
+dependencies. For example, Gradle 4.3 ships with Kotlin 1.1.51, as well as `stdlib` and `reflect` with the same version.
+The `kotlin` package from those modules is visible through the Gradle classpath.
 
-For both backward and forward compatibility, the [compatibility guarantees](https://kotlinlang.org/docs/reference/compatibility.html) provided by Kotlin apply.
+For both backward and forward compatibility, the
+[compatibility guarantees](https://kotlinlang.org/docs/reference/compatibility.html) provided by Kotlin apply.
 
 ### Backward compatibility
 
-Our approach is to only do backwards-breaking Kotlin upgrades on a major Gradle release. We will always clearly document which Kotlin version we ship and announce upgrade plans before a major release. 
+Our approach is to only do backwards-breaking Kotlin upgrades on a major Gradle release. We will always clearly document
+which Kotlin version we ship and announce upgrade plans before a major release. 
 
-Plugin authors who want to stay compatible with older Gradle versions need to limit their API usage to a subset that is compatible with these old versions. It’s not really different from any other new API in Gradle. E.g. if we introduce a new API for dependency resolution and a plugin wants to use that API, then they either need to drop support for older Gradle versions or they need to do some clever organization of their code to only execute the new code path on newer versions.
+Plugin authors who want to stay compatible with older Gradle versions need to limit their API usage to a subset that is
+compatible with these old versions. It’s not really different from any other new API in Gradle. E.g. if we introduce a
+new API for dependency resolution and a plugin wants to use that API, then they either need to drop support for older
+Gradle versions or they need to do some clever organization of their code to only execute the new code path on newer
+versions.
 
 ### Forward compatibility
 
-The biggest issue is the compatibility between the external `kotlin-gradle-plugin` version and the `kotlin-stdlib` version shipped with Gradle. More generally, between any plugin that transitively depends on `kotlin-stdlib` and its version shipped with Gradle. As long as the combination is compatible everything should work. This will become less of an issue as the language matures.
+The biggest issue is the compatibility between the external `kotlin-gradle-plugin` version and the `kotlin-stdlib`
+version shipped with Gradle. More generally, between any plugin that transitively depends on `kotlin-stdlib` and its
+version shipped with Gradle. As long as the combination is compatible everything should work. This will become less of
+an issue as the language matures.

--- a/doc/getting-started/Kotlin-Versions.md
+++ b/doc/getting-started/Kotlin-Versions.md
@@ -12,6 +12,9 @@ both backward and forward compatibility.
 Our approach is to only do backwards-breaking Kotlin upgrades on a major Gradle release. We will always clearly document
 which Kotlin version we ship and announce upgrade plans before a major release. 
 
+> Until the Gradle Kotlin DSL v1.0 release our policy will be to ship with the latest stable Kotlin version available
+> at the time.
+
 Plugin authors who want to stay compatible with older Gradle versions need to limit their API usage to a subset that is
 compatible with these old versions. It’s not really different from any other new API in Gradle. E.g. if we introduce a
 new API for dependency resolution and a plugin wants to use that API, then they either need to drop support for older

--- a/doc/getting-started/Kotlin-Versions.md
+++ b/doc/getting-started/Kotlin-Versions.md
@@ -1,7 +1,7 @@
 ## Kotlin versions and the Gradle Kotlin DSL 
 
-Gradle ships with Kotlin DSL support which uses embedded Kotlin compiler, plus fixed Kotlin `stdlib` and `reflect`
-dependencies. For example, Gradle 4.3 ships with Kotlin 1.1.51, as well as `stdlib` and `reflect` with the same version.
+Gradle Kotlin DSL ships with the embedded Kotlin compiler plus matching versions of the Kotlin `stdlib` and `reflect`
+libraries. For example, Gradle 4.3 ships with Kotlin 1.1.51, as well as `stdlib` and `reflect` with the same version.
 The `kotlin` package from those modules is visible through the Gradle classpath.
 
 The [compatibility guarantees](https://kotlinlang.org/docs/reference/compatibility.html) provided by Kotlin apply for
@@ -12,7 +12,7 @@ both backward and forward compatibility.
 Our approach is to only do backwards-breaking Kotlin upgrades on a major Gradle release. We will always clearly document
 which Kotlin version we ship and announce upgrade plans before a major release. 
 
-> Until the Gradle Kotlin DSL v1.0 release our policy will be to ship with the latest stable Kotlin version available
+> Until the release of Gradle Kotlin DSL v1.0 our policy will be to ship with the latest stable Kotlin version available
 > at the time.
 
 Plugin authors who want to stay compatible with older Gradle versions need to limit their API usage to a subset that is

--- a/doc/getting-started/Kotlin-Versions.md
+++ b/doc/getting-started/Kotlin-Versions.md
@@ -1,0 +1,15 @@
+## Kotlin versions and the Gradle Kotlin DSL 
+
+Gradle ships with Kotlin DSL support which uses embedded Kotlin compiler, plus fixed Kotlin `stdlib` and `reflect` dependencies. For example, Gradle 4.3 ships with Kotlin 1.1.51, as well as `stdlib` and `reflect` with the same version. The `kotlin` package from those modules is visible through the Gradle classpath.
+
+For both backward and forward compatibility, the [compatibility guarantees](https://kotlinlang.org/docs/reference/compatibility.html) provided by Kotlin apply.
+
+### Backward compatibility
+
+Our approach is to only do backwards-breaking Kotlin upgrades on a major Gradle release. We will always clearly document which Kotlin version we ship and announce upgrade plans before a major release. 
+
+Plugin authors who want to stay compatible with older Gradle versions need to limit their API usage to a subset that is compatible with these old versions. It’s not really different from any other new API in Gradle. E.g. if we introduce a new API for dependency resolution and a plugin wants to use that API, then they either need to drop support for older Gradle versions or they need to do some clever organization of their code to only execute the new code path on newer versions.
+
+### Forward compatibility
+
+The biggest issue is the compatibility between the external `kotlin-gradle-plugin` version and the `kotlin-stdlib` version shipped with Gradle. More generally, between any plugin that transitively depends on `kotlin-stdlib` and its version shipped with Gradle. As long as the combination is compatible everything should work. This will become less of an issue as the language matures.

--- a/doc/getting-started/Kotlin-Versions.md
+++ b/doc/getting-started/Kotlin-Versions.md
@@ -4,8 +4,8 @@ Gradle ships with Kotlin DSL support which uses embedded Kotlin compiler, plus f
 dependencies. For example, Gradle 4.3 ships with Kotlin 1.1.51, as well as `stdlib` and `reflect` with the same version.
 The `kotlin` package from those modules is visible through the Gradle classpath.
 
-For both backward and forward compatibility, the
-[compatibility guarantees](https://kotlinlang.org/docs/reference/compatibility.html) provided by Kotlin apply.
+The [compatibility guarantees](https://kotlinlang.org/docs/reference/compatibility.html) provided by Kotlin apply for
+both backward and forward compatibility.
 
 ### Backward compatibility
 

--- a/doc/getting-started/README.md
+++ b/doc/getting-started/README.md
@@ -7,3 +7,4 @@ Please check out these additional notes if you want to know more about:
 
   * [Using Groovy closures in Kotlin](./Closures.md)
   * [Configuring plugins in Kotlin](./Configuring-Plugins.md)
+  * [Kotlin versions and the Gradle Kotlin DSL ](./Kotlin-Versions.md)


### PR DESCRIPTION
Following discussions in #519 about the usage of Kotlin 1.2.