### PR TITLE
Move from jre7/8 to jdk7/8

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -50,7 +50,7 @@ tasks.withType<KotlinCompile> {
 dependencies {
     compile(gradleApi())
     compile(kotlin("gradle-plugin"))
-    compile(kotlin("stdlib-jre8"))
+    compile(kotlin("stdlib-jdk8"))
     compile(kotlin("reflect"))
     compile("org.ow2.asm:asm-all:5.1")
     testCompile("junit:junit:4.12")

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -14,7 +14,7 @@ base {
 dependencies {
     compileOnly(gradleKotlinDsl())
 
-    implementation(futureKotlin("stdlib-jre8"))
+    implementation(futureKotlin("stdlib-jdk8"))
     implementation(futureKotlin("gradle-plugin"))
     implementation(futureKotlin("sam-with-receiver"))
 

--- a/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -47,14 +47,14 @@ open class EmbeddedKotlinPlugin @Inject internal constructor(
             embeddedKotlin.addDependenciesTo(
                 dependencies,
                 embeddedKotlinConfiguration.name,
-                "stdlib-jre8", "reflect")
+                "stdlib-jdk8", "reflect")
 
             listOf("compileOnly", "testCompileOnly").forEach {
                 configurations.getByName(it).extendsFrom(embeddedKotlinConfiguration)
             }
 
             configurations.all {
-                embeddedKotlin.pinDependenciesOn(it, "stdlib-jre8", "reflect", "compiler-embeddable")
+                embeddedKotlin.pinDependenciesOn(it, "stdlib-jdk8", "reflect", "compiler-embeddable")
             }
         }
     }

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -56,7 +56,7 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
             tasks {
                 "assertions" {
                     doLast {
-                        val requiredLibs = listOf("kotlin-stdlib-jre8-$embeddedKotlinVersion.jar", "kotlin-reflect-$embeddedKotlinVersion.jar")
+                        val requiredLibs = listOf("kotlin-stdlib-jdk8-$embeddedKotlinVersion.jar", "kotlin-reflect-$embeddedKotlinVersion.jar")
                         listOf("compileOnly", "testCompileOnly").forEach { configuration ->
                             require(configurations[configuration].files.map { it.name }.containsAll(requiredLibs), {
                                 "Embedded Kotlin libraries not found in ${'$'}configuration"

--- a/provider/build.gradle.kts
+++ b/provider/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     compileOnly(gradleApi())
 
     compile(project(":tooling-models"))
-    compile(futureKotlin("stdlib-jre8"))
+    compile(futureKotlin("stdlib-jdk8"))
     compile(futureKotlin("reflect"))
     compile(futureKotlin("compiler-embeddable"))
     compile(futureKotlin("sam-with-receiver-compiler-plugin")) {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -139,7 +139,7 @@ class KotlinBuildScriptCompiler(
             addRepositoryTo(scriptHandler.repositories)
             pinDependenciesOn(
                 scriptHandler.configurations["classpath"],
-                "stdlib-jre8", "reflect")
+                "stdlib-jdk8", "reflect")
         }
     }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -58,15 +58,15 @@ val embeddedModules: List<EmbeddedModule> by lazy {
     // TODO:pm could be generated at build time
     val annotations = EmbeddedModule("org.jetbrains", "annotations", "13.0")
     val stdlib = embeddedKotlin("stdlib", listOf(annotations))
-    val stdlibJre7 = embeddedKotlin("stdlib-jre7", listOf(stdlib))
-    val stdlibJre8 = embeddedKotlin("stdlib-jre8", listOf(stdlibJre7))
+    val stdlibJdk7 = embeddedKotlin("stdlib-jdk7", listOf(stdlib))
+    val stdlibJdk8 = embeddedKotlin("stdlib-jdk8", listOf(stdlibJdk7))
     val reflect = embeddedKotlin("reflect", listOf(stdlib))
     val compilerEmbeddable = embeddedKotlin("compiler-embeddable")
     val scriptRuntime = embeddedKotlin("script-runtime")
     val samWithReceiverCompilerPlugin = embeddedKotlin("sam-with-receiver-compiler-plugin")
     listOf(
         annotations,
-        stdlib, stdlibJre7, stdlibJre8,
+        stdlib, stdlibJdk7, stdlibJdk8,
         reflect,
         compilerEmbeddable,
         scriptRuntime,

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -408,13 +408,13 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
     }
 
     @Test
-    fun `build script can use jre8 extensions`() {
+    fun `build script can use jdk8 extensions`() {
 
         assumeJavaLessThan9()
 
         withBuildScript("""
 
-            // without kotlin-stdlib-jre8 we get:
+            // without kotlin-stdlib-jdk8 we get:
             // > Retrieving groups by name is not supported on this platform.
 
             val regex = Regex("(?<bla>.*)")

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
@@ -265,7 +265,7 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
         assertSourcePathGiven(
             rootProjectScript,
             subProjectScript,
-            hasItems("kotlin-stdlib-jre8-$embeddedKotlinVersion-sources.jar"))
+            hasItems("kotlin-stdlib-jdk8-$embeddedKotlinVersion-sources.jar"))
     }
 
     private

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
@@ -113,4 +113,4 @@ fun resolveSourcesUsing(dependencyHandler: DependencyHandler, query: ArtifactRes
 
 
 private
-val builtinKotlinModules = listOf("kotlin-stdlib-jre8", "kotlin-reflect")
+val builtinKotlinModules = listOf("kotlin-stdlib-jdk8", "kotlin-reflect")


### PR DESCRIPTION
### Context
This will fix #690 

I've simply replaced all jre7/8 changed to jdk7/8 in the files I found in this commit https://github.com/gradle/kotlin-dsl/commit/9dd7074deefe9d6f5c2985bd9d6c67d22d88ac7f

Hope that was all 👍 

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] ~Provide integration tests to verify changes from a user perspective~
- [x] ~Provide unit tests to verify logic~
- [ ] Ensure that tests pass locally: `./gradlew check --parallel`
