### PR TITLE
Remove link to Wrapper Plugin userguide chapter from plugin accessor kdoc

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -236,9 +236,7 @@ object UserGuideLink {
             "war" to "war_plugin.html",
 
             "windows-resource-script" to "native_software.html#native_binaries:windows-resources",
-            "windows-resources" to "native_software.html#native_binaries:windows-resources",
-
-            "wrapper" to "wrapper_plugin.html")
+            "windows-resources" to "native_software.html#native_binaries:windows-resources")
 }
 
 


### PR DESCRIPTION
Follow up for https://github.com/gradle/gradle/pull/3544
To merge once the upstream PR is
