### PR TITLE
Remove mention of nebula.kotlin plugin from Readme of hello-coroutines

### DIFF
--- a/samples/hello-coroutines/README.md
+++ b/samples/hello-coroutines/README.md
@@ -1,4 +1,4 @@
 hello-coroutines
 ================
 
-Demonstrates how to enable experimental support for [coroutines in Kotlin](https://kotlinlang.org/docs/reference/coroutines.html) by using the [`nebula.kotlin` plugin](https://plugins.gradle.org/plugin/nebula.kotlin) to trigger the availability of the `kotlin` extension.
+Demonstrates how to enable experimental support for [coroutines in Kotlin](https://kotlinlang.org/docs/reference/coroutines.html).


### PR DESCRIPTION
### Context
nebula.kotlin is not used anymore and Readme should be updated

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] ~Provide integration tests to verify changes from a user perspective~ N/A
- [x] ~Provide unit tests to verify logic~ N/A
- [x] ~Ensure that tests pass locally: `./gradlew check --parallel`~ N/A
