### PR TITLE
Forcefully delete temporary folder upon test end

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -53,7 +53,7 @@ import kotlin.reflect.KProperty
 
 
 /**
- * Sets the the default tasks of this project. These are used when no tasks names are provided when
+ * Sets the default tasks of this project. These are used when no tasks names are provided when
  * starting the build.
  */
 inline

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
+import org.gradle.kotlin.dsl.fixtures.LeaksFileHandles
 import org.gradle.kotlin.dsl.fixtures.canPublishBuildScan
 import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 
@@ -27,6 +28,7 @@ import java.io.File
 class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
 
     @Test
+    @LeaksFileHandles
     fun `given a buildscript block, it will be used to compute the runtime classpath`() {
         checkBuildscriptBlockIsUsedToComputeRuntimeClasspathAfter({ it })
     }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
@@ -2,12 +2,15 @@ package org.gradle.kotlin.dsl.integration
 
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
+import org.gradle.kotlin.dsl.fixtures.LeaksFileHandles
+
 import org.junit.Test
 
 
 class KotlinInitScriptIntegrationTest : AbstractIntegrationTest() {
 
     @Test
+    @LeaksFileHandles
     fun `initscript classpath`() {
 
         withClassJar("fixture.jar", DeepThought::class.java)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchyTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchyTest.kt
@@ -2,15 +2,19 @@ package org.gradle.kotlin.dsl.provider
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
+
 import org.gradle.api.internal.initialization.AbstractClassLoaderScope
 
+import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 
-import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.DeepThought
+import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.classEntriesFor
+
 import org.gradle.kotlin.dsl.support.zipTo
 
 import org.hamcrest.CoreMatchers.equalTo
@@ -21,34 +25,42 @@ import org.junit.Test
 
 import java.lang.ClassLoader.getSystemClassLoader
 
+
 class ClassLoaderHierarchyTest : TestWithTempFiles() {
 
     @Test
     fun `can dump complete ClassLoader hierarchy to json`() {
-        val jar = file("fixture.jar")
-        zipTo(jar, classEntriesFor(DeepThought::class.java))
 
-        val loader = ChildFirstClassLoader(getSystemClassLoader(), DefaultClassPath.of(listOf(jar)))
-        val klass = loader.loadClass(DeepThought::class.qualifiedName)
+        ChildFirstClassLoader(getSystemClassLoader(), classPathWith(DeepThought::class.java)).use { loader ->
 
-        val targetScope = mock<AbstractClassLoaderScope> {
-            on { localClassLoader } doReturn loader
-            on { exportClassLoader } doReturn loader.parent
-            on { parent }.then { it.mock }
-            on { path }.then { "the path" }
+            val `class` = loader.loadClass(DeepThought::class.qualifiedName)
+
+            val targetScope = mock<AbstractClassLoaderScope> {
+                on { localClassLoader } doReturn loader
+                on { exportClassLoader } doReturn loader.parent
+                on { parent }.then { it.mock }
+                on { path }.then { "the path" }
+            }
+
+            val json = classLoaderHierarchyJsonFor(`class`, targetScope)
+
+            val mapper = jacksonObjectMapper()
+            val hierarchy = mapper.readValue<ClassLoaderHierarchy>(json)
+
+            assertThat(hierarchy.classLoaders.size, equalTo(3))
+            assertThat(hierarchy.scopes.size, equalTo(1))
+            assertThat(hierarchy.classLoaders[0].parents, hasItem(hierarchy.classLoaders[1].id))
+            assertThat(hierarchy.scopes[0].label, equalTo("the path"))
+            assertThat(hierarchy.scopes[0].localClassLoader, equalTo(hierarchy.classLoaders[0].id))
+            assertThat(hierarchy.scopes[0].exportClassLoader, equalTo(hierarchy.classLoaders[1].id))
         }
+    }
 
-        val json = classLoaderHierarchyJsonFor(klass, targetScope)
-
-        val mapper = jacksonObjectMapper()
-        val hierarchy = mapper.readValue<ClassLoaderHierarchy>(json)
-
-        assertThat(hierarchy.classLoaders.size, equalTo(3))
-        assertThat(hierarchy.scopes.size, equalTo(1))
-        assertThat(hierarchy.classLoaders[0].parents, hasItem(hierarchy.classLoaders[1].id))
-        assertThat(hierarchy.scopes[0].label, equalTo("the path"))
-        assertThat(hierarchy.scopes[0].localClassLoader, equalTo(hierarchy.classLoaders[0].id))
-        assertThat(hierarchy.scopes[0].exportClassLoader, equalTo(hierarchy.classLoaders[1].id))
+    private
+    fun classPathWith(`class`: Class<*>): ClassPath {
+        val jar = file("fixture.jar")
+        zipTo(jar, classEntriesFor(`class`))
+        return DefaultClassPath.of(listOf(jar))
     }
 
     data class ClassLoaderHierarchy(

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/GradlePluginSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/GradlePluginSampleTest.kt
@@ -1,5 +1,7 @@
 package org.gradle.kotlin.dsl.samples
 
+import org.gradle.kotlin.dsl.fixtures.LeaksFileHandles
+
 import org.junit.Test
 import org.junit.Assert.assertTrue
 
@@ -9,6 +11,7 @@ import java.io.File
 class GradlePluginSampleTest : AbstractSampleTest("gradle-plugin") {
 
     @Test
+    @LeaksFileHandles
     fun `can use the plugin`() {
 
         build("consumer")

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
@@ -14,7 +14,6 @@ import org.hamcrest.CoreMatchers.containsString
 
 import org.junit.Assert.assertThat
 import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import org.junit.rules.TestName
 
 import java.io.File
@@ -30,7 +29,7 @@ open class AbstractIntegrationTest {
     @Rule val testName = TestName()
 
     @JvmField
-    @Rule val temporaryFolder = TemporaryFolder()
+    @Rule val temporaryFolder = ForcefullyDeletedTemporaryFolder()
 
     protected
     val projectRoot: File

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
@@ -1,14 +1,13 @@
 package org.gradle.kotlin.dsl.fixtures
 
 import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 
 import java.io.File
 
 abstract class FolderBasedTest {
 
     @JvmField
-    @Rule val tempFolder = TemporaryFolder()
+    @Rule val tempFolder = ForcefullyDeletedTemporaryFolder()
 
     fun withFolders(folders: FoldersDslExpression) =
         tempFolder.root.withFolders(folders)

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/ForcefullyDeletedTemporaryFolder.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/ForcefullyDeletedTemporaryFolder.kt
@@ -1,12 +1,63 @@
 package org.gradle.kotlin.dsl.fixtures
 
+import org.gradle.api.UncheckedIOException
 import org.gradle.util.GFileUtils
+
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+import kotlin.annotation.AnnotationTarget.FUNCTION
+
 
 /**
  * A [TemporaryFolder] JUnit rule that fails the test if the
- * the temporary folder cannot be deleted when the test finishes.
+ * the temporary folder cannot be deleted when the test finishes and
+ * the test is not annotated with [LeaksFileHandles].
  */
 class ForcefullyDeletedTemporaryFolder : TemporaryFolder() {
+
     override fun delete() = GFileUtils.forceDelete(root)
+
+    override fun apply(base: Statement, description: Description) = object : Statement() {
+
+        override fun evaluate() {
+            before()
+            try {
+                base.evaluate()
+            } finally {
+                if (leaksFileHandles(description)) {
+                    ignoringDeleteErrorCausedBy(description) {
+                        after()
+                    }
+                } else after()
+            }
+        }
+    }
+
+    private
+    fun ignoringDeleteErrorCausedBy(description: Description, action: () -> Unit) {
+        try {
+            action()
+        } catch (e: UncheckedIOException) {
+            System.err.println(
+                "Couldn't delete test dir for `${description.displayName}` (test is holding files open).\n"
+                    + "In order to find out which files are held open you may find http://file-leak-detector.kohsuke.org/ useful.")
+            e.printStackTrace()
+        }
+    }
+
+    private
+    fun leaksFileHandles(description: Description) =
+        description.getAnnotation(LeaksFileHandles::class.java) != null
 }
+
+
+/**
+ * Declares that the test holds files open and therefore not to error if the temporary test directory
+ * can't be forcefully deleted.
+ *
+ * @see ForcefullyDeletedTemporaryFolder
+ */
+@Target(FUNCTION)
+annotation class LeaksFileHandles

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/ForcefullyDeletedTemporaryFolder.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/ForcefullyDeletedTemporaryFolder.kt
@@ -11,9 +11,8 @@ import kotlin.annotation.AnnotationTarget.FUNCTION
 
 
 /**
- * A [TemporaryFolder] JUnit rule that fails the test if the
- * the temporary folder cannot be deleted when the test finishes and
- * the test is not annotated with [LeaksFileHandles].
+ * A [TemporaryFolder] JUnit rule that fails the test if the temporary folder cannot be deleted
+ * when the test finishes and the test is not annotated with [LeaksFileHandles].
  */
 class ForcefullyDeletedTemporaryFolder : TemporaryFolder() {
 

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/ForcefullyDeletedTemporaryFolder.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/ForcefullyDeletedTemporaryFolder.kt
@@ -1,0 +1,12 @@
+package org.gradle.kotlin.dsl.fixtures
+
+import org.gradle.util.GFileUtils
+import org.junit.rules.TemporaryFolder
+
+/**
+ * A [TemporaryFolder] JUnit rule that fails the test if the
+ * the temporary folder cannot be deleted when the test finishes.
+ */
+class ForcefullyDeletedTemporaryFolder : TemporaryFolder() {
+    override fun delete() = GFileUtils.forceDelete(root)
+}

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
@@ -1,14 +1,13 @@
 package org.gradle.kotlin.dsl.fixtures
 
 import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 
 import java.io.File
 
 abstract class TestWithTempFiles {
 
     @JvmField
-    @Rule val tempFolder = TemporaryFolder()
+    @Rule val tempFolder = ForcefullyDeletedTemporaryFolder()
 
     protected
     val root: File

--- a/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelIntegrationTest.kt
+++ b/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelIntegrationTest.kt
@@ -15,6 +15,7 @@ import org.gradle.kotlin.dsl.fixtures.customDaemonRegistry
 import org.gradle.kotlin.dsl.fixtures.customInstallation
 import org.gradle.kotlin.dsl.fixtures.withDaemonIdleTimeout
 import org.gradle.kotlin.dsl.fixtures.withDaemonRegistry
+import org.gradle.kotlin.dsl.fixtures.LeaksFileHandles
 
 import org.junit.Test
 
@@ -24,6 +25,7 @@ import java.io.File
 class KotlinBuildScriptTemplateModelIntegrationTest : AbstractIntegrationTest() {
 
     @Test
+    @LeaksFileHandles
     fun `can load script template using classpath model`() {
 
         withBuildScript("")


### PR DESCRIPTION
And fail the test if the folder cannot be deleted and it's not annotated with `@LeaksFileHandles`.