### PR TITLE
Remove "Limitation" section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ Staying in Touch
 
 Come chat with us in the #gradle channel of the public [Kotlin Slack](http://slack.kotlinlang.org/) instance.
 
-Limitations
------------
 
- * `settings.gradle` cannot yet be written Kotlin, continue to use Groovy there for now.
-   
 License
 -------
 Like the rest of Gradle, the _Gradle Kotlin DSL_ is released under version 2.0 of the [Apache License](LICENSE.md).


### PR DESCRIPTION
### Context
Release 0.13.1 has support for settings.gradle.kts and "Limitation" section now outdated
Fixes #614

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] [Sign Gradle CLA](http://gradle.org/contributor-license-agreement/)
- [x] ~Provide integration tests to verify changes from a user perspective~ N/A
- [x] ~Provide unit tests to verify logic~ N/A
- [x] Ensure that tests pass locally: `./gradlew check --parallel`