### PR TITLE
Enhance the maven-plugin sample by demonstrating how to publish accompanying source and javadoc jars

### DIFF
--- a/samples/maven-plugin/README.md
+++ b/samples/maven-plugin/README.md
@@ -1,6 +1,8 @@
 # maven-plugin sample
 
-Demonstrates the use of the `withConvention` and `withGroovyBuilder` utility extensions for configuring the `uploadArchives` task to [deploy to a Maven repository](https://docs.gradle.org/current/userguide/maven_plugin.html#sec:deploying_to_a_maven_repository) with a [custom pom](./build.gradle.kts#L25).
+Demonstrates the use of the `withConvention` and `withGroovyBuilder` utility extensions for configuring the `uploadArchives` task to [deploy to a Maven repository](https://docs.gradle.org/current/userguide/maven_plugin.html#sec:deploying_to_a_maven_repository) with a [custom pom](./build.gradle.kts#L42).
+
+Also demonstrates how to publish accompanying source and javadoc jars.
 
 ## Running the sample
 

--- a/samples/maven-plugin/build.gradle.kts
+++ b/samples/maven-plugin/build.gradle.kts
@@ -9,6 +9,23 @@ version = "1.0"
 
 tasks {
 
+    val sourcesJar by creating(Jar::class) {
+        dependsOn(JavaPlugin.CLASSES_TASK_NAME)
+        classifier = "sources"
+        from(java.sourceSets["main"].allSource)
+    }
+
+    val javadocJar by creating(Jar::class) {
+        dependsOn(JavaPlugin.JAVADOC_TASK_NAME)
+        classifier = "javadoc"
+        from(java.docsDir)
+    }
+
+    artifacts {
+        add("archives", sourcesJar)
+        add("archives", javadocJar)
+    }
+
     "uploadArchives"(Upload::class) {
 
         repositories {


### PR DESCRIPTION
Signed-off-by: wheleph <wheleph@gmail.com>

### Context
I spent quite some time before I figured out how to configure publishing of accompanying source and javadoc jars in a Gradle build that used Kotlin DSL. Since this project is the first place where people look for documentation/samples/help I think many will benefit from this addition.

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commmits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Provide integration tests to verify changes from a user perspective
- [ ] Provide unit tests to verify logic
- [ ] Ensure that tests pass locally: `./gradlew check --parallel`
