### PR TITLE
Replace deprecated build scan configuration methods

### DIFF
--- a/samples/build-scan/build.gradle.kts
+++ b/samples/build-scan/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 buildScan {
-    setLicenseAgreementUrl("https://gradle.com/terms-of-service")
-    setLicenseAgree("yes")
+    setTermsOfServiceUrl("https://gradle.com/terms-of-service")
+    setTermsOfServiceAgree("yes")
 }


### PR DESCRIPTION
### Context
this replaces the deprecated methods `setLicenseAgreementUrl` and `setLicenseAgree` with `setTermsOfServiceUrl` and `setTermsOfServiceAgree` in the  build scan configuration example.
