### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ Staying in Touch
 
 Come chat with us in the #gradle channel of the public [Kotlin Slack](http://slack.kotlinlang.org/) instance.
 
-Limitations
------------
 
- * `settings.gradle` cannot yet be written Kotlin, continue to use Groovy there for now.
-   
 License
 -------
 Like the rest of Gradle, the _Gradle Kotlin DSL_ is released under version 2.0 of the [Apache License](LICENSE.md).


### PR DESCRIPTION
Remove the limitations since kotlin-dsl version `0.13.1` already supported `settings.gradle.kts`

> Gradle Kotlin DSL v0.13.1 brings support for settings.gradle.kts files, Kotlin standard library extensions to the Java 7 and Java 8 APIs for use in build scripts, improvements to the plugins {} DSL, and more!

[More info](https://github.com/gradle/kotlin-dsl/releases)