### PR TITLE
Support for apply from directly in the buildscript block

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -21,12 +21,14 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.initialization.dsl.ScriptHandler.CLASSPATH_CONFIGURATION
+import org.gradle.api.plugins.PluginAware
 
 
 /**
  * Receiver for the `buildscript` block.
  */
-class ScriptHandlerScope(scriptHandler: ScriptHandler) : ScriptHandler by scriptHandler {
+open class ScriptHandlerScope(scriptHandler: ScriptHandler, pluginAware: PluginAware) :
+    ScriptHandler by scriptHandler, PluginAware by pluginAware {
 
     /**
      * The dependencies of the script.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
@@ -35,7 +35,7 @@ abstract class KotlinBuildscriptBlock(project: Project) : KotlinBuildScript(proj
      * @see [Project.buildscript]
      */
     override fun buildscript(block: ScriptHandlerScope.() -> Unit) {
-        ScriptHandlerScope(project.buildscript).block()
+        ScriptHandlerScope(project.buildscript, project).block()
     }
 }
 
@@ -51,6 +51,6 @@ abstract class KotlinSettingsBuildscriptBlock(settings: Settings) : KotlinSettin
      * @see [Settings.buildscript]
      */
     override fun buildscript(block: ScriptHandlerScope.() -> Unit) {
-        ScriptHandlerScope(settings.buildscript).block()
+        ScriptHandlerScope(settings.buildscript, settings).block()
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
@@ -250,6 +250,31 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
         assertExcludes(classPath, projectDependency)
     }
 
+    @Test
+    fun `can call apply from within buildscript block`() {
+        withFile("classes.jar")
+
+        val appliedFromFileName = "extraInfo.gradle.kts"
+        withFile(appliedFromFileName, """
+            val shouldIncludeClasses by extra { true }
+        """)
+
+        withBuildScript("""
+            buildscript {
+                apply { from("$appliedFromFileName") }
+                val shouldIncludeClasses : Boolean by extra
+                dependencies {
+                    if (shouldIncludeClasses) {
+                        classpath(files("classes.jar"))
+                    }
+                }
+            }
+        """)
+
+        assertClassPathContains(
+            existing("classes.jar"))
+    }
+
     private
     fun assertSourcePathIncludesGradleSourcesGiven(rootProjectScript: String, subProjectScript: String) {
 


### PR DESCRIPTION
Before you had do to this:
```kotlin
buildscript {
    project.apply {
        from("repositoryConfig.gradle.kts")
    }
}
```
Now you can do this:
```kotlin
buildscript {
    apply {
        from("repositoryConfig.gradle.kts")
    }
}
```

This improves the parity with the Groovy DSL

Closes #497

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
