### PR TITLE
All Kotlin scripts implement org.gradle.kotlin.dsl.provider.ScriptApi

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -16,11 +16,39 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.initialization.Settings
-import org.gradle.api.plugins.ObjectConfigurationAction
+
 import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver
 
 import kotlin.script.extensions.SamWithReceiverAnnotations
 import kotlin.script.templates.ScriptTemplateDefinition
+
+import org.gradle.api.PathValidation
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DeleteSpec
+import org.gradle.api.file.FileTree
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.logging.LoggingManager
+import org.gradle.api.plugins.ObjectConfigurationAction
+import org.gradle.api.resources.ResourceHandler
+import org.gradle.api.tasks.WorkResult
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import org.gradle.process.JavaExecSpec
+
+import org.gradle.kotlin.dsl.support.serviceOf
+
+import org.gradle.api.internal.file.DefaultFileOperations
+import org.gradle.api.internal.file.FileLookup
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.internal.hash.FileHasher
+import org.gradle.internal.hash.StreamHasher
+import org.gradle.internal.reflect.Instantiator
+
+import java.io.File
+import java.net.URI
 
 
 /**
@@ -31,6 +59,310 @@ import kotlin.script.templates.ScriptTemplateDefinition
     scriptFilePattern = "settings\\.gradle\\.kts")
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 abstract class KotlinSettingsScript(settings: Settings) : Settings by settings {
+
+    private
+    val fileOperations = fileOperationsFor(settings)
+
+    /**
+     * Logger for settings. You can use this in your settings file to write log messages.
+     */
+    @Suppress("unused")
+    val logger: Logger = Logging.getLogger(Settings::class.java)
+
+    /**
+     * The [LoggingManager] which can be used to receive logging and to control the standard output/error capture for
+     * this script. By default, `System.out` is redirected to the Gradle logging system at the `QUIET` log level,
+     * and `System.err` is redirected at the `ERROR` log level.
+     */
+    @Suppress("unused")
+    val logging: LoggingManager = settings.serviceOf()
+
+    /**
+     * Provides access to resource-specific utility methods, for example factory methods that create various resources.
+     */
+    @Suppress("unused")
+    val resources: ResourceHandler = fileOperations.resources
+
+    /**
+     * Returns the relative path from this script's target base directory to the given path.
+     *
+     * The given path object is (logically) resolved as described for [KotlinSettingsScript.file],
+     * from which a relative path is calculated.
+     *
+     * @param path The path to convert to a relative path.
+     * @return The relative path.
+     */
+    @Suppress("unused")
+    fun relativePath(path: Any): String =
+        fileOperations.relativePath(path)
+
+    /**
+     * Resolves a file path to a URI, relative to this script's target base directory.
+     *
+     * Evaluates the provided path object as described for [KotlinSettingsScript.file],
+     * with the exception that any URI scheme is supported, not just `file:` URIs.
+     */
+    @Suppress("unused")
+    fun uri(path: Any): URI =
+        fileOperations.uri(path)
+
+    /**
+     * Resolves a file path relative to this script's target base directory.
+     *
+     * If this script targets [org.gradle.api.Project],
+     * then `path` is resolved relative to the project directory.
+     *
+     * If this script targets [org.gradle.api.initialization.Settings],
+     * then `path` is resolved relative to the build root directory.
+     *
+     * This method converts the supplied path based on its type:
+     *
+     * - A [CharSequence], including [String].
+     *   A string that starts with `file:` is treated as a file URL.
+     * - A [File].
+     *   If the file is an absolute file, it is returned as is. Otherwise it is resolved.
+     * - A [java.nio.file.Path].
+     *   The path must be associated with the default provider and is treated the same way as an instance of `File`.
+     * - A [URI] or [java.net.URL].
+     *   The URL's path is interpreted as the file path. Only `file:` URLs are supported.
+     * - A [org.gradle.api.file.Directory] or [org.gradle.api.file.RegularFile].
+     * - A [org.gradle.api.provider.Provider] of any supported type.
+     *   The provider's value is resolved recursively.
+     * - A [java.util.concurrent.Callable] that returns any supported type.
+     *   The callable's return value is resolved recursively.
+     *
+     * @param path The object to resolve as a `File`.
+     * @return The resolved file.
+     */
+    @Suppress("unused")
+    fun file(path: Any): File =
+        fileOperations.file(path)
+
+    /**
+     * Resolves a file path relative to this script's target base directory.
+     *
+     * @param path The object to resolve as a `File`.
+     * @param validation The validation to perform on the file.
+     * @return The resolved file.
+     * @see KotlinSettingsScript.file
+     */
+    @Suppress("unused")
+    fun file(path: Any, validation: PathValidation): File =
+        fileOperations.file(path, validation)
+
+    /**
+     * Creates a [ConfigurableFileCollection] containing the given files.
+     *
+     * You can pass any of the following types to this method:
+     *
+     * - A [CharSequence], including [String] as defined by [KotlinSettingsScript.file].
+     * - A [File] as defined by [KotlinSettingsScript.file].
+     * - A [java.nio.file.Path] as defined by [KotlinSettingsScript.file].
+     * - A [URI] or [java.net.URL] as defined by [KotlinSettingsScript.file].
+     * - A [org.gradle.api.file.Directory] or [org.gradle.api.file.RegularFile]
+     *   as defined by [KotlinSettingsScript.file].
+     * - A [Sequence], [Array] or [Iterable] that contains objects of any supported type.
+     *   The elements of the collection are recursively converted to files.
+     * - A [org.gradle.api.file.FileCollection].
+     *   The contents of the collection are included in the returned collection.
+     * - A [org.gradle.api.provider.Provider] of any supported type.
+     *   The provider's value is recursively converted to files. If the provider represents an output of a task,
+     *   that task is executed if the file collection is used as an input to another task.
+     * - A [java.util.concurrent.Callable] that returns any supported type.
+     *   The callable's return value is recursively converted to files.
+     *   A `null` return value is treated as an empty collection.
+     * - A [org.gradle.api.Task].
+     *   Converted to the task's output files.
+     *   The task is executed if the file collection is used as an input to another task.
+     * - A [org.gradle.api.tasks.TaskOutputs].
+     *   Converted to the output files the related task.
+     *   The task is executed if the file collection is used as an input to another task.
+     * - Anything else is treated as a failure.
+     *
+     * The returned file collection is lazy, so that the paths are evaluated only when the contents of the file
+     * collection are queried. The file collection is also live, so that it evaluates the above each time the contents
+     * of the collection is queried.
+     *
+     * The returned file collection maintains the iteration order of the supplied paths.
+     *
+     * The returned file collection maintains the details of the tasks that produce the files,
+     * so that these tasks are executed if this file collection is used as an input to some task.
+     *
+     * This method can also be used to create an empty collection, which can later be mutated to add elements.
+     *
+     * @param paths The paths to the files. May be empty.
+     * @return The file collection.
+     */
+    @Suppress("unused")
+    fun files(vararg paths: Any): ConfigurableFileCollection =
+        fileOperations.files(paths)
+
+    /**
+     * Creates a [ConfigurableFileCollection] containing the given files.
+     *
+     * @param paths The contents of the file collection. Evaluated as per [KotlinSettingsScript.files].
+     * @param configuration The block to use to configure the file collection.
+     * @return The file collection.
+     * @see KotlinSettingsScript.files
+     */
+    @Suppress("unused")
+    fun files(paths: Any, configuration: ConfigurableFileCollection.() -> Unit): ConfigurableFileCollection =
+        fileOperations.files(paths).also(configuration)
+
+    /**
+     * Creates a new [ConfigurableFileTree] using the given base directory.
+     *
+     * The given `baseDir` path is evaluated as per [KotlinSettingsScript.file].
+     *
+     * The returned file tree is lazy, so that it scans for files only when the contents of the file tree are
+     * queried. The file tree is also live, so that it scans for files each time the contents of the file tree are
+     * queried.
+     *
+     * @param baseDir The base directory of the file tree. Evaluated as per [KotlinSettingsScript.file].
+     * @return The file tree.
+     */
+    @Suppress("unused")
+    fun fileTree(baseDir: Any): ConfigurableFileTree =
+        fileOperations.fileTree(baseDir)
+
+    /**
+     * Creates a new [ConfigurableFileTree] using the given base directory.
+     *
+     * @param baseDir The base directory of the file tree. Evaluated as per [KotlinSettingsScript.file].
+     * @param configuration The block to use to configure the file tree.
+     * @return The file tree.
+     * @see [KotlinSettingsScript.fileTree]
+     */
+    @Suppress("unused")
+    fun fileTree(baseDir: Any, configuration: ConfigurableFileTree.() -> Unit): ConfigurableFileTree =
+        fileOperations.fileTree(baseDir).also(configuration)
+
+    /**
+     * Creates a new [FileTree] which contains the contents of the given ZIP file.
+     *
+     * The given `zipPath` path is evaluated as per [KotlinSettingsScript.file]
+     *
+     * The returned file tree is lazy, so that it scans for files only when the contents of the file tree are
+     * queried. The file tree is also live, so that it scans for files each time the contents of the file tree are
+     * queried.
+     *
+     * You can combine this method with the [KotlinSettingsScript.copy] method to unzip a ZIP file.
+     *
+     * @param zipPath The ZIP file. Evaluated as per [KotlinSettingsScript.file].
+     * @return The file tree.
+     */
+    @Suppress("unused")
+    fun zipTree(zipPath: Any): FileTree =
+        fileOperations.zipTree(zipPath)
+
+    /**
+     * Creates a new [FileTree] which contains the contents of the given TAR file.
+     *
+     * The given tarPath path can be:
+     * - an instance of [org.gradle.api.resources.Resource],
+     * - any other object is evaluated as per [KotlinSettingsScript.file].
+     *
+     * The returned file tree is lazy, so that it scans for files only when the contents of the file tree are
+     * queried. The file tree is also live, so that it scans for files each time the contents of the file tree are
+     * queried.
+     *
+     * Unless custom implementation of resources is passed,
+     * the tar tree attempts to guess the compression based on the file extension.
+     *
+     * You can combine this method with the [KotlinSettingsScript.copy] method to unzip a ZIP file.
+     *
+     * @param tarPath The TAR file or an instance of [org.gradle.api.resources.Resource].
+     * @return The file tree.
+     */
+    @Suppress("unused")
+    fun tarTree(tarPath: Any): FileTree =
+        fileOperations.tarTree(tarPath)
+
+    /**
+     * Copies the specified files.
+     *
+     * @param configuration The block to use to configure the [CopySpec].
+     * @return `WorkResult` that can be used to check if the copy did any work.
+     */
+    @Suppress("unused")
+    fun copy(configuration: CopySpec.() -> Unit): WorkResult =
+        fileOperations.copy(configuration)
+
+    /**
+     * Creates a {@link CopySpec} which can later be used to copy files or create an archive.
+     *
+     * @return The created [CopySpec]
+     */
+    @Suppress("unused")
+    fun copySpec(): CopySpec =
+        fileOperations.copySpec()
+
+    /**
+     * Creates a {@link CopySpec} which can later be used to copy files or create an archive.
+     *
+     * @param configuration The block to use to configure the [CopySpec].
+     * @return The configured [CopySpec]
+     */
+    @Suppress("unused")
+    fun copySpec(configuration: CopySpec.() -> Unit): CopySpec =
+        fileOperations.copySpec().also(configuration)
+
+    /**
+     * Creates a directory and returns a file pointing to it.
+     *
+     * @param path The path for the directory to be created. Evaluated as per [KotlinSettingsScript.file].
+     * @return The created directory.
+     * @throws org.gradle.api.InvalidUserDataException If the path points to an existing file.
+     */
+    @Suppress("unused")
+    fun mkdir(path: Any): File =
+        fileOperations.mkdir(path)
+
+    /**
+     * Deletes files and directories.
+     *
+     * This will not follow symlinks. If you need to follow symlinks too use [KotlinSettingsScript.delete].
+     *
+     * @param paths Any type of object accepted by [KotlinSettingsScript.file]
+     * @return true if anything got deleted, false otherwise
+     */
+    @Suppress("unused")
+    fun delete(vararg paths: Any): Boolean =
+        fileOperations.delete(*paths)
+
+    /**
+     * Deletes the specified files.
+     *
+     * @param configuration The block to use to configure the [DeleteSpec].
+     * @return `WorkResult` that can be used to check if delete did any work.
+     */
+    @Suppress("unused")
+    fun delete(configuration: DeleteSpec.() -> Unit): WorkResult =
+        fileOperations.delete(configuration)
+
+    /**
+     * Executes an external command.
+     *
+     * This method blocks until the process terminates, with its result being returned.
+     *
+     * @param configuration The block to use to configure the [ExecSpec].
+     * @return The result of the execution.
+     */
+    @Suppress("unused")
+    fun exec(configuration: ExecSpec.() -> Unit): ExecResult =
+        fileOperations.exec(configuration)
+
+    /**
+     * Executes an external Java process.
+     *
+     * This method blocks until the process terminates, with its result being returned.
+     *
+     * @param configuration The block to use to configure the [JavaExecSpec].
+     * @return The result of the execution.
+     */
+    @Suppress("unused")
+    fun javaexec(configuration: JavaExecSpec.() -> Unit): ExecResult =
+        fileOperations.javaexec(configuration)
 
     /**
      * Configures the build script classpath for settings.
@@ -48,4 +380,19 @@ abstract class KotlinSettingsScript(settings: Settings) : Settings by settings {
     inline
     fun apply(crossinline configuration: ObjectConfigurationAction.() -> Unit) =
         settings.apply({ it.configuration() })
+}
+
+
+private
+fun fileOperationsFor(settings: Settings): DefaultFileOperations {
+    val fileLookup = settings.serviceOf<FileLookup>()
+    return DefaultFileOperations(
+        fileLookup.getFileResolver(settings.rootDir),
+        null,
+        null,
+        settings.serviceOf<Instantiator>(),
+        fileLookup,
+        settings.serviceOf<DirectoryFileTreeFactory>(),
+        settings.serviceOf<StreamHasher>(),
+        settings.serviceOf<FileHasher>())
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ScriptApi.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ScriptApi.kt
@@ -45,6 +45,7 @@ import java.net.URI
  * Members here must not use default parameters values.
  * Documentation should go to the actual implementations so that it shows up in IDEs properly.
  */
