### PR TITLE
Use older version of JDK 9 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ matrix:
       jdk: openjdk8
     - os: linux
       sudo: false
-      jdk: oraclejdk9 # JDK 9+175 or newer
-      addons:
-        apt:
-          packages:
-            - oracle-java9-installer # Forces use of even newer JDK 9 build
+      jdk: oraclejdk9
 
 script: ./gradlew :provider:check --info --stacktrace --console=plain --max-workers=1 --no-daemon -Dkotlin.compiler.execution.strategy="in-process" -Dkotlin.colors.enabled=false
 


### PR DESCRIPTION
Related to: https://github.com/travis-ci/travis-ci/issues/8600

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
