### PR TITLE
Kotlin scripts implement org.gradle.api.Script

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.Project
+import org.gradle.api.Script
 
 import org.gradle.plugin.use.PluginDependenciesSpec
 
@@ -34,7 +35,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
     scriptFilePattern = ".*\\.gradle\\.kts")
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 @GradleDsl
-abstract class KotlinBuildScript(project: Project) : Project by project {
+abstract class KotlinBuildScript(project: Project) : Project by project, Script {
 
     /**
      * Configures the build script classpath for this project.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -15,9 +15,46 @@
  */
 package org.gradle.kotlin.dsl
 
+import org.gradle.api.Script
 import org.gradle.api.initialization.Settings
-import org.gradle.api.plugins.ObjectConfigurationAction
+
 import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+import org.gradle.api.PathValidation
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.FileTree
+import org.gradle.api.initialization.dsl.ScriptHandler
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.ProcessOperations
+import org.gradle.api.internal.SettingsInternal
+import org.gradle.api.internal.file.DefaultFileOperations
+import org.gradle.api.internal.file.FileLookup
+import org.gradle.api.internal.file.FileOperations
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.logging.LoggingManager
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.plugins.ObjectConfigurationAction
+import org.gradle.api.provider.PropertyState
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.resources.ResourceHandler
+import org.gradle.api.tasks.WorkResult
+import org.gradle.internal.hash.FileHasher
+import org.gradle.internal.hash.StreamHasher
+import org.gradle.internal.reflect.Instantiator
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import org.gradle.process.JavaExecSpec
+
+import java.io.File
+import java.net.URI
+import java.util.concurrent.Callable
 
 import kotlin.script.extensions.SamWithReceiverAnnotations
 import kotlin.script.templates.ScriptTemplateDefinition
@@ -30,9 +67,89 @@ import kotlin.script.templates.ScriptTemplateDefinition
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = "settings\\.gradle\\.kts")
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
-abstract class KotlinSettingsScript(settings: Settings) : Settings by settings {
+abstract class KotlinSettingsScript(settings: Settings) : Settings by settings, Script by scriptApiFor(settings) {
 
     inline
     fun apply(crossinline configuration: ObjectConfigurationAction.() -> Unit) =
         settings.apply({ it.configuration() })
+
+    // ---- Resolve multiple inheritance via delegation conflicts
+
+    override fun getBuildscript(): ScriptHandler = settings.buildscript
+    override fun apply(closure: Closure<*>) = settings.apply(closure)
+    override fun apply(options: MutableMap<String, *>) = settings.apply(options)
+}
+
+
+// TODO:pm prefer canonical extension added in the model-builder PR
+private inline
+fun <reified T : Any> Settings.serviceOf(): T =
+    (gradle as GradleInternal).services[T::class.java]!!
+
+
+private
+fun scriptApiFor(settings: Settings): Script {
+    val fileLookup = settings.serviceOf<FileLookup>()
+    val fileOps = DefaultFileOperations(
+        fileLookup.getFileResolver(settings.rootDir),
+        null,
+        null,
+        settings.serviceOf<Instantiator>(),
+        fileLookup,
+        settings.serviceOf<DirectoryFileTreeFactory>(),
+        settings.serviceOf<StreamHasher>(),
+        settings.serviceOf<FileHasher>())
+    return GradleSettingsScriptApi(settings as SettingsInternal, fileOps, fileOps)
+}
+
+
+/**
+ * [Script] implementation for [Settings].
+ */
+private
+class GradleSettingsScriptApi(
+    private val settings: Settings,
+    private val fileOperations: FileOperations,
+    private val processOperations: ProcessOperations,
+    private val logger: Logger = Logging.getLogger(Settings::class.java),
+    private val logging: LoggingManager = settings.serviceOf<LoggingManager>(),
+    private val objectFactory: ObjectFactory = settings.serviceOf<ObjectFactory>(),
+    private val providerFactory: ProviderFactory = settings.serviceOf<ProviderFactory>()) : Script {
+
+    override fun buildscript(configureClosure: Closure<*>) {
+        configureClosure.call(settings.buildscript)
+    }
+
+    override fun getBuildscript(): ScriptHandler = settings.buildscript
+    override fun apply(closure: Closure<*>) = settings.apply { closure.call(it) }
+    override fun apply(options: MutableMap<String, *>) = settings.apply(options)
+
+    override fun getLogger(): Logger = logger
+    override fun getLogging(): LoggingManager = logging
+
+    override fun <T : Any?> property(clazz: Class<T>): PropertyState<T> = objectFactory.property(clazz) as PropertyState
+    override fun <T : Any?> provider(value: Callable<T>): Provider<T> = providerFactory.provider(value)
+
+    override fun file(path: Any): File = fileOperations.file(path)
+    override fun file(path: Any, validation: PathValidation): File = fileOperations.file(path, validation)
+    override fun files(vararg paths: Any?): ConfigurableFileCollection = fileOperations.files(paths)
+    override fun files(paths: Any, configureClosure: Closure<*>): ConfigurableFileCollection = fileOperations.files(paths, configureClosure)
+    override fun relativePath(path: Any): String = fileOperations.relativePath(path)
+    override fun uri(path: Any): URI = fileOperations.uri(path)
+    override fun fileTree(baseDir: Any): ConfigurableFileTree = fileOperations.fileTree(baseDir)
+    override fun fileTree(args: MutableMap<String, *>): ConfigurableFileTree = fileOperations.fileTree(args)
+    override fun fileTree(baseDir: Any, configureClosure: Closure<*>): ConfigurableFileTree = fileOperations.fileTree(baseDir).also { configureClosure.call(it) }
+    override fun zipTree(zipPath: Any): FileTree = fileOperations.zipTree(zipPath)
+    override fun tarTree(tarPath: Any): FileTree = fileOperations.tarTree(tarPath)
+    override fun mkdir(path: Any): File = fileOperations.mkdir(path)
+    override fun delete(vararg paths: Any?): Boolean = fileOperations.delete(*paths)
+    override fun copy(closure: Closure<*>): WorkResult = fileOperations.copy { closure.call(it) }
+    override fun copySpec(closure: Closure<*>): CopySpec = fileOperations.copySpec().also { closure.call(it) }
+    override fun getResources(): ResourceHandler = fileOperations.resources
+
+
+    override fun exec(closure: Closure<*>): ExecResult = processOperations.exec { closure.call(it) }
+    override fun exec(action: Action<in ExecSpec>): ExecResult = processOperations.exec(action)
+    override fun javaexec(closure: Closure<*>): ExecResult = processOperations.javaexec { closure.call(it) }
+    override fun javaexec(action: Action<in JavaExecSpec>): ExecResult = processOperations.javaexec(action)
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -453,6 +453,24 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
             containsString("Settings plugin applied!"))
     }
 
+    @Test
+    fun `settings script can use the gradle script api`() {
+        withSettings("""
+
+            logger.error("Error logging")
+
+            require(file("settings.gradle.kts").isFile, { "file(path)" })
+            require(uri("settings.gradle.kts").toString().endsWith("settings.gradle.kts"), { "uri(path)" })
+            require(fileTree(".").contains(file("settings.gradle.kts")), { "fileTree(path)" })
+            require(resources != null, { "resources" })
+
+        """)
+
+        assertThat(
+            build("help").output,
+            containsString("Error logging"))
+    }
+
     private
     fun assumeJavaLessThan9() {
         assumeTrue("Test disabled under JDK 9 and higher", JavaVersion.current() < JavaVersion.VERSION_1_9)

--- a/samples/gradle-plugin/consumer/settings.gradle.kts
+++ b/samples/gradle-plugin/consumer/settings.gradle.kts
@@ -1,5 +1,5 @@
 pluginManagement {
     repositories {
-        maven { setUrl("../plugin/build/repository") }
+        maven { url = uri("../plugin/build/repository") }
     }
 }

--- a/samples/hello-android/settings.gradle.kts
+++ b/samples/hello-android/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { setUrl("https://jcenter.bintray.com/") }
+        maven { url = uri("https://jcenter.bintray.com/") }
     }
     resolutionStrategy {
         eachPlugin {

--- a/samples/hello-js/settings.gradle.kts
+++ b/samples/hello-js/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
         // Use the Gradle Plugin Portal as a regular maven repository
         // allowing the plugin resolution strategy below to route the
         // plugin request to artifact coordinates.
-        maven { setUrl("https://plugins.gradle.org/m2") }
+        maven { url = uri("https://plugins.gradle.org/m2") }
     }
     resolutionStrategy {
         eachPlugin {

--- a/samples/kotlin-friendly-groovy-plugin/consumer/settings.gradle.kts
+++ b/samples/kotlin-friendly-groovy-plugin/consumer/settings.gradle.kts
@@ -1,5 +1,5 @@
 pluginManagement {
     repositories {
-        maven { setUrl("../plugin/build/repository") }
+        maven { url = uri("../plugin/build/repository") }
     }
 }


### PR DESCRIPTION
This PR makes `KotlinBuildScript` and `KotlinSettingsScript` script templates implement `org.gradle.api.Script`.

For `KotlinBuildScript` this is a very simple change as `Project` already has all the methods of `org.gradle.api.Script`.

For `KotlinSettingsScript` implementation is provided via delegation. Moreover, a few methods conflict due to multiple inheritance via delegation, they needs to be explicitly routed.

This work is part of #543 