+@Suppress("unused")
 internal
 interface ScriptApi {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ScriptApi.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ScriptApi.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.kotlin.dsl.provider
+
+import org.gradle.api.PathValidation
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DeleteSpec
+import org.gradle.api.file.FileTree
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.LoggingManager
+import org.gradle.api.resources.ResourceHandler
+import org.gradle.api.tasks.WorkResult
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import org.gradle.process.JavaExecSpec
+
+import java.io.File
+import java.net.URI
+
+/**
+ * Base contract for all Gradle Kotlin DSL scripts.
+ *
+ * This is the Kotlin flavored equivalent of [org.gradle.api.Script].
+ *
+ * It is not implemented directly by script templates to overcome ambiguous conflicts and Kotlin language
+ * limitations. See each script template for actual implementations.
+ *
+ * `ScriptApiTest` validates that each script template provide compatible methods/properties.
+ *
+ * Members here must not use default parameters values.
+ * Documentation should go to the actual implementations so that it shows up in IDEs properly.
+ */
+internal
+interface ScriptApi {
+
+    val logger: Logger
+    val logging: LoggingManager
+    val resources: ResourceHandler
+
+    fun relativePath(path: Any): String
+    fun uri(path: Any): URI
+
+    fun file(path: Any): File
+    fun file(path: Any, validation: PathValidation): File
+    fun files(vararg paths: Any): ConfigurableFileCollection
+    fun files(paths: Any, configuration: ConfigurableFileCollection.() -> Unit): ConfigurableFileCollection
+
+    fun fileTree(baseDir: Any): ConfigurableFileTree
+    fun fileTree(baseDir: Any, configuration: ConfigurableFileTree.() -> Unit): ConfigurableFileTree
+    fun zipTree(zipPath: Any): FileTree
+    fun tarTree(tarPath: Any): FileTree
+
+    fun copy(configuration: CopySpec.() -> Unit): WorkResult
+    fun copySpec(): CopySpec
+    fun copySpec(configuration: CopySpec.() -> Unit): CopySpec
+
+    fun mkdir(path: Any): File
+
+    fun delete(vararg paths: Any): Boolean
+    fun delete(configuration: DeleteSpec.() -> Unit): WorkResult
+
+    fun exec(configuration: ExecSpec.() -> Unit): ExecResult
+    fun javaexec(configuration: JavaExecSpec.() -> Unit): ExecResult
+}

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -511,7 +511,7 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
             require(logging is LoggingManager, { "logging" })
             require(resources is ResourceHandler, { "resources" })
 
-            require(relativePath("settings.gradle.kts") == "settings.gradle.kts", { "relativePath(path)" })
+            require(relativePath(File("settings.gradle.kts").absolutePath) == "settings.gradle.kts", { "relativePath(path)" })
             require(uri("settings.gradle.kts").toString().endsWith("settings.gradle.kts"), { "uri(path)" })
             require(file("settings.gradle.kts").isFile, { "file(path)" })
             require(files("settings.gradle.kts").files.isNotEmpty(), { "files(paths)" })

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -502,6 +502,37 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
             containsString("Settings plugin applied!"))
     }
 
+    @Test
+    fun `scripts can use the gradle script api`() {
+
+        fun usageFor(target: String) = """
+
+            logger.error("Error logging from $target")
+            require(logging is LoggingManager, { "logging" })
+            require(resources is ResourceHandler, { "resources" })
+
+            require(relativePath("settings.gradle.kts") == "settings.gradle.kts", { "relativePath(path)" })
+            require(uri("settings.gradle.kts").toString().endsWith("settings.gradle.kts"), { "uri(path)" })
+            require(file("settings.gradle.kts").isFile, { "file(path)" })
+            require(files("settings.gradle.kts").files.isNotEmpty(), { "files(paths)" })
+            require(fileTree(".").contains(file("settings.gradle.kts")), { "fileTree(path)" })
+            require(copySpec {} != null, { "copySpec {}" })
+            require(mkdir("some").isDirectory, { "mkdir(path)" })
+            require(delete("some"), { "delete(path)" })
+            require(delete {} != null, { "delete {}" })
+
+        """
+
+        withSettings(usageFor("Settings"))
+        withBuildScript(usageFor("Project"))
+
+        assertThat(
+            build("help").output,
+            allOf(
+                containsString("Error logging from Settings"),
+                containsString("Error logging from Project")))
+    }
+
     private
     fun assumeJavaLessThan9() {
         assumeTrue("Test disabled under JDK 9 and higher", JavaVersion.current() < JavaVersion.VERSION_1_9)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -511,7 +511,7 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
             require(logging is LoggingManager, { "logging" })
             require(resources is ResourceHandler, { "resources" })
 
-            require(relativePath(File("settings.gradle.kts").absolutePath) == "settings.gradle.kts", { "relativePath(path)" })
+            require(relativePath("src/../settings.gradle.kts") == "settings.gradle.kts", { "relativePath(path)" })
             require(uri("settings.gradle.kts").toString().endsWith("settings.gradle.kts"), { "uri(path)" })
             require(file("settings.gradle.kts").isFile, { "file(path)" })
             require(files("settings.gradle.kts").files.isNotEmpty(), { "files(paths)" })

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
@@ -1,0 +1,165 @@
+package org.gradle.kotlin.dsl.provider
+
+import org.gradle.kotlin.dsl.KotlinBuildScript
+import org.gradle.kotlin.dsl.KotlinSettingsScript
+
+import org.gradle.api.Action
+
+import kotlin.reflect.KCallable
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.declaredMembers
+import kotlin.reflect.full.valueParameters
+import kotlin.reflect.full.withNullability
+import kotlin.reflect.jvm.javaGetter
+import kotlin.reflect.jvm.jvmErasure
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+
+class ScriptApiTest {
+
+    @Test
+    fun `build script template implements script api`() =
+        assertThat(
+            ScriptApi::class.apiMembers.missingMembersFrom(KotlinBuildScript::class),
+            equalTo(emptyList()))
+
+    @Test
+    fun `settings script template implements script api`() =
+        assertThat(
+            ScriptApi::class.apiMembers.missingMembersFrom(KotlinSettingsScript::class),
+            equalTo(emptyList()))
+}
+
+
+private
+typealias ScriptApiMembers = Collection<KCallable<*>>
+
+
+private
+val KClass<*>.apiMembers: ScriptApiMembers
+    get() = declaredMembers
+
+
+private
+fun ScriptApiMembers.missingMembersFrom(scriptTemplate: KClass<*>): List<KCallable<*>> =
+    candidateMembersOf(scriptTemplate).let { scriptTemplateMembers ->
+        filter { apiMember ->
+            !scriptTemplateMembers.containsMemberCompatibleWith(apiMember)
+        }
+    }
+
+
+private
+fun candidateMembersOf(scriptTemplate: KClass<*>) =
+    scriptTemplate.members.filter { it.visibility == KVisibility.PUBLIC }
+
+
+private
+fun List<KCallable<*>>.containsMemberCompatibleWith(api: KCallable<*>) =
+    find { it.isCompatibleWith(api) } != null
+
+
+private
+fun KCallable<*>.isCompatibleWith(api: KCallable<*>) =
+    when (this) {
+        is KFunction -> isCompatibleWith(api)
+        is KProperty -> isCompatibleWith(api)
+        else         -> false
+    }
+
+
+private
+fun KProperty<*>.isCompatibleWith(api: KCallable<*>) =
+    this::class == api::class && name == api.name && returnType == api.returnType
+
+
+private
+fun KFunction<*>.isCompatibleWith(api: KCallable<*>) =
+    when {
+        api is KProperty && api !is KMutableProperty && isCompatibleWithGetterOf(api) -> true
+        api is KFunction && isCompatibleWith(api)                                     -> true
+        else                                                                          -> false
+    }
+
+
+private
+fun KFunction<*>.isCompatibleWithGetterOf(api: KProperty<*>) =
+    name == api.javaGetter?.name
+        && returnType == api.getter.returnType
+        && valueParameters.isEmpty() && api.getter.valueParameters.isEmpty()
+
+
+private
+fun KFunction<*>.isCompatibleWith(api: KFunction<*>) =
+    name == api.name && returnType == api.returnType && valueParameters.isCompatibleWith(api.valueParameters)
+
+
+private
+fun List<KParameter>.isCompatibleWith(api: List<KParameter>) =
+    when {
+        size != api.size -> false
+        isEmpty()        -> true
+        else             -> (0..(size - 1)).all { idx -> this[idx].isCompatibleWith(api[idx]) }
+    }
+
+
+private
+fun KParameter.isCompatibleWith(api: KParameter) =
+    when {
+        isVarargCompatibleWith(api)       -> true
+        isGradleActionCompatibleWith(api) -> true
+        type == api.type                  -> true
+        else                              -> false
+    }
+
+
+private
+fun KParameter.isGradleActionCompatibleWith(api: KParameter) =
+    type.jvmErasure == Action::class
+        && api.isSamWithReceiverReturningUnit()
+        && type.arguments[0].type!!.isTypeArgumentCompatibleWith(api.type.arguments[0].type!!)
+
+
+private
+fun KParameter.isSamWithReceiverReturningUnit() =
+    type.jvmErasure == Function1::class
+        && type.arguments[1] == KTypeProjection(KVariance.INVARIANT, Unit::class.createType())
+
+
+private
+fun KParameter.isVarargCompatibleWith(api: KParameter) =
+    isVararg && api.isVararg && type.isParameterTypeCompatibleWith(api.type)
+
+
+private
+fun KType.isParameterTypeCompatibleWith(apiParameterType: KType) =
+    when {
+        this == apiParameterType                     -> true
+        classifier != apiParameterType.classifier    -> false
+        hasCompatibleTypeArguments(apiParameterType) -> true
+        else                                         -> false
+    }
+
+
+private
+fun KType.hasCompatibleTypeArguments(api: KType) =
+    arguments.size == api.arguments.size && (0..(arguments.size - 1)).all { idx ->
+        arguments[idx].type!!.isTypeArgumentCompatibleWith(api.arguments[idx].type!!)
+    }
+
+
+private
+fun KType.isTypeArgumentCompatibleWith(api: KType) =
+    withNullability(false) == api

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
@@ -55,9 +55,7 @@ val KClass<*>.apiMembers: ScriptApiMembers
 private
 fun ScriptApiMembers.missingMembersFrom(scriptTemplate: KClass<*>): List<KCallable<*>> =
     candidateMembersOf(scriptTemplate).let { scriptTemplateMembers ->
-        filter { apiMember ->
-            !scriptTemplateMembers.containsMemberCompatibleWith(apiMember)
-        }
+        filterNot(scriptTemplateMembers::containsMemberCompatibleWith)
     }
 
 

--- a/samples/build-cache/settings.gradle.kts
+++ b/samples/build-cache/settings.gradle.kts
@@ -3,13 +3,13 @@ buildCache {
         isEnabled = true
     }
     remote(DirectoryBuildCache::class.java) {
-        setDirectory("path/to/some/local-cache")
+        directory = file("path/to/some/local-cache")
         isEnabled = true
         isPush = false
         targetSizeInMB = 1024
     }
     remote(HttpBuildCache::class.java) {
-        setUrl("http://example.com/cache")
+        url = uri("http://example.com/cache")
         isEnabled = false
         isPush = false
         isAllowUntrustedServer = false

--- a/samples/gradle-plugin/consumer/settings.gradle.kts
+++ b/samples/gradle-plugin/consumer/settings.gradle.kts
@@ -1,5 +1,5 @@
 pluginManagement {
     repositories {
-        maven { setUrl("../plugin/build/repository") }
+        maven { url = uri("../plugin/build/repository") }
     }
 }

--- a/samples/hello-android/settings.gradle.kts
+++ b/samples/hello-android/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { setUrl("https://jcenter.bintray.com/") }
+        maven { url = uri("https://jcenter.bintray.com/") }
     }
     resolutionStrategy {
         eachPlugin {

--- a/samples/hello-js/settings.gradle.kts
+++ b/samples/hello-js/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
         // Use the Gradle Plugin Portal as a regular maven repository
         // allowing the plugin resolution strategy below to route the
         // plugin request to artifact coordinates.
-        maven { setUrl("https://plugins.gradle.org/m2") }
+        maven { url = uri("https://plugins.gradle.org/m2") }
     }
     resolutionStrategy {
         eachPlugin {

--- a/samples/kotlin-friendly-groovy-plugin/consumer/settings.gradle.kts
+++ b/samples/kotlin-friendly-groovy-plugin/consumer/settings.gradle.kts
@@ -1,5 +1,5 @@
 pluginManagement {
     repositories {
-        maven { setUrl("../plugin/build/repository") }
+        maven { url = uri("../plugin/build/repository") }
     }
 }


### PR DESCRIPTION
Introduce `org.gradle.kotlin.dsl.provider.ScriptApi` as a Kotlin flavored equivalent of `org.gradle.api.Script` that defines a common API to be supported by all script templates.

It is not implemented directly by script templates to overcome ambiguous conflicts, kotlin/java interop, platform types nullability etc.. A reflection based unit test validates that all script templates contains compatible members.

The validation handles a range of selected use cases supporting the introduced api.

This work is part of #543