### PR TITLE
Fix static accessors missing in buildSrc/build.gradle.kts IDEA editor

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -234,6 +234,8 @@ internal
 fun projectRootOf(scriptFile: File, importedProjectRoot: File): File {
 
     // TODO:pm remove hardcoded reference to settings.gradle
+    // Using `DefaultScriptFileResolver()` here would do
+    // but that class is not available when this gets run inside IntelliJ
     fun isProjectRoot(dir: File) =
         File(dir, "settings.gradle.kts").isFile
             || File(dir, "settings.gradle").isFile

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -235,7 +235,9 @@ fun projectRootOf(scriptFile: File, importedProjectRoot: File): File {
 
     // TODO:pm remove hardcoded reference to settings.gradle
     fun isProjectRoot(dir: File) =
-        File(dir, "settings.gradle.kts").isFile || File(dir, "settings.gradle").isFile
+        File(dir, "settings.gradle.kts").isFile
+            || File(dir, "settings.gradle").isFile
+            || dir.name == "buildSrc"
 
     tailrec fun test(dir: File): File =
         when {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ProjectRootOfTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ProjectRootOfTest.kt
@@ -100,4 +100,22 @@ class ProjectRootOfTest(private val settingsFileName: String) : FolderBasedTest(
                 importedProjectRoot = folder("root")),
             equalTo(folder("root")))
     }
+
+    @Test
+    fun `given a script file in buildSrc it should return the buildSrc project root`() {
+
+        withFolders {
+            "root" {
+                "buildSrc" {
+                    withFile("build.gradle.kts")
+                }
+            }
+        }
+
+        assertThat(
+            projectRootOf(
+                scriptFile = file("root/buildSrc/build.gradle.kts"),
+                importedProjectRoot = folder("root")),
+            equalTo(folder("root/buildSrc")))
+    }
 }


### PR DESCRIPTION
when no buildSrc/settings.gradle[.kts]
by using buildSrc/ directory as a root for the tapi request.