### PR TITLE
JavaScript sample apply kotlin2js plugin using the plugins {} block

### DIFF
--- a/samples/hello-js/build.gradle.kts
+++ b/samples/hello-js/build.gradle.kts
@@ -1,20 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
 
-buildscript {
-    dependencies {
-        classpath(kotlin("gradle-plugin", "1.1.51"))
-    }
-    repositories {
-        jcenter()
-    }
-}
-
-apply {
-    plugin("kotlin2js")
+plugins {
+    id("kotlin2js") version "1.1.51"
 }
 
 dependencies {
-    "compile"(kotlin("stdlib-js"))
+    compile(kotlin("stdlib-js"))
 }
 
 repositories {

--- a/samples/hello-js/settings.gradle
+++ b/samples/hello-js/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        // Use the Gradle Plugin Portal as a regular maven repository
+        // allowing the plugin resolution strategy below to route the
+        // plugin request to artifact coordinates.
+        maven { url "https://plugins.gradle.org/m2" }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "kotlin2js") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
In order to get generated accessors for the `kotlin2js` plugin in the build script.