### PR TITLE
Add reified extension function for `ListProperty`

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -38,6 +38,7 @@ import org.gradle.api.plugins.Convention
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginManager
 
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.PropertyState
 
@@ -195,6 +196,17 @@ operator fun Project.getValue(any: Any, property: KProperty<*>): Any? =
 inline
 fun <reified T> ObjectFactory.property(): Property<T> =
     property(T::class.java)
+
+
+/**
+ * Creates a [ListProperty] that holds values of the given type [T].
+ *
+ * @see [ObjectFactory.listProperty]
+ */
+@Incubating
+inline
+fun <reified T> ObjectFactory.listProperty(): ListProperty<T> =
+    listProperty(T::class.java)
 
 
 /**


### PR DESCRIPTION
### Context

<!--- Why do you believe many users will benefit from this change? -->

Lazy values are now in Gradle proper and `ListProperty` is another specialized type that can be used. This aligns the `ListProperty` reified function with the `property()` function.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Provide integration tests to verify changes from a user perspective
- [ ] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
