### PR TITLE
Update to latest `com.gradle.plugin-publish` plugin that is compatibl…

### DIFF
--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("kotlin-dsl-module")
     `maven-publish`
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "0.9.7"
+    id("com.gradle.plugin-publish") version "0.9.9"
 }
 
 base {
@@ -14,9 +14,9 @@ base {
 dependencies {
     compileOnly(gradleKotlinDsl())
 
-    compile(futureKotlin("stdlib-jre8"))
-    compile(futureKotlin("gradle-plugin"))
-    compile(futureKotlin("sam-with-receiver"))
+    implementation(futureKotlin("stdlib-jre8"))
+    implementation(futureKotlin("gradle-plugin"))
+    implementation(futureKotlin("sam-with-receiver"))
 
     testImplementation(project(":test-fixtures"))
 }


### PR DESCRIPTION
…e with Java 9 and the new configurations

### Context

- 0.9.8 fixes the `implementation` and `api` usages - see https://discuss.gradle.org/t/com-gradle-plugin-publish-does-not-respect-new-java-library-configurations/24041
- 0.9.9 for java 9 support - https://github.com/gradle/gradle/issues/3195

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests to verify changes from a user perspective
- [ ] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
