### PR TITLE
Let `configure<T> { }` and `the<T>()` extensions be available to any `ExtensionAware` type

### DIFF
--- a/fixtures/plugin-compiled-against-kotlin-1.0/src/main/kotlin/fixtures/ThePlugin.kt
+++ b/fixtures/plugin-compiled-against-kotlin-1.0/src/main/kotlin/fixtures/ThePlugin.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Project
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-class ThePlugin() : Plugin<Project> {
+class ThePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.tasks.create("the-plugin-task", ThePluginTask::class.java)
@@ -16,10 +16,10 @@ open class ThePluginTask : DefaultTask() {
 
     var from: String = "default from value"
 
-    open fun configure(setup: (String) -> String) = setup(from)
+    open fun transform(f: (String) -> String) = f(from)
 
     @TaskAction
     fun run() {
-        println(configure { "it = $it" })
+        println(transform { "it = $it" })
     }
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.plugins.ExtensionAware
+import kotlin.reflect.KClass
+
+
+/**
+ * Returns the extension of the specified type.
+ */
+inline
+fun <reified T : Any> ExtensionAware.the() =
+    the(T::class)
+
+
+fun <T : Any> ExtensionAware.the(extensionType: KClass<T>) =
+    extensions.findByType(extensionType.java) ?: extensions.getByType(extensionType.java)
+
+
+/**
+ * Executes the given configuration block against the [extension][ExtensionAware] of the specified type.
+ *
+ * @param T the extension type.
+ * @param configuration the configuration block.
+ * @see [ExtensionAware]
+ */
+inline
+fun <reified T : Any> ExtensionAware.configure(noinline configuration: T.() -> Unit) =
+    extensions.findByType(T::class.java)?.let(configuration)
+        ?: extensions.configure(T::class.java, configuration)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensions.kt
@@ -21,12 +21,20 @@ import kotlin.reflect.KClass
 
 /**
  * Returns the extension of the specified type.
+ *
+ * @param T the extension type.
  */
 inline
 fun <reified T : Any> ExtensionAware.the() =
     the(T::class)
 
 
+/**
+ * Returns the extension of the specified [extensionType].
+ *
+ * @param T the extension type.
+ * @param extensionType the reified extension type.
+ */
 fun <T : Any> ExtensionAware.the(extensionType: KClass<T>) =
     extensions.findByType(extensionType.java) ?: extensions.getByType(extensionType.java)
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensionsTest.kt
@@ -1,0 +1,35 @@
+package org.gradle.kotlin.dsl
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+
+import org.gradle.api.Task
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+
+import org.junit.Test
+
+
+class ExtensionAwareExtensionsTest {
+
+    @Test
+    fun `can configure task extensions`() {
+
+        val extensionType = JacocoTaskExtension::class.java
+
+        val extensionContainer = mock<ExtensionContainer>()
+
+        val task = mock<Task> {
+            on { extensions } doReturn extensionContainer
+        }
+
+        task.the<JacocoTaskExtension>()
+        verify(extensionContainer).getByType(eq(extensionType))
+
+        task.configure<JacocoTaskExtension> {}
+        verify(extensionContainer).configure(eq(extensionType), any())
+    }
+}

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -156,7 +156,7 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
             tasks.withType<fixtures.ThePluginTask> {
                 from = "new value"
                 doLast {
-                    println(configure { "*[" + it + "]*" })
+                    println(this@withType.configure { "*[" + it + "]*" })
                 }
             }
         """)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -156,7 +156,7 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
             tasks.withType<fixtures.ThePluginTask> {
                 from = "new value"
                 doLast {
-                    println(this@withType.configure { "*[" + it + "]*" })
+                    println(transform { "*[" + it + "]*" })
                 }
             }
         """)


### PR DESCRIPTION
See #703 