### PR TITLE
Allow `Gradle` as a script target for init scripts

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.invocation.Gradle
+
+import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver
+
+import kotlin.script.extensions.SamWithReceiverAnnotations
+import kotlin.script.templates.ScriptTemplateDefinition
+
+
+/**
+ * Base class for Kotlin init scripts.
+ */
+@ScriptTemplateDefinition(
+    resolver = KotlinBuildScriptDependenciesResolver::class,
+    scriptFilePattern = ".+\\.init\\.gradle\\.kts")
+@SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
+abstract class KotlinInitScript(gradle: Gradle) : Gradle by gradle {
+
+    /**
+     * Configures the classpath of the init script.
+     */
+    @Suppress("unused")
+    open fun initscript(@Suppress("unused_parameter") block: ScriptHandlerScope.() -> Unit) = Unit
+
+    /**
+     * Creates a [ConfigurableFileCollection] containing the given files.
+     *
+     * You can pass any of the following types to this method:
+     *
+     * - A [CharSequence], including [String] as defined by [KotlinSettingsScript.file].
+     * - A [File] as defined by [KotlinSettingsScript.file].
+     * - A [java.nio.file.Path] as defined by [KotlinSettingsScript.file].
+     * - A [URI] or [java.net.URL] as defined by [KotlinSettingsScript.file].
+     * - A [org.gradle.api.file.Directory] or [org.gradle.api.file.RegularFile]
+     *   as defined by [KotlinSettingsScript.file].
+     * - A [Sequence], [Array] or [Iterable] that contains objects of any supported type.
+     *   The elements of the collection are recursively converted to files.
+     * - A [org.gradle.api.file.FileCollection].
+     *   The contents of the collection are included in the returned collection.
+     * - A [org.gradle.api.provider.Provider] of any supported type.
+     *   The provider's value is recursively converted to files. If the provider represents an output of a task,
+     *   that task is executed if the file collection is used as an input to another task.
+     * - A [java.util.concurrent.Callable] that returns any supported type.
+     *   The callable's return value is recursively converted to files.
+     *   A `null` return value is treated as an empty collection.
+     * - A [org.gradle.api.Task].
+     *   Converted to the task's output files.
+     *   The task is executed if the file collection is used as an input to another task.
+     * - A [org.gradle.api.tasks.TaskOutputs].
+     *   Converted to the output files the related task.
+     *   The task is executed if the file collection is used as an input to another task.
+     * - Anything else is treated as a failure.
+     *
+     * The returned file collection is lazy, so that the paths are evaluated only when the contents of the file
+     * collection are queried. The file collection is also live, so that it evaluates the above each time the contents
+     * of the collection is queried.
+     *
+     * The returned file collection maintains the iteration order of the supplied paths.
+     *
+     * The returned file collection maintains the details of the tasks that produce the files,
+     * so that these tasks are executed if this file collection is used as an input to some task.
+     *
+     * This method can also be used to create an empty collection, which can later be mutated to add elements.
+     *
+     * @param paths The paths to the files. May be empty.
+     * @return The file collection.
+     */
+    @Suppress("unused")
+    fun files(vararg paths: Any): ConfigurableFileCollection =
+        fileOperations.files(paths)
+
+    private
+    val fileOperations by lazy {
+        fileOperationsFor(gradle, gradle.startParameter.currentDir)
+    }
+}
+

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -43,6 +43,9 @@ import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.api.internal.file.DefaultFileOperations
 import org.gradle.api.internal.file.FileLookup
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+
+import org.gradle.api.invocation.Gradle
+
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
 import org.gradle.internal.reflect.Instantiator
@@ -385,16 +388,21 @@ abstract class KotlinSettingsScript(settings: Settings) : Settings by settings {
 
 
 private
-fun fileOperationsFor(settings: Settings): DefaultFileOperations {
-    val fileLookup = settings.serviceOf<FileLookup>()
+fun fileOperationsFor(settings: Settings): DefaultFileOperations =
+    fileOperationsFor(settings.gradle, settings.rootDir)
+
+
+internal
+fun fileOperationsFor(gradle: Gradle, baseDir: File): DefaultFileOperations {
+    val fileLookup = gradle.serviceOf<FileLookup>()
     return DefaultFileOperations(
-        fileLookup.getFileResolver(settings.rootDir),
+        fileLookup.getFileResolver(baseDir),
         null,
         null,
-        settings.serviceOf<Instantiator>(),
+        gradle.serviceOf<Instantiator>(),
         fileLookup,
-        settings.serviceOf<DirectoryFileTreeFactory>(),
-        settings.serviceOf<StreamHasher>(),
-        settings.serviceOf<FileHasher>(),
-        settings.serviceOf<ExecFactory>())
+        gradle.serviceOf<DirectoryFileTreeFactory>(),
+        gradle.serviceOf<StreamHasher>(),
+        gradle.serviceOf<FileHasher>(),
+        gradle.serviceOf<ExecFactory>())
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinBuildscriptBlock.kt
@@ -16,18 +16,23 @@
 
 package org.gradle.kotlin.dsl.support
 
-import org.gradle.kotlin.dsl.KotlinBuildScript
-import org.gradle.kotlin.dsl.KotlinSettingsScript
-import org.gradle.kotlin.dsl.ScriptHandlerScope
-
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
+import org.gradle.api.initialization.dsl.ScriptHandler
+import org.gradle.api.invocation.Gradle
+
+import org.gradle.kotlin.dsl.KotlinBuildScript
+import org.gradle.kotlin.dsl.KotlinInitScript
+import org.gradle.kotlin.dsl.KotlinSettingsScript
+import org.gradle.kotlin.dsl.ScriptHandlerScope
 
 
 /**
  * Base class for `buildscript` block evaluation on scripts targeting Project.
  */
-abstract class KotlinBuildscriptBlock(project: Project) : KotlinBuildScript(project) {
+abstract class KotlinBuildscriptBlock(
+    project: Project,
+    private val scriptHandler: ScriptHandler) : KotlinBuildScript(project) {
 
     /**
      * Configures the build script classpath for this project.
@@ -35,15 +40,18 @@ abstract class KotlinBuildscriptBlock(project: Project) : KotlinBuildScript(proj
      * @see [Project.buildscript]
      */
     override fun buildscript(block: ScriptHandlerScope.() -> Unit) {
-        ScriptHandlerScope(project.buildscript).block()
+        scriptHandler.configureWith(block)
     }
+
 }
 
 
 /**
  * Base class for `buildscript` block evaluation on scripts targeting Settings.
  */
-abstract class KotlinSettingsBuildscriptBlock(settings: Settings) : KotlinSettingsScript(settings) {
+abstract class KotlinSettingsBuildscriptBlock(
+    settings: Settings,
+    private val scriptHandler: ScriptHandler) : KotlinSettingsScript(settings) {
 
     /**
      * Configures the build script classpath for settings.
@@ -51,6 +59,28 @@ abstract class KotlinSettingsBuildscriptBlock(settings: Settings) : KotlinSettin
      * @see [Settings.buildscript]
      */
     override fun buildscript(block: ScriptHandlerScope.() -> Unit) {
-        ScriptHandlerScope(settings.buildscript).block()
+        scriptHandler.configureWith(block)
     }
+}
+
+
+/**
+ * Base class for `initscript` block evaluation on scripts targeting Gradle.
+ */
+abstract class KotlinInitscriptBlock(
+    gradle: Gradle,
+    private val scriptHandler: ScriptHandler) : KotlinInitScript(gradle) {
+
+    /**
+     * Configures the classpath of the init script.
+     */
+    override fun initscript(block: ScriptHandlerScope.() -> Unit) {
+        scriptHandler.configureWith(block)
+    }
+}
+
+
+private
+fun ScriptHandler.configureWith(block: ScriptHandlerScope.() -> Unit) {
+    ScriptHandlerScope(this).block()
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/SettingsExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/SettingsExtensions.kt
@@ -17,7 +17,14 @@ package org.gradle.kotlin.dsl.support
 
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.invocation.Gradle
+
 
 inline
 fun <reified T : Any> Settings.serviceOf(): T =
+    gradle.serviceOf()
+
+
+inline
+fun <reified T : Any> Gradle.serviceOf(): T =
     (gradle as GradleInternal).services[T::class.java]!!

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
@@ -1,0 +1,30 @@
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.DeepThought
+import org.junit.Test
+
+
+class KotlinInitScriptIntegrationTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `initscript classpath`() {
+
+        withClassJar("fixture.jar", DeepThought::class.java)
+
+        val initScript =
+            withFile("init.gradle.kts", """
+
+                initscript {
+                    dependencies { classpath(files("fixture.jar")) }
+                }
+
+                val computer = ${DeepThought::class.qualifiedName}()
+                val answer = computer.compute()
+                println("*" + answer + "*")
+            """)
+
+        assert(
+            build("-I", initScript.canonicalPath).output.contains("*42*"))
+    }
+}


### PR DESCRIPTION
With an `initscript` block instead of a `buildscript` block.

See #684