### PR TITLE
Made Provider API sample more idiomatic for what we can do with Kotlin

### DIFF
--- a/samples/provider-properties/build.gradle.kts
+++ b/samples/provider-properties/build.gradle.kts
@@ -1,24 +1,28 @@
 apply<GreetingPlugin>()
 
+fun buildFile(path: String) = layout.buildDirectory.file(path)
+
 configure<GreetingPluginExtension> {
+
     message.set("Hi from Gradle")
+
     outputFiles.from(
-        project.layout.buildDirectory.file("a.txt"),
-        project.layout.buildDirectory.file("b.txt"))
+        buildFile("a.txt"),
+        buildFile("b.txt"))
 }
 
 open class GreetingPlugin : Plugin<Project> {
 
-    override fun apply(project: Project) {
+    override fun apply(project: Project): Unit = project.run {
 
         // Add the 'greeting' extension object
-        val greeting = project.extensions.create(
-                "greeting",
-                GreetingPluginExtension::class.java,
-                project)
+        val greeting = extensions.create(
+            "greeting",
+            GreetingPluginExtension::class.java,
+            project)
 
         // Add a task that uses the configuration
-        project.tasks {
+        tasks {
             "hello"(Greeting::class) {
                 group = "Greeting"
                 message.set(greeting.message)
@@ -29,11 +33,14 @@ open class GreetingPlugin : Plugin<Project> {
 }
 
 open class GreetingPluginExtension(project: Project) {
+
     val message = project.objects.property<String>()
+
     val outputFiles: ConfigurableFileCollection = project.files()
 }
 
 open class Greeting : DefaultTask() {
+
     @get:Input
     val message = project.objects.property<String>()
 


### PR DESCRIPTION

This takes the approach to make Kotlin look more like the explicitness
of Java until we can do something fancier (like setter overloads).

- We want to expose a single getter that returns the Provider/Property
- The GreetingExtension and Greeting task had unnecessarily mutable variables
- Handwritten separate setters/getters for a Property isn't what we want people
  to do.  And I think we don't want authors to expose special methods for
  setting Provider or raw values.

Fixes #597

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] Base the PR against the `develop` branch
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Provide integration tests to verify changes from a user perspective
- [ ] Provide unit tests to verify logic
- [ ] Ensure that tests pass locally: `./gradlew check --parallel`
