### PR TITLE
Move from kotlin-stdlib-jre8 to kotlin-stdlib-jdk8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,8 @@ allprojects {
     version = "0.16.0-SNAPSHOT"
 }
 
-val publishedPluginsVersion by extra { "0.15.4" }
-val futurePluginsVersion = "0.15.5"
+val publishedPluginsVersion by extra { "0.15.5" }
+val futurePluginsVersion = "0.15.6"
 project(":plugins") {
     group = "org.gradle.kotlin"
     version = futurePluginsVersion

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -50,7 +50,7 @@ tasks.withType<KotlinCompile> {
 dependencies {
     compile(gradleApi())
     compile(kotlin("gradle-plugin"))
-    compile(kotlin("stdlib-jre8"))
+    compile(kotlin("stdlib-jdk8"))
     compile(kotlin("reflect"))
     compile("org.ow2.asm:asm-all:5.1")
     testCompile("junit:junit:4.12")

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -14,7 +14,7 @@ base {
 dependencies {
     compileOnly(gradleKotlinDsl())
 
-    implementation(futureKotlin("stdlib-jre8"))
+    implementation(futureKotlin("stdlib-jdk8"))
     implementation(futureKotlin("gradle-plugin"))
     implementation(futureKotlin("sam-with-receiver"))
 

--- a/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -47,14 +47,14 @@ open class EmbeddedKotlinPlugin @Inject internal constructor(
             embeddedKotlin.addDependenciesTo(
                 dependencies,
                 embeddedKotlinConfiguration.name,
-                "stdlib-jre8", "reflect")
+                "stdlib-jdk8", "reflect")
 
             listOf("compileOnly", "testCompileOnly").forEach {
                 configurations.getByName(it).extendsFrom(embeddedKotlinConfiguration)
             }
 
             configurations.all {
-                embeddedKotlin.pinDependenciesOn(it, "stdlib-jre8", "reflect", "compiler-embeddable")
+                embeddedKotlin.pinDependenciesOn(it, "stdlib-jdk8", "reflect", "compiler-embeddable")
             }
         }
     }

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -56,7 +56,7 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
             tasks {
                 "assertions" {
                     doLast {
-                        val requiredLibs = listOf("kotlin-stdlib-jre8-$embeddedKotlinVersion.jar", "kotlin-reflect-$embeddedKotlinVersion.jar")
+                        val requiredLibs = listOf("kotlin-stdlib-jdk8-$embeddedKotlinVersion.jar", "kotlin-reflect-$embeddedKotlinVersion.jar")
                         listOf("compileOnly", "testCompileOnly").forEach { configuration ->
                             require(configurations[configuration].files.map { it.name }.containsAll(requiredLibs), {
                                 "Embedded Kotlin libraries not found in ${'$'}configuration"

--- a/provider/build.gradle.kts
+++ b/provider/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     compileOnly(gradleApi())
 
     compile(project(":tooling-models"))
-    compile(futureKotlin("stdlib-jre8"))
+    compile(futureKotlin("stdlib-jdk8"))
     compile(futureKotlin("reflect"))
     compile(futureKotlin("compiler-embeddable"))
     compile(futureKotlin("sam-with-receiver-compiler-plugin")) {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -141,7 +141,7 @@ class KotlinBuildScriptCompiler(
             addRepositoryTo(scriptHandler.repositories)
             pinDependenciesOn(
                 scriptHandler.configurations["classpath"],
-                "stdlib-jre8", "reflect")
+                "stdlib-jdk8", "reflect")
         }
     }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -58,15 +58,15 @@ val embeddedModules: List<EmbeddedModule> by lazy {
     // TODO:pm could be generated at build time
     val annotations = EmbeddedModule("org.jetbrains", "annotations", "13.0")
     val stdlib = embeddedKotlin("stdlib", listOf(annotations))
-    val stdlibJre7 = embeddedKotlin("stdlib-jre7", listOf(stdlib))
-    val stdlibJre8 = embeddedKotlin("stdlib-jre8", listOf(stdlibJre7))
+    val stdlibJdk7 = embeddedKotlin("stdlib-jdk7", listOf(stdlib))
+    val stdlibJdk8 = embeddedKotlin("stdlib-jdk8", listOf(stdlibJdk7))
     val reflect = embeddedKotlin("reflect", listOf(stdlib))
     val compilerEmbeddable = embeddedKotlin("compiler-embeddable")
     val scriptRuntime = embeddedKotlin("script-runtime")
     val samWithReceiverCompilerPlugin = embeddedKotlin("sam-with-receiver-compiler-plugin")
     listOf(
         annotations,
-        stdlib, stdlibJre7, stdlibJre8,
+        stdlib, stdlibJdk7, stdlibJdk8,
         reflect,
         compilerEmbeddable,
         scriptRuntime,

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -34,7 +34,7 @@ import java.util.*
 
 
 private
-const val embeddedRepositoryCacheKeyVersion = 1
+const val embeddedRepositoryCacheKeyVersion = 2
 
 
 private

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -410,13 +410,13 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
     }
 
     @Test
-    fun `build script can use jre8 extensions`() {
+    fun `build script can use jdk8 extensions`() {
 
         assumeJavaLessThan9()
 
         withBuildScript("""
 
-            // without kotlin-stdlib-jre8 we get:
+            // without kotlin-stdlib-jdk8 we get:
             // > Retrieving groups by name is not supported on this platform.
 
             val regex = Regex("(?<bla>.*)")

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
@@ -265,7 +265,7 @@ class KotlinBuildScriptModelIntegrationTest : AbstractIntegrationTest() {
         assertSourcePathGiven(
             rootProjectScript,
             subProjectScript,
-            hasItems("kotlin-stdlib-jre8-$embeddedKotlinVersion-sources.jar"))
+            hasItems("kotlin-stdlib-jdk8-$embeddedKotlinVersion-sources.jar"))
     }
 
     private

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
@@ -113,4 +113,4 @@ fun resolveSourcesUsing(dependencyHandler: DependencyHandler, query: ArtifactRes
 
 
 private
-val builtinKotlinModules = listOf("kotlin-stdlib-jre8", "kotlin-reflect")
+val builtinKotlinModules = listOf("kotlin-stdlib-jdk8", "kotlin-reflect")


### PR DESCRIPTION
Since Kotlin 1.2.

See http://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages

This PR is a follow up to #693