### PR TITLE
Settings can use buildscript dependencies

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -32,6 +32,14 @@ import kotlin.script.templates.ScriptTemplateDefinition
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 abstract class KotlinSettingsScript(settings: Settings) : Settings by settings {
 
+    /**
+     * Configures the build script classpath for settings.
+     *
+     * @see [Settings.buildscript]
+     */
+    @Suppress("unused")
+    open fun buildscript(@Suppress("unused_parameter") block: ScriptHandlerScope.() -> Unit) = Unit
+
     inline
     fun apply(crossinline configuration: ObjectConfigurationAction.() -> Unit) =
         settings.apply({ it.configuration() })

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CachingKotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CachingKotlinCompiler.kt
@@ -66,8 +66,9 @@ class CachingKotlinCompiler(
         classPath: ClassPath,
         parentClassLoader: ClassLoader): CompiledScript {
 
-        val scriptFileName = scriptFileNameFor(buildscriptBlockTemplate, scriptPath)
-        return compileScript(cacheKeyPrefix + scriptFileName + buildscript, classPath, parentClassLoader) { cacheDir ->
+        val scriptFileName = scriptFileNameFor(scriptPath)
+        val cacheKeySpec = cacheKeyPrefix + buildscriptBlockTemplate.qualifiedName + scriptFileName + buildscript
+        return compileScript(cacheKeySpec, classPath, parentClassLoader) { cacheDir ->
             ScriptCompilationSpec(
                 buildscriptBlockTemplate,
                 scriptPath,
@@ -86,15 +87,15 @@ class CachingKotlinCompiler(
         parentClassLoader: ClassLoader): CompiledPluginsBlock {
 
         val (lineNumber, plugins) = lineNumberedPluginsBlock
-        val scriptFileName = scriptFileNameFor(pluginsBlockTemplate, scriptPath)
-        val compiledScript =
-            compileScript(cacheKeyPrefix + scriptFileName + plugins, classPath, parentClassLoader) { cacheDir ->
-                ScriptCompilationSpec(
-                    pluginsBlockTemplate,
-                    scriptPath,
-                    cacheFileFor(plugins, cacheDir, scriptFileName),
-                    scriptFileName + " plugins block")
-            }
+        val scriptFileName = scriptFileNameFor(scriptPath)
+        val cacheKeySpec = cacheKeyPrefix + pluginsBlockTemplate.qualifiedName + scriptFileName + plugins
+        val compiledScript = compileScript(cacheKeySpec, classPath, parentClassLoader) { cacheDir ->
+            ScriptCompilationSpec(
+                pluginsBlockTemplate,
+                scriptPath,
+                cacheFileFor(plugins, cacheDir, scriptFileName),
+                scriptFileName + " plugins block")
+        }
         return CompiledPluginsBlock(lineNumber, compiledScript)
     }
 
@@ -107,8 +108,9 @@ class CachingKotlinCompiler(
         classPath: ClassPath,
         parentClassLoader: ClassLoader): CompiledScript {
 
-        val scriptFileName = scriptFileNameFor(scriptTemplate, scriptPath)
-        return compileScript(cacheKeyPrefix + scriptFileName + script, classPath, parentClassLoader) { cacheDir ->
+        val scriptFileName = scriptFileNameFor(scriptPath)
+        val cacheKeySpec = cacheKeyPrefix + scriptTemplate.qualifiedName + scriptFileName + script
+        return compileScript(cacheKeySpec, classPath, parentClassLoader) { cacheDir ->
             ScriptCompilationSpec(
                 scriptTemplate,
                 scriptPath,
@@ -118,8 +120,8 @@ class CachingKotlinCompiler(
     }
 
     private
-    fun scriptFileNameFor(scriptTemplate: KClass<*>, scriptPath: String) =
-        "${scriptTemplate.qualifiedName}_${scriptPath.substringAfterLast(File.separatorChar)}"
+    fun scriptFileNameFor(scriptPath: String) =
+        scriptPath.substringAfterLast(File.separatorChar)
 
     private
     fun compileScript(

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -176,8 +176,7 @@ class KotlinBuildScriptCompiler(
 
     private
     fun executePluginsBlock() {
-        val pluginRequests = pluginRequests()
-        applyPlugins(pluginRequests)
+        applyPlugins(pluginRequests())
     }
 
     private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -51,6 +51,7 @@ typealias KotlinScript = (Any) -> Unit
 internal
 class KotlinBuildScriptCompiler(
     val kotlinCompiler: CachingKotlinCompiler,
+    val scriptTarget: KotlinScriptTarget<out Any>,
     val scriptSource: ScriptSource,
     val topLevelScript: Boolean,
     val scriptHandler: ScriptHandlerInternal,
@@ -79,53 +80,52 @@ class KotlinBuildScriptCompiler(
         }
 
     fun compileForClassPath() =
-        asKotlinScript { target ->
-            ignoringErrors { executeBuildscriptBlockOn(target) }
-            ignoringErrors { prepareTargetClassLoaderScopeOf(target) }
-            ignoringErrors { executeScriptBodyOn(target) }
+        asKotlinScript {
+            ignoringErrors { executeBuildscriptBlock() }
+            ignoringErrors { prepareTargetClassLoaderScope() }
+            ignoringErrors { executeScriptBody() }
         }
 
     private
     fun compileTopLevelScript() =
-        asKotlinScript { target ->
+        asKotlinScript {
             withUnexpectedBlockHandling {
-                executeBuildscriptBlockOn(target)
-                prepareAndExecuteScriptBodyOn(target)
+                executeBuildscriptBlock()
+                prepareAndExecuteScriptBody()
             }
         }
 
     private
     fun compileScriptPlugin() =
-        asKotlinScript { target ->
+        asKotlinScript {
             withUnexpectedBlockHandling {
-                prepareAndExecuteScriptBodyOn(target)
+                prepareAndExecuteScriptBody()
             }
         }
 
     private
-    fun asKotlinScript(script: (KotlinScriptTarget<*>) -> Unit): KotlinScript = { target ->
-        val scriptTarget = kotlinScriptTargetFor(target)
+    fun asKotlinScript(script: () -> Unit): KotlinScript = {
         scriptTarget.prepare()
-        script(scriptTarget)
+        script()
     }
 
     private
-    fun prepareAndExecuteScriptBodyOn(target: KotlinScriptTarget<*>) {
-        prepareTargetClassLoaderScopeOf(target)
-        executeScriptBodyOn(target)
+    fun prepareAndExecuteScriptBody() {
+        prepareTargetClassLoaderScope()
+        executeScriptBody()
     }
 
     private
-    fun executeScriptBodyOn(target: KotlinScriptTarget<*>) {
-        val accessorsClassPath = accessorsClassPathFor(target)
-        val compiledScript = compileScriptFileFor(target, compilationClassPath + accessorsClassPath)
+    fun executeScriptBody() {
+        val accessorsClassPath = accessorsClassPath()
+        val compiledScript = compileScriptFileFor(compilationClassPath + accessorsClassPath)
         val scriptScope = scriptClassLoaderScopeWith(accessorsClassPath)
-        executeCompiledScript(compiledScript, scriptScope, target)
+        executeCompiledScript(compiledScript, scriptScope)
     }
 
     private
-    fun accessorsClassPathFor(target: KotlinScriptTarget<*>): ClassPath =
-        target.takeIf { topLevelScript }?.accessorsClassPathFor(compilationClassPath)?.bin
+    fun accessorsClassPath(): ClassPath =
+        scriptTarget.takeIf { topLevelScript }?.accessorsClassPathFor(compilationClassPath)?.bin
             ?: ClassPath.EMPTY
 
     private
@@ -133,19 +133,19 @@ class KotlinBuildScriptCompiler(
         targetScope.createChild("script").apply { local(accessorsClassPath) }
 
     private
-    fun executeBuildscriptBlockOn(target: KotlinScriptTarget<*>) {
+    fun executeBuildscriptBlock() {
         setupEmbeddedKotlinForBuildscript()
-        if (target.supportsBuildscriptBlock) {
+        if (scriptTarget.supportsBuildscriptBlock) {
             extractBuildscriptBlockFrom(script)?.let { buildscriptRange ->
-                executeBuildscriptBlockOn(target, buildscriptRange)
+                executeBuildscriptBlockFrom(buildscriptRange)
             }
         }
     }
 
     private
-    fun executeBuildscriptBlockOn(target: KotlinScriptTarget<*>, buildscriptRange: IntRange) {
+    fun executeBuildscriptBlockFrom(buildscriptRange: IntRange) {
         val compiledScript = compileBuildscriptBlock(buildscriptRange)
-        executeCompiledScript(compiledScript, buildscriptBlockClassLoaderScope(), target)
+        executeCompiledScript(compiledScript, buildscriptBlockClassLoaderScope())
     }
 
     private
@@ -163,30 +163,26 @@ class KotlinBuildScriptCompiler(
     }
 
     private
-    fun executeCompiledScript(
-        compiledScript: CachingKotlinCompiler.CompiledScript,
-        scope: ClassLoaderScope,
-        target: KotlinScriptTarget<*>) {
-
+    fun executeCompiledScript(compiledScript: CachingKotlinCompiler.CompiledScript, scope: ClassLoaderScope) {
         val scriptClass = classFrom(compiledScript, scope)
-        executeScriptWithContextClassLoader(scriptClass, target)
+        executeScriptWithContextClassLoader(scriptClass)
     }
 
     private
-    fun prepareTargetClassLoaderScopeOf(target: KotlinScriptTarget<*>) {
+    fun prepareTargetClassLoaderScope() {
         targetScope.export(classPathProvider.gradleApiExtensions)
-        executePluginsBlockOn(target)
+        executePluginsBlock()
     }
 
     private
-    fun executePluginsBlockOn(target: KotlinScriptTarget<*>) {
-        val pluginRequests = pluginRequestsFor(target)
-        applyPluginsTo(target, pluginRequests)
+    fun executePluginsBlock() {
+        val pluginRequests = pluginRequests()
+        applyPlugins(pluginRequests)
     }
 
     private
-    fun pluginRequestsFor(target: KotlinScriptTarget<*>): PluginRequests =
-        if (target.supportsPluginsBlock) collectPluginRequestsFromPluginsBlock()
+    fun pluginRequests(): PluginRequests =
+        if (scriptTarget.supportsPluginsBlock) collectPluginRequestsFromPluginsBlock()
         else DefaultPluginRequests.EMPTY
 
     private
@@ -226,14 +222,15 @@ class KotlinBuildScriptCompiler(
         extractTopLevelSectionFrom(script, "plugins")
 
     private
-    fun applyPluginsTo(target: KotlinScriptTarget<*>, pluginRequests: PluginRequests) {
+    fun applyPlugins(pluginRequests: PluginRequests) {
         pluginRequestsHandler.handle(
-            pluginRequests, scriptHandler, target.`object` as PluginAwareInternal, targetScope)
+            pluginRequests, scriptHandler, scriptTarget.`object` as PluginAwareInternal, targetScope)
     }
 
     private
     fun compileBuildscriptBlock(buildscriptRange: IntRange) =
         kotlinCompiler.compileBuildscriptBlockOf(
+            scriptTarget.buildscriptBlockTemplate!!,
             scriptPath,
             script.linePreservingSubstring(buildscriptRange),
             buildscriptBlockCompilationClassPath,
@@ -242,15 +239,16 @@ class KotlinBuildScriptCompiler(
     private
     fun compilePluginsBlock(pluginsRange: IntRange) =
         kotlinCompiler.compilePluginsBlockOf(
+            scriptTarget.pluginsBlockTemplate!!,
             scriptPath,
             script.linePreservingSubstring_(pluginsRange),
             pluginsBlockCompilationClassPath,
             baseScope.exportClassLoader)
 
     private
-    fun compileScriptFileFor(target: KotlinScriptTarget<*>, classPath: ClassPath) =
+    fun compileScriptFileFor(classPath: ClassPath) =
         kotlinCompiler.compileGradleScript(
-            target.scriptTemplate,
+            scriptTarget.scriptTemplate,
             scriptPath,
             script,
             classPath,
@@ -270,16 +268,16 @@ class KotlinBuildScriptCompiler(
         }
 
     private
-    fun executeScriptWithContextClassLoader(scriptClass: Class<*>, target: KotlinScriptTarget<*>) {
+    fun executeScriptWithContextClassLoader(scriptClass: Class<*>) {
         withContextClassLoader(scriptClass.classLoader) {
-            executeScriptOf(scriptClass, target)
+            executeScriptOf(scriptClass)
         }
     }
 
     private
-    fun executeScriptOf(scriptClass: Class<*>, target: KotlinScriptTarget<*>) {
+    fun executeScriptOf(scriptClass: Class<*>) {
         try {
-            instantiate(scriptClass, target.type, target.`object`)
+            instantiate(scriptClass, scriptTarget.type, scriptTarget.`object`)
         } catch (e: InvocationTargetException) {
             throw e.targetException
         }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
@@ -90,8 +90,5 @@ data class KotlinScriptTarget<T : Any>(
     val accessorsClassPath: (ClassPath) -> AccessorsClassPath? = { null },
     val prepare: () -> Unit = {}) {
 
-    val supportsBuildscriptBlock = buildscriptBlockTemplate != null
-    val supportsPluginsBlock = pluginsBlockTemplate != null
-
     fun accessorsClassPathFor(classPath: ClassPath) = accessorsClassPath(classPath)
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
@@ -54,21 +54,21 @@ private
 fun settingsScriptTarget(settings: Settings) =
     KotlinScriptTarget(
         settings,
-        rootDir = settings.rootDir,
         type = Settings::class,
         scriptTemplate = KotlinSettingsScript::class,
-        buildscriptBlockTemplate = KotlinSettingsBuildscriptBlock::class)
+        buildscriptBlockTemplate = KotlinSettingsBuildscriptBlock::class,
+        rootDir = settings.rootDir)
 
 
 private
 fun projectScriptTarget(project: Project): KotlinScriptTarget<Project> =
     KotlinScriptTarget(
         project,
-        rootDir = project.rootDir,
         type = Project::class,
         scriptTemplate = KotlinBuildScript::class,
         buildscriptBlockTemplate = KotlinBuildscriptBlock::class,
         pluginsBlockTemplate = KotlinPluginsBlock::class,
+        rootDir = project.rootDir,
         accessorsClassPath = { accessorsClassPathFor(project, it) },
         prepare = {
             project.run {
@@ -82,11 +82,11 @@ fun projectScriptTarget(project: Project): KotlinScriptTarget<Project> =
 internal
 data class KotlinScriptTarget<T : Any>(
     val `object`: T,
-    val rootDir: File,
     val type: KClass<T>,
     val scriptTemplate: KClass<*>,
     val buildscriptBlockTemplate: KClass<*>? = null,
     val pluginsBlockTemplate: KClass<*>? = null,
+    val rootDir: File,
     val accessorsClassPath: (ClassPath) -> AccessorsClassPath? = { null },
     val prepare: () -> Unit = {}) {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
@@ -23,6 +23,10 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.kotlin.dsl.KotlinBuildScript
 import org.gradle.kotlin.dsl.KotlinSettingsScript
 
+import org.gradle.kotlin.dsl.support.KotlinBuildscriptBlock
+import org.gradle.kotlin.dsl.support.KotlinPluginsBlock
+import org.gradle.kotlin.dsl.support.KotlinSettingsBuildscriptBlock
+
 import org.gradle.kotlin.dsl.accessors.AccessorsClassPath
 import org.gradle.kotlin.dsl.accessors.accessorsClassPathFor
 
@@ -33,7 +37,7 @@ import kotlin.reflect.KClass
 
 
 internal
-fun kotlinScriptTargetFor(target: Any): KotlinScriptTarget<*> =
+fun kotlinScriptTargetFor(target: Any): KotlinScriptTarget<out Any> =
     when (target) {
         is Project  -> projectScriptTarget(target)
         is Settings -> settingsScriptTarget(target)
@@ -50,20 +54,21 @@ private
 fun settingsScriptTarget(settings: Settings) =
     KotlinScriptTarget(
         settings,
+        rootDir = settings.rootDir,
         type = Settings::class,
         scriptTemplate = KotlinSettingsScript::class,
-        rootDir = settings.rootDir)
+        buildscriptBlockTemplate = KotlinSettingsBuildscriptBlock::class)
 
 
 private
-fun projectScriptTarget(project: Project) =
+fun projectScriptTarget(project: Project): KotlinScriptTarget<Project> =
     KotlinScriptTarget(
         project,
+        rootDir = project.rootDir,
         type = Project::class,
         scriptTemplate = KotlinBuildScript::class,
-        rootDir = project.rootDir,
-        supportsBuildscriptBlock = true,
-        supportsPluginsBlock = true,
+        buildscriptBlockTemplate = KotlinBuildscriptBlock::class,
+        pluginsBlockTemplate = KotlinPluginsBlock::class,
         accessorsClassPath = { accessorsClassPathFor(project, it) },
         prepare = {
             project.run {
@@ -77,13 +82,16 @@ fun projectScriptTarget(project: Project) =
 internal
 data class KotlinScriptTarget<T : Any>(
     val `object`: T,
+    val rootDir: File,
     val type: KClass<T>,
     val scriptTemplate: KClass<*>,
-    val rootDir: File,
-    val supportsBuildscriptBlock: Boolean = false,
-    val supportsPluginsBlock: Boolean = false,
+    val buildscriptBlockTemplate: KClass<*>? = null,
+    val pluginsBlockTemplate: KClass<*>? = null,
     val accessorsClassPath: (ClassPath) -> AccessorsClassPath? = { null },
     val prepare: () -> Unit = {}) {
+
+    val supportsBuildscriptBlock = buildscriptBlockTemplate != null
+    val supportsPluginsBlock = pluginsBlockTemplate != null
 
     fun accessorsClassPathFor(classPath: ClassPath) = accessorsClassPath(classPath)
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
@@ -17,13 +17,15 @@
 package org.gradle.kotlin.dsl.support
 
 import org.gradle.kotlin.dsl.KotlinBuildScript
+import org.gradle.kotlin.dsl.KotlinSettingsScript
 import org.gradle.kotlin.dsl.ScriptHandlerScope
 
 import org.gradle.api.Project
+import org.gradle.api.initialization.Settings
 
 
 /**
- * Base class for `buildscript` block evaluation.
+ * Base class for `buildscript` block evaluation on scripts targeting Project.
  */
 abstract class KotlinBuildscriptBlock(project: Project) : KotlinBuildScript(project) {
 
@@ -34,5 +36,21 @@ abstract class KotlinBuildscriptBlock(project: Project) : KotlinBuildScript(proj
      */
     override fun buildscript(block: ScriptHandlerScope.() -> Unit) {
         ScriptHandlerScope(project.buildscript).block()
+    }
+}
+
+
+/**
+ * Base class for `buildscript` block evaluation on scripts targeting Settings.
+ */
+abstract class KotlinSettingsBuildscriptBlock(settings: Settings) : KotlinSettingsScript(settings) {
+
+    /**
+     * Configures the build script classpath for settings.
+     *
+     * @see [Settings.buildscript]
+     */
+    override fun buildscript(block: ScriptHandlerScope.() -> Unit) {
+        ScriptHandlerScope(settings.buildscript).block()
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
@@ -220,7 +220,7 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
         val settings = withSettings("""
             buildscript {
                 repositories {
-                    maven { setUrl(File("dependencies").toURI()) }
+                    maven { setUrl(File(rootDir, "dependencies").toURI()) }
                 }
                 dependencies {
                     classpath("settings:settings-dep:1.0")


### PR DESCRIPTION
By moving kotlin script target decision up to the script plugin factory
in order to distinguish Project & Settings sub-block templates
(buildscript {} & plugins {}).

The script template now contributes to the compiled script cache key.

See #542 