### PR TITLE
Leverage upstream changes to settings pluginManagement.repositories

### DIFF
--- a/doc/getting-started/Configuring-Plugins.md
+++ b/doc/getting-started/Configuring-Plugins.md
@@ -71,18 +71,18 @@ artifact.
 This is done in two steps.
 
 First add a plugin repository in your `settings.gradle.kts` file for the whole build: 
-```groovy
+```kotlin
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { url = uri("https://maven.google.com") }
+        google()
     }
 }
 ```
 
 Then, map the plugin `id` to the corresponding artifact coordinates, still in your `settings.gradle.kts` file:
 
-```groovy
+```kotlin
 pluginManagement {
     // ...
     resolutionStrategy {
@@ -112,8 +112,10 @@ android {
 See the [Plugin Management](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_management) section of
 the Gradle documentation for more information.
 
-However, it is not yet possible to use the `plugins {}` block to request
-[plugins from composite builds](https://github.com/gradle/gradle/issues/2528)
+The same can be applied to resolving plugins from composite builds.
+Composite builds [do not expose plugin markers](https://github.com/gradle/gradle/issues/2528) yet.
+This can be worked around by mapping the plugin `id` to the corresponding artifact coordinates using a plugin
+resolution strategy, just like above.
 
 If you can't use the `plugins {}` block, you need to apply the plugin imperatively (using the `buildscript` block and
 `apply { from("") }`) and to know the type of the extension.

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/AbstractPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/AbstractPluginTest.kt
@@ -18,7 +18,7 @@ open class AbstractPluginTest : AbstractIntegrationTest() {
         withSettings("""
             pluginManagement {
                 repositories {
-                    maven { setUrl("$testRepository") }
+                    maven { url = uri("$testRepository") }
                     jcenter()
                 }
                 resolutionStrategy {

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/AbstractPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/AbstractPluginTest.kt
@@ -19,7 +19,7 @@ open class AbstractPluginTest : AbstractIntegrationTest() {
             pluginManagement {
                 repositories {
                     maven { setUrl("$testRepository") }
-                    maven { setUrl("https://jcenter.bintray.com/") }
+                    jcenter()
                 }
                 resolutionStrategy {
                     eachPlugin {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaAccessorsIntegrationTest.kt
@@ -252,7 +252,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractIntegrationTest() {
         withFile("init.gradle", """
             initscript {
                 repositories {
-                    maven { url "https://plugins.gradle.org/m2" }
+                    gradlePluginPortal()
                 }
                 dependencies {
                     classpath "com.gradle:build-scan-plugin:1.8"

--- a/samples/hello-android/settings.gradle.kts
+++ b/samples/hello-android/settings.gradle.kts
@@ -1,8 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { url = uri("https://jcenter.bintray.com/") }
-        maven { url = uri("https://maven.google.com/") }
+        google()
     }
     resolutionStrategy {
         eachPlugin {

--- a/samples/hello-js/settings.gradle.kts
+++ b/samples/hello-js/settings.gradle.kts
@@ -1,10 +1,4 @@
 pluginManagement {
-    repositories {
-        // Use the Gradle Plugin Portal as a regular maven repository
-        // allowing the plugin resolution strategy below to route the
-        // plugin request to artifact coordinates.
-        maven { url = uri("https://plugins.gradle.org/m2") }
-    }
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "kotlin2js") {


### PR DESCRIPTION
- use named repositories where applicable
- remove workarounds to make plugin resolution across composite builds work
- update `Configuring-Plugins.md` doc