### PR TITLE
Kotlin code linting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,8 @@ project(":plugins") {
     version = futurePluginsVersion
 }
 
-val futurePluginsExperimentsVersion = "0.1.0"
+val publishedPluginsExperimentsVersion by extra { "0.1.0" }
+val futurePluginsExperimentsVersion = "0.1.1"
 project(":plugins-experiments") {
     group = "org.gradle.kotlin"
     version = futurePluginsExperimentsVersion

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,12 @@ project(":plugins") {
     version = futurePluginsVersion
 }
 
+val futurePluginsExperimentsVersion = "0.1.0"
+project(":plugins-experiments") {
+    group = "org.gradle.kotlin"
+    version = futurePluginsExperimentsVersion
+}
+
 // --- Configure publications ------------------------------------------
 val publishedProjects =
     listOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,8 +35,8 @@ project(":plugins") {
     version = futurePluginsVersion
 }
 
-val publishedPluginsExperimentsVersion by extra { "0.1.0" }
-val futurePluginsExperimentsVersion = "0.1.1"
+val publishedPluginsExperimentsVersion by extra { "0.1.1" }
+val futurePluginsExperimentsVersion = "0.1.2"
 project(":plugins-experiments") {
     group = "org.gradle.kotlin"
     version = futurePluginsExperimentsVersion

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     compile(kotlin("gradle-plugin"))
     compile(kotlin("stdlib-jdk8"))
     compile(kotlin("reflect"))
+    compile("gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins-experiments:0.1.0")
     compile("com.gradle.publish:plugin-publish-plugin:0.9.10")
     compile("org.ow2.asm:asm-all:5.1")
     testCompile("junit:junit:4.12")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,6 +35,10 @@ gradlePlugin {
             id = "public-kotlin-dsl-module"
             implementationClass = "plugins.PublicKotlinDslModule"
         }
+        "kotlinDslPluginBundle" {
+            id = "kotlin-dsl-plugin-bundle"
+            implementationClass = "plugins.KotlinDslPluginBundle"
+        }
     }
 }
 
@@ -52,6 +56,7 @@ dependencies {
     compile(kotlin("gradle-plugin"))
     compile(kotlin("stdlib-jdk8"))
     compile(kotlin("reflect"))
+    compile("com.gradle.publish:plugin-publish-plugin:0.9.10")
     compile("org.ow2.asm:asm-all:5.1")
     testCompile("junit:junit:4.12")
     testCompile(gradleTestKit())

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
 
 plugins {
     `java-gradle-plugin`
-    id("org.gradle.kotlin.ktlint-convention") version "0.1.0"
+    id("org.gradle.kotlin.ktlint-convention") version "0.1.1"
 }
 
 apply {
@@ -57,7 +57,7 @@ dependencies {
     compile(kotlin("gradle-plugin"))
     compile(kotlin("stdlib-jdk8"))
     compile(kotlin("reflect"))
-    compile("gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins-experiments:0.1.0")
+    compile("gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins-experiments:0.1.1")
     compile("com.gradle.publish:plugin-publish-plugin:0.9.10")
     compile("org.ow2.asm:asm-all:5.1")
     testCompile("junit:junit:4.12")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
 
 plugins {
     `java-gradle-plugin`
+    id("org.gradle.kotlin.ktlint-convention") version "0.1.0"
 }
 
 apply {

--- a/buildSrc/src/main/kotlin/build/ExtraProperties.kt
+++ b/buildSrc/src/main/kotlin/build/ExtraProperties.kt
@@ -15,12 +15,13 @@ fun loadExtraPropertiesOf(project: Project) = project.run {
 }
 
 
-val Project.kotlinVersion get() = rootProject.extra["kotlinVersion"] as String
+val Project.kotlinVersion
+    get() = rootProject.extra["kotlinVersion"] as String
 
 
 fun Project.futureKotlin(module: String) = "org.jetbrains.kotlin:kotlin-$module:$kotlinVersion"
 
 
 private
-val Project.extra: ExtraPropertiesExtension get() = extensions.extraProperties
-
+val Project.extra: ExtraPropertiesExtension
+    get() = extensions.extraProperties

--- a/buildSrc/src/main/kotlin/build/Testing.kt
+++ b/buildSrc/src/main/kotlin/build/Testing.kt
@@ -31,4 +31,3 @@ fun Project.withParallelTests() {
         test.logger.info("${test.path} will run with maxParallelForks=${test.maxParallelForks}.")
     }
 }
-

--- a/buildSrc/src/main/kotlin/codegen/GenerateClasspathManifest.kt
+++ b/buildSrc/src/main/kotlin/codegen/GenerateClasspathManifest.kt
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.TaskAction
 
 import java.io.File
 
+
 open class GenerateClasspathManifest : DefaultTask() {
 
     @get:OutputDirectory

--- a/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
+++ b/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
@@ -119,6 +119,7 @@ fun PluginDependenciesSpec.kotlin(module: String): PluginDependencySpec =
 val PluginDependenciesSpec.`embedded-kotlin`: PluginDependencySpec
     get() = id("org.gradle.kotlin.embedded-kotlin") version "$kotlinDslPluginsVersion"
 
+
 /**
  * The `kotlin-dsl` plugin.
  *
@@ -130,7 +131,6 @@ val PluginDependenciesSpec.`embedded-kotlin`: PluginDependencySpec
  */
 val PluginDependenciesSpec.`kotlin-dsl`: PluginDependencySpec
     get() = id("org.gradle.kotlin.kotlin-dsl") version "$kotlinDslPluginsVersion"
-
 """)
     }
 }

--- a/buildSrc/src/main/kotlin/criterion/Duration.kt
+++ b/buildSrc/src/main/kotlin/criterion/Duration.kt
@@ -18,16 +18,19 @@ package criterion
 
 import java.lang.System.nanoTime
 
+
 data class Duration(val ns: Double) {
     val ms: Double
         get() = ns / 1e+6
 }
+
 
 inline
 fun durationOf(block: () -> Unit): Duration =
     nanoTimeOf(block).let {
         Duration(it.toDouble())
     }
+
 
 inline
 fun nanoTimeOf(block: () -> Unit): Long =

--- a/buildSrc/src/main/kotlin/criterion/Result.kt
+++ b/buildSrc/src/main/kotlin/criterion/Result.kt
@@ -18,6 +18,7 @@ package criterion
 
 import java.lang.Math.sqrt
 
+
 /**
  * A result of an experiment expressed as a set of observations measured in a unit [U].
  *
@@ -59,5 +60,6 @@ abstract class Result<U>(observations: List<U>) {
     fun Iterable<U>.average() =
         map { it.magnitude }.average().measure
 }
+
 
 fun square(d: Double) = d * d

--- a/buildSrc/src/main/kotlin/criterion/benchmark.kt
+++ b/buildSrc/src/main/kotlin/criterion/benchmark.kt
@@ -18,8 +18,6 @@
 /**
  * A small, criterion-like benchmarking framework.
  */
-
-
 package criterion
 
 

--- a/buildSrc/src/main/kotlin/criterion/benchmark.kt
+++ b/buildSrc/src/main/kotlin/criterion/benchmark.kt
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
+
 /**
  * A small, criterion-like benchmarking framework.
  */
+
+
 package criterion
+
 
 fun benchmark(config: BenchmarkConfig, experiment: () -> Unit): BenchmarkResult {
     warmUp(config, experiment)
@@ -25,7 +29,9 @@ fun benchmark(config: BenchmarkConfig, experiment: () -> Unit): BenchmarkResult 
     return BenchmarkResult(observations)
 }
 
+
 data class BenchmarkConfig(val warmUpRuns: Int, val observationRuns: Int)
+
 
 class BenchmarkResult(observations: List<Duration>) : Result<Duration>(observations) {
 
@@ -36,12 +42,14 @@ class BenchmarkResult(observations: List<Duration>) : Result<Duration>(observati
         get() = Duration(this)
 }
 
+
 private
 fun warmUp(config: BenchmarkConfig, experiment: () -> Unit) {
     for (i in 1..config.warmUpRuns) {
         experiment()
     }
 }
+
 
 private
 fun collectObservations(config: BenchmarkConfig, experiment: () -> Unit): List<Duration> =

--- a/buildSrc/src/main/kotlin/integration/Benchmark.kt
+++ b/buildSrc/src/main/kotlin/integration/Benchmark.kt
@@ -232,12 +232,15 @@ open class Benchmark : DefaultTask() {
         File(temporaryDir, "$sampleName/$temporaryDirName")
 }
 
+
 private
 data class BenchmarkRunConfig(
     val name: String,
     val sampleName: String,
     val sampleDir: File,
-    val benchmarkConfig: BenchmarkConfig)
+    val benchmarkConfig: BenchmarkConfig
+)
+
 
 class QuotientResult(observations: List<Double>) : Result<Double>(observations) {
 
@@ -248,8 +251,10 @@ class QuotientResult(observations: List<Double>) : Result<Double>(observations) 
         get() = this
 }
 
+
 fun connectorFor(projectDir: File) =
     newConnector().forProjectDirectory(projectDir)!!
+
 
 inline
 fun <T> withConnectionFrom(connector: GradleConnector, block: ProjectConnection.() -> T): T {
@@ -260,6 +265,7 @@ fun <T> withConnectionFrom(connector: GradleConnector, block: ProjectConnection.
     }
 }
 
+
 inline
 fun <T> ProjectConnection.use(block: (ProjectConnection) -> T): T {
     try {
@@ -269,6 +275,7 @@ fun <T> ProjectConnection.use(block: (ProjectConnection) -> T): T {
     }
 }
 
+
 /**
  * Forces a new daemon process to be started by basing the registry on an unique temp dir.
  */
@@ -276,9 +283,11 @@ inline
 fun <T> withUniqueDaemonRegistry(baseDir: File, block: () -> T) =
     withDaemonRegistry(createTempDir("daemon-registry-", directory = baseDir), block)
 
+
 inline
 fun <T> withDaemonRegistry(registryBase: File, block: () -> T) =
     withSystemProperty("org.gradle.daemon.registry.base", registryBase.path, block)
+
 
 inline
 fun <T> withSystemProperty(key: String, value: String, block: () -> T): T {
@@ -290,6 +299,7 @@ fun <T> withSystemProperty(key: String, value: String, block: () -> T): T {
         setOrClearProperty(key, originalValue)
     }
 }
+
 
 fun setOrClearProperty(key: String, value: String?) {
     when (value) {

--- a/buildSrc/src/main/kotlin/integration/Samples.kt
+++ b/buildSrc/src/main/kotlin/integration/Samples.kt
@@ -19,7 +19,9 @@ package integration
 import org.gradle.api.Project
 import java.io.File
 
+
 fun Project.sampleDirs(): List<File> =
     samplesDir().listFiles()!!.filter { it.isDirectory }
+
 
 fun Project.samplesDir(): File = file("samples")

--- a/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
@@ -89,7 +89,7 @@ open class KotlinDslPluginBundle : Plugin<Project> {
     }
 
     // TODO Remove work around for TestKit withPluginClassPath() issues
-    // See TODO ISSUE NUMBER
+    // See https://github.com/gradle/kotlin-dsl/issues/492
     // Also see AbstractPluginTest
     private
     fun Project.workAroundTestKitWithPluginClassPathIssues() {

--- a/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
@@ -33,7 +33,7 @@ open class KotlinDslPluginBundle : Plugin<Project> {
         plugins.apply("java-gradle-plugin")
         plugins.apply("com.gradle.plugin-publish")
 
-        testsDependOnCustomInstallation()
+        testDependsOnCustomInstallation()
 
         kotlinDslPlugins = container(KotlinDslPlugin::class.java)
         extensions.add("kotlinDslPlugins", kotlinDslPlugins)
@@ -44,10 +44,8 @@ open class KotlinDslPluginBundle : Plugin<Project> {
     }
 
     private
-    fun Project.testsDependOnCustomInstallation() =
-        tasks.withType(Test::class.java).all {
-            it.dependsOn(rootProject.tasks.getByName("customInstallation"))
-        }
+    fun Project.testDependsOnCustomInstallation() =
+        tasks.getByName("test").dependsOn(rootProject.tasks.getByName("customInstallation"))
 
     private
     fun Project.configureGradlePluginDevelopmentPlugins() {

--- a/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
@@ -1,6 +1,5 @@
 package plugins
 
-import com.gradle.publish.PluginBundleExtension
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Named
 import org.gradle.api.Plugin
@@ -8,8 +7,12 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.BasePluginConvention
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.WriteProperties
+
 import org.gradle.language.jvm.tasks.ProcessResources
+
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
+
+import com.gradle.publish.PluginBundleExtension
 
 
 class KotlinDslPlugin(private val name: String) : Named {
@@ -27,15 +30,15 @@ open class KotlinDslPluginBundle : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
 
+        kotlinDslPlugins = container(KotlinDslPlugin::class.java)
+        extensions.add("kotlinDslPlugins", kotlinDslPlugins)
+
         plugins.apply(KotlinDslModule::class.java)
         plugins.apply("maven-publish")
         plugins.apply("java-gradle-plugin")
         plugins.apply("com.gradle.plugin-publish")
 
         testDependsOnCustomInstallation()
-
-        kotlinDslPlugins = container(KotlinDslPlugin::class.java)
-        extensions.add("kotlinDslPlugins", kotlinDslPlugins)
 
         configureGradlePluginDevelopmentPlugins()
 

--- a/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
@@ -8,7 +8,6 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.BasePluginConvention
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.WriteProperties
-import org.gradle.api.tasks.testing.Test
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 

--- a/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinDslPluginBundle.kt
@@ -1,0 +1,148 @@
+package plugins
+
+import com.gradle.publish.PluginBundleExtension
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.Named
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.BasePluginConvention
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.tasks.WriteProperties
+import org.gradle.api.tasks.testing.Test
+import org.gradle.language.jvm.tasks.ProcessResources
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
+
+
+class KotlinDslPlugin(private val name: String) : Named {
+    override fun getName() = name
+    lateinit var displayName: String
+    lateinit var id: String
+    lateinit var implementationClass: String
+}
+
+
+open class KotlinDslPluginBundle : Plugin<Project> {
+
+    private
+    lateinit var kotlinDslPlugins: DomainObjectCollection<KotlinDslPlugin>
+
+    override fun apply(project: Project): Unit = project.run {
+
+        plugins.apply(KotlinDslModule::class.java)
+        plugins.apply("maven-publish")
+        plugins.apply("java-gradle-plugin")
+        plugins.apply("com.gradle.plugin-publish")
+
+        testsDependOnCustomInstallation()
+
+        kotlinDslPlugins = container(KotlinDslPlugin::class.java)
+        extensions.add("kotlinDslPlugins", kotlinDslPlugins)
+
+        configureGradlePluginDevelopmentPlugins()
+
+        workAroundTestKitWithPluginClassPathIssues()
+    }
+
+    private
+    fun Project.testsDependOnCustomInstallation() =
+        tasks.withType(Test::class.java).all {
+            it.dependsOn(rootProject.tasks.getByName("customInstallation"))
+        }
+
+    private
+    fun Project.configureGradlePluginDevelopmentPlugins() {
+
+        pluginBundle {
+            tags = listOf("Kotlin", "DSL")
+            website = "https://github.com/gradle/kotlin-dsl"
+            vcsUrl = "https://github.com/gradle/kotlin-dsl"
+        }
+
+        afterEvaluate {
+
+            pluginBundle {
+                mavenCoordinates.artifactId = base.archivesBaseName
+            }
+
+            kotlinDslPlugins.all { plugin ->
+
+                gradlePlugin {
+                    plugins {
+                        it.create(plugin.name) {
+                            it.id = plugin.id
+                            it.implementationClass = plugin.implementationClass
+                        }
+                    }
+                }
+
+                pluginBundle {
+                    plugins {
+                        it.create(plugin.name) {
+                            it.id = plugin.id
+                            it.displayName = plugin.displayName
+                            it.description = plugin.displayName
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // TODO Remove work around for TestKit withPluginClassPath() issues
+    // See TODO ISSUE NUMBER
+    // Also see AbstractPluginTest
+    private
+    fun Project.workAroundTestKitWithPluginClassPathIssues() {
+
+        publishing {
+            repositories {
+                it.maven {
+                    it.name = "test"
+                    it.url = uri("$buildDir/repository")
+                }
+            }
+        }
+
+        val publishPluginsToTestRepository = tasks.create("publishPluginsToTestRepository").apply {
+            dependsOn("publishPluginMavenPublicationToTestRepository")
+        }
+
+        val processTestResources = tasks.getByName("processTestResources") as ProcessResources
+        val writeTestProperties = tasks.create("writeTestProperties", WriteProperties::class.java).apply {
+            outputFile = processTestResources.destinationDir.resolve("test.properties")
+            property("version", version)
+        }
+        processTestResources.dependsOn(writeTestProperties)
+
+        tasks.getByName("test").apply {
+            dependsOn(publishPluginsToTestRepository)
+        }
+
+        afterEvaluate {
+            kotlinDslPlugins.all {
+                publishPluginsToTestRepository
+                    .dependsOn("publish${it.name.capitalize()}PluginMarkerMavenPublicationToTestRepository")
+            }
+        }
+    }
+}
+
+
+private
+val Project.base
+    get() = convention.getPlugin(BasePluginConvention::class.java)
+
+
+private
+fun Project.publishing(action: PublishingExtension.() -> Unit) =
+    extensions.configure(PublishingExtension::class.java, action)
+
+
+private
+fun Project.gradlePlugin(action: GradlePluginDevelopmentExtension.() -> Unit) =
+    extensions.configure(GradlePluginDevelopmentExtension::class.java, action)
+
+
+private
+fun Project.pluginBundle(action: PluginBundleExtension.() -> Unit) =
+    extensions.configure(PluginBundleExtension::class.java, action)

--- a/buildSrc/src/main/kotlin/plugins/KotlinLibrary.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinLibrary.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.Coroutines
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+
 open class KotlinLibrary : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {

--- a/buildSrc/src/main/kotlin/plugins/KotlinLibrary.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinLibrary.kt
@@ -10,6 +10,7 @@ open class KotlinLibrary : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
 
         plugins.apply("kotlin")
+        plugins.apply("org.gradle.kotlin.ktlint-convention")
 
         kotlin {
             experimental.coroutines = Coroutines.ENABLE

--- a/plugins-experiments/.gitignore
+++ b/plugins-experiments/.gitignore
@@ -1,0 +1,2 @@
+/build
+/out

--- a/plugins-experiments/build.gradle.kts
+++ b/plugins-experiments/build.gradle.kts
@@ -1,0 +1,17 @@
+import build.futureKotlin
+
+plugins {
+    id("kotlin-dsl-plugin-bundle")
+}
+
+base {
+    archivesBaseName = "gradle-kotlin-dsl-plugins-experiments"
+}
+
+dependencies {
+    compileOnly(gradleKotlinDsl())
+
+    implementation(futureKotlin("stdlib-jdk8"))
+
+    testImplementation(project(":test-fixtures"))
+}

--- a/plugins-experiments/build.gradle.kts
+++ b/plugins-experiments/build.gradle.kts
@@ -70,6 +70,7 @@ val rulesetJar by tasks.creating(ShadowJar::class) {
 val rulesetChecksum by tasks.creating {
     dependsOn(rulesetJar)
     val rulesetChecksumFile = generatedResourcesRulesetJarDir.resolve(basePackagePath).resolve("gradle-kotlin-dsl-ruleset.md5")
+    inputs.file(rulesetJar.archivePath)
     outputs.file(rulesetChecksumFile)
     doLast {
         rulesetChecksumFile.parentFile.mkdirs()

--- a/plugins-experiments/build.gradle.kts
+++ b/plugins-experiments/build.gradle.kts
@@ -1,17 +1,80 @@
 import build.futureKotlin
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     id("kotlin-dsl-plugin-bundle")
+    id("com.github.johnrengelman.shadow") version "2.0.2"
 }
 
 base {
     archivesBaseName = "gradle-kotlin-dsl-plugins-experiments"
 }
 
+repositories {
+    gradlePluginPortal()
+}
+
 dependencies {
     compileOnly(gradleKotlinDsl())
 
+    implementation("gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.1.0")
     implementation(futureKotlin("stdlib-jdk8"))
 
     testImplementation(project(":test-fixtures"))
+}
+
+
+// plugins ------------------------------------------------------------
+
+kotlinDslPlugins {
+    create("ktlintConvention") {
+        displayName = "Gradle Kotlin DSL ktlint convention plugin (experimental)"
+        id = "org.gradle.kotlin.ktlint-convention"
+        implementationClass = "org.gradle.kotlin.dsl.experiments.plugins.GradleKotlinDslKtlintConventionPlugin"
+    }
+}
+
+
+// default versions ---------------------------------------------------
+
+val ktlintVersion = "0.19.0"
+
+val basePackagePath = "org/gradle/kotlin/dsl/experiments/plugins"
+val processResources: ProcessResources by tasks
+val writeDefaultVersionsProperties by tasks.creating(WriteProperties::class) {
+    outputFile = processResources.destinationDir.resolve("$basePackagePath/default-versions.properties")
+    property("ktlint", ktlintVersion)
+}
+processResources.dependsOn(writeDefaultVersionsProperties)
+
+
+// ktlint custom ruleset ----------------------------------------------
+
+java.sourceSets {
+    "ruleset"()
+}
+
+val rulesetShaded by configurations.creating
+val rulesetCompileOnly by configurations.getting {
+    extendsFrom(rulesetShaded)
+}
+
+val generatedResourcesRulesetJarDir = file("$buildDir/generated-resources/ruleset/resources")
+val rulesetJar by tasks.creating(ShadowJar::class) {
+    archiveName = "gradle-kotlin-dsl-ruleset.jar"
+    destinationDir = generatedResourcesRulesetJarDir.resolve(basePackagePath)
+    configurations = listOf(rulesetShaded)
+    from(java.sourceSets["ruleset"].output)
+}
+java.sourceSets["main"].output.dir(mapOf("builtBy" to rulesetJar), generatedResourcesRulesetJarDir)
+
+artifacts {
+    add("archives", rulesetJar)
+}
+
+dependencies {
+    rulesetShaded("com.github.shyiko.ktlint:ktlint-ruleset-standard:$ktlintVersion") {
+        isTransitive = false
+    }
+    rulesetCompileOnly("com.github.shyiko.ktlint:ktlint-core:$ktlintVersion")
 }

--- a/plugins-experiments/build.gradle.kts
+++ b/plugins-experiments/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     id("kotlin-dsl-plugin-bundle")
-    id("com.github.johnrengelman.shadow") version "2.0.2"
+    id("com.github.johnrengelman.shadow") version "2.0.2" apply false
 }
 
 base {

--- a/plugins-experiments/build.gradle.kts
+++ b/plugins-experiments/build.gradle.kts
@@ -68,10 +68,6 @@ val rulesetJar by tasks.creating(ShadowJar::class) {
 }
 java.sourceSets["main"].output.dir(mapOf("builtBy" to rulesetJar), generatedResourcesRulesetJarDir)
 
-artifacts {
-    add("archives", rulesetJar)
-}
-
 dependencies {
     rulesetShaded("com.github.shyiko.ktlint:ktlint-ruleset-standard:$ktlintVersion") {
         isTransitive = false

--- a/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -1,0 +1,135 @@
+package org.gradle.kotlin.dsl.experiments.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionListener
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskState
+
+import org.gradle.cache.internal.GeneratedGradleJarCache
+import org.gradle.internal.hash.Hashing
+import org.gradle.internal.logging.ConsoleRenderer
+
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
+import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.serviceOf
+
+
+private
+const val rulesetJarName = "gradle-kotlin-dsl-ruleset.jar"
+
+
+open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
+
+    override fun apply(project: Project): Unit = project.run {
+
+        plugins.apply("org.jlleitschuh.gradle.ktlint")
+
+        configure<KtlintExtension> {
+            version = DefaultVersions.ktlint
+            reporters = arrayOf(ReporterType.PLAIN)
+        }
+
+        val ktlint by configurations.creating {
+            exclude(module = "ktlint-ruleset-standard")
+        }
+
+        dependencies {
+            ktlint(files(gradleKotlinDslKtlintRulesetJar()))
+        }
+
+        afterEvaluate {
+            fixKtlintTasks()
+        }
+    }
+
+
+    private
+    fun Project.gradleKotlinDslKtlintRulesetJar() = provider {
+        val ruleset = this@GradleKotlinDslKtlintConventionPlugin.javaClass
+            .getResourceAsStream(rulesetJarName)!!.use { it.readBytes() }
+        val cacheKey = Hashing.md5().hashBytes(ruleset).toString()
+        serviceOf<GeneratedGradleJarCache>().get("ktlint-convention-ruleset-$cacheKey") { jar ->
+            jar.outputStream().use { it.write(ruleset) }
+        }
+    }
+
+
+    // TODO Report and fix upstream
+    // Note that below are workarounds, not how things should be fixed upstream
+    private
+    fun Project.fixKtlintTasks() {
+        val reporters = the<KtlintExtension>().reporters
+        val ktLintCheckTasks = collectKtLintCheckTasks()
+        fixKtlintCheckTaskCacheability(ktLintCheckTasks, reporters)
+        displayLinkToReportsOnFailure(ktLintCheckTasks, reporters)
+    }
+
+
+    private
+    fun Project.collectKtLintCheckTasks() =
+        the<JavaPluginConvention>().sourceSets.mapNotNull { sourceSet ->
+            (tasks.findByName("ktlint${sourceSet.name.capitalize()}Check") as? JavaExec)?.let { task ->
+                Pair(sourceSet, task)
+            }
+        }
+
+
+    private
+    fun Project.fixKtlintCheckTaskCacheability(
+        tasksBySourceSets: List<Pair<SourceSet, JavaExec>>,
+        reporters: Array<ReporterType>
+    ) =
+
+        tasksBySourceSets.forEach { (sourceSet, task) ->
+
+            sourceSet.allSource.sourceDirectories.forEach { srcDir ->
+                task.inputs.property(
+                    "kt files from $srcDir",
+                    files(srcDir).asFileTree.matching {
+                        it.include("**/*.kt")
+                    }
+                )
+                reporters.forEach {
+                    task.outputs.file("$buildDir/${it.reportPathFor(sourceSet)}")
+                }
+                task.outputs.cacheIf { true }
+            }
+        }
+
+
+    private
+    fun Project.displayLinkToReportsOnFailure(
+        tasksBySourceSets: List<Pair<SourceSet, JavaExec>>,
+        reporters: Array<ReporterType>
+    ) =
+
+        gradle.taskGraph.addTaskExecutionListener(object : TaskExecutionListener {
+
+            val consoleRenderer = ConsoleRenderer()
+
+            override fun beforeExecute(aTask: Task) = Unit
+
+            override fun afterExecute(aTask: Task, state: TaskState) {
+                if (state.failure != null) {
+                    tasksBySourceSets.find { it.second == aTask }?.let { (sourceSet, _) ->
+                        val message = "ktlint check failed\n\n" + reporters.map {
+                            file("$buildDir/${it.reportPathFor(sourceSet)}")
+                        }.joinToString(separator = "\n") {
+                            consoleRenderer.asClickableFileUrl(it).prependIndent()
+                        } + '\n'
+                        logger.error(message)
+                    }
+                }
+            }
+        })
+
+    private
+    fun ReporterType.reportPathFor(sourceSet: SourceSet) =
+        "reports/ktlint/ktlint-${sourceSet.name}.$fileExtension"
+}

--- a/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -19,15 +19,17 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.serviceOf
 
 
-private
-val rulesetJar = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.jar")
-
-
-private
-val rulesetChecksum = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.md5").readText()
-
-
 open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
+
+    companion object {
+
+        private
+        val rulesetJar = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.jar")
+
+
+        private
+        val rulesetChecksum = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.md5").readText()
+    }
 
     override fun apply(project: Project): Unit = project.run {
 

--- a/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -19,17 +19,19 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.serviceOf
 
 
+private
+val rulesetChecksum by lazy {
+    GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.md5").readText()
+}
+
+
+private
+val rulesetJar by lazy {
+    GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.jar")
+}
+
+
 open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
-
-    companion object {
-
-        private
-        val rulesetJar = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.jar")
-
-
-        private
-        val rulesetChecksum = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.md5").readText()
-    }
 
     override fun apply(project: Project): Unit = project.run {
 

--- a/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -60,8 +60,9 @@ open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
     }
 
 
-    // TODO Report and fix upstream
     // Note that below are workarounds, not how things should be fixed upstream
+    // https://github.com/JLLeitschuh/ktlint-gradle/issues/67
+    // https://github.com/JLLeitschuh/ktlint-gradle/issues/51
     private
     fun Project.fixKtlintTasks() {
         val reporters = the<KtlintExtension>().reporters

--- a/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -10,7 +10,6 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskState
 
 import org.gradle.cache.internal.GeneratedGradleJarCache
-import org.gradle.internal.hash.Hashing
 import org.gradle.internal.logging.ConsoleRenderer
 
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
@@ -21,7 +20,11 @@ import org.gradle.kotlin.dsl.support.serviceOf
 
 
 private
-const val rulesetJarName = "gradle-kotlin-dsl-ruleset.jar"
+val rulesetJar = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.jar")
+
+
+private
+val rulesetChecksum = GradleKotlinDslKtlintConventionPlugin::class.java.getResource("gradle-kotlin-dsl-ruleset.md5").readText()
 
 
 open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
@@ -51,11 +54,8 @@ open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
 
     private
     fun Project.gradleKotlinDslKtlintRulesetJar() = provider {
-        val ruleset = this@GradleKotlinDslKtlintConventionPlugin.javaClass
-            .getResourceAsStream(rulesetJarName)!!.use { it.readBytes() }
-        val cacheKey = Hashing.md5().hashBytes(ruleset).toString()
-        serviceOf<GeneratedGradleJarCache>().get("ktlint-convention-ruleset-$cacheKey") { jar ->
-            jar.outputStream().use { it.write(ruleset) }
+        serviceOf<GeneratedGradleJarCache>().get("ktlint-convention-ruleset-$rulesetChecksum") { jar ->
+            jar.outputStream().use { it.write(rulesetJar.readBytes()) }
         }
     }
 

--- a/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/default-versions.kt
+++ b/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/default-versions.kt
@@ -1,0 +1,19 @@
+package org.gradle.kotlin.dsl.experiments.plugins
+
+import java.util.Properties
+
+
+internal
+object DefaultVersions {
+
+    val ktlint: String by DEFAULT_VERSIONS
+}
+
+
+private
+val DEFAULT_VERSIONS =
+    Properties().also { props ->
+        DefaultVersions::javaClass.get().getResourceAsStream("default-versions.properties")!!.use { input ->
+            props.load(input)
+        }
+    }

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/BlankLinesRule.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/BlankLinesRule.kt
@@ -1,0 +1,57 @@
+package org.gradle.kotlin.dsl.ktlint.ruleset
+
+import com.github.shyiko.ktlint.core.Rule
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+
+class BlankLinesRule : Rule("gradle-kotlin-dsl-blank-lines") {
+
+    private
+    var skippedFirstTopLevelWhiteSpace = false
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+
+        if (node is PsiWhiteSpace) {
+
+            val split = node.getText().split("\n")
+
+            // Not more than 2 blank lines anywhere in the file
+            if (split.size > 4 || split.size == 3 && PsiTreeUtil.nextLeaf(node) == null /* eof */) {
+                emit(node.startOffset + split[0].length + split[1].length + 2, "Needless blank line(s)", true)
+                if (autoCorrect) {
+                    (node as LeafPsiElement)
+                        .rawReplaceWithText("${split.first()}\n${if (split.size > 3) "\n" else ""}${split.last()}")
+                }
+            }
+
+            // Two blank lines before top level elements
+            if (node.treeParent.elementType == KtStubElementTypes.FILE) {
+                if (!skippedFirstTopLevelWhiteSpace) {
+                    skippedFirstTopLevelWhiteSpace = true
+                    return
+                }
+                if (node.treeNext != null
+                    && node.treeNext.elementType != KtStubElementTypes.IMPORT_LIST
+                    && PsiTreeUtil.nextLeaf(node) != null /* not oef */
+                ) {
+                    if (split.size < 4) {
+                        emit(
+                            node.startOffset,
+                            "Top level elements must be separated by two blank lines",
+                            false
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/BlankLinesRule.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/BlankLinesRule.kt
@@ -41,8 +41,7 @@ class BlankLinesRule : Rule("gradle-kotlin-dsl-blank-lines") {
                 }
                 if (node.treeNext != null
                     && node.treeNext.elementType != KtStubElementTypes.IMPORT_LIST
-                    && PsiTreeUtil.nextLeaf(node) != null /* not oef */
-                ) {
+                    && PsiTreeUtil.nextLeaf(node) != null /* not oef */) {
                     if (split.size < 4) {
                         emit(
                             node.startOffset,

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/CustomChainWrappingRule.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/CustomChainWrappingRule.kt
@@ -1,0 +1,54 @@
+package org.gradle.kotlin.dsl.ktlint.ruleset
+
+import com.github.shyiko.ktlint.core.Rule
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.psiUtil.nextLeaf
+import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
+
+
+// Same as upstream except it doesn't have checks for "same line tokens"
+class CustomChainWrappingRule : Rule("gradle-kotlin-dsl-chain-wrapping") {
+
+    private
+    val nextLineTokens = TokenSet.create(KtTokens.DOT, KtTokens.SAFE_ACCESS, KtTokens.ELVIS)
+
+    private
+    val noSpaceAroundTokens = TokenSet.create(KtTokens.DOT, KtTokens.SAFE_ACCESS)
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        /*
+           org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement (DOT) | "."
+           org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl (WHITE_SPACE) | "\n        "
+           org.jetbrains.kotlin.psi.KtCallExpression (CALL_EXPRESSION)
+         */
+        val elementType = node.elementType
+        if (nextLineTokens.contains(elementType)) {
+            val nextLeaf = node.psi.nextLeaf(true)
+            if (nextLeaf is PsiWhiteSpaceImpl && nextLeaf.textContains('\n')) {
+                emit(node.startOffset, "Line must not end with \"${node.text}\"", true)
+                if (autoCorrect) {
+                    val prevLeaf = node.psi.prevLeaf(true)
+                    if (prevLeaf is PsiWhiteSpaceImpl) {
+                        prevLeaf.rawReplaceWithText(nextLeaf.text)
+                    } else {
+                        (node.psi as LeafPsiElement).rawInsertBeforeMe(PsiWhiteSpaceImpl(nextLeaf.text))
+                    }
+                    if (noSpaceAroundTokens.contains(elementType)) {
+                        nextLeaf.node.treeParent.removeChild(nextLeaf.node)
+                    } else {
+                        nextLeaf.rawReplaceWithText(" ")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/CustomImportsRule.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/CustomImportsRule.kt
@@ -1,0 +1,37 @@
+package org.gradle.kotlin.dsl.ktlint.ruleset
+
+import com.github.shyiko.ktlint.core.Rule
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+
+private
+val allowedWildcardImports = listOf(
+
+    "java.util.*",
+    "org.gradle.kotlin.dsl.*",
+
+    "org.junit.Assert.*",
+    "org.hamcrest.CoreMatchers.*",
+    "com.nhaarman.mockito_kotlin.*"
+)
+
+
+class CustomImportsRule : Rule("gradle-kotlin-dsl-imports") {
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.elementType == KtStubElementTypes.IMPORT_DIRECTIVE) {
+            val importDirective = node.psi as KtImportDirective
+            val path = importDirective.importPath?.pathStr
+            if (path != null && path.contains('*') && path !in allowedWildcardImports) {
+                emit(node.startOffset, "Wildcard import not allowed ($path)", false)
+            }
+        }
+    }
+}

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/GradleKotlinDslRuleSetProvider.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/GradleKotlinDslRuleSetProvider.kt
@@ -1,0 +1,82 @@
+package org.gradle.kotlin.dsl.ktlint.ruleset
+
+import com.github.shyiko.ktlint.core.RuleSet
+import com.github.shyiko.ktlint.core.RuleSetProvider
+import com.github.shyiko.ktlint.ruleset.standard.FinalNewlineRule
+import com.github.shyiko.ktlint.ruleset.standard.IndentationRule
+import com.github.shyiko.ktlint.ruleset.standard.MaxLineLengthRule
+import com.github.shyiko.ktlint.ruleset.standard.ModifierOrderRule
+import com.github.shyiko.ktlint.ruleset.standard.NoBlankLineBeforeRbraceRule
+import com.github.shyiko.ktlint.ruleset.standard.NoEmptyClassBodyRule
+import com.github.shyiko.ktlint.ruleset.standard.NoLineBreakAfterElseRule
+import com.github.shyiko.ktlint.ruleset.standard.NoLineBreakBeforeAssignmentRule
+import com.github.shyiko.ktlint.ruleset.standard.NoMultipleSpacesRule
+import com.github.shyiko.ktlint.ruleset.standard.NoSemicolonsRule
+import com.github.shyiko.ktlint.ruleset.standard.NoTrailingSpacesRule
+import com.github.shyiko.ktlint.ruleset.standard.NoUnitReturnRule
+import com.github.shyiko.ktlint.ruleset.standard.NoUnusedImportsRule
+import com.github.shyiko.ktlint.ruleset.standard.ParameterListWrappingRule
+import com.github.shyiko.ktlint.ruleset.standard.SpacingAroundColonRule
+import com.github.shyiko.ktlint.ruleset.standard.SpacingAroundCommaRule
+import com.github.shyiko.ktlint.ruleset.standard.SpacingAroundCurlyRule
+import com.github.shyiko.ktlint.ruleset.standard.SpacingAroundKeywordRule
+import com.github.shyiko.ktlint.ruleset.standard.SpacingAroundOperatorsRule
+import com.github.shyiko.ktlint.ruleset.standard.SpacingAroundRangeOperatorRule
+import com.github.shyiko.ktlint.ruleset.standard.StringTemplateRule
+
+
+/**
+ * Gradle Kotlin DSL ktlint RuleSetProvider.
+ *
+ * Reuse ktlint-standard-ruleset rules and add custom ones.
+ */
+class GradleKotlinDslRuleSetProvider : RuleSetProvider {
+
+    override fun get(): RuleSet =
+        RuleSet(
+            "gradle-kotlin-dsl",
+
+            // ktlint standard ruleset rules --------------------------
+            // See https://github.com/shyiko/ktlint/blob/master/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+
+            // kotlin-dsl: disabled in favor of CustomChainWrappingRule
+            // ChainWrappingRule(),
+            FinalNewlineRule(),
+            // disabled until it's clear how to reconcile difference in Intellij & Android Studio import layout
+            // ImportOrderingRule(),
+            IndentationRule(),
+            MaxLineLengthRule(),
+            ModifierOrderRule(),
+            NoBlankLineBeforeRbraceRule(),
+            // kotlin-dsl disabled in favor of BlankLinesRule
+            // NoConsecutiveBlankLinesRule(),
+            NoEmptyClassBodyRule(),
+            // disabled until it's clear what to do in case of `import _.it`
+            // NoItParamInMultilineLambdaRule(),
+            NoLineBreakAfterElseRule(),
+            NoLineBreakBeforeAssignmentRule(),
+            NoMultipleSpacesRule(),
+            NoSemicolonsRule(),
+            NoTrailingSpacesRule(),
+            NoUnitReturnRule(),
+            NoUnusedImportsRule(),
+            // kotlin-dsl: disabled in favor of CustomImportsRule
+            // NoWildcardImportsRule(),
+            ParameterListWrappingRule(),
+            SpacingAroundColonRule(),
+            SpacingAroundCommaRule(),
+            SpacingAroundCurlyRule(),
+            SpacingAroundKeywordRule(),
+            SpacingAroundOperatorsRule(),
+            SpacingAroundRangeOperatorRule(),
+            StringTemplateRule(),
+
+            // gradle-kotlin-dsl rules --------------------------------
+
+            BlankLinesRule(),
+            CustomChainWrappingRule(),
+            CustomImportsRule(),
+            VisibilityModifiersOwnLineRule(),
+            PropertyAccessorOnNewLine()
+        )
+}

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/PropertyAccessorOnNewLine.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/PropertyAccessorOnNewLine.kt
@@ -1,0 +1,23 @@
+package org.gradle.kotlin.dsl.ktlint.ruleset
+
+import com.github.shyiko.ktlint.core.Rule
+import org.jetbrains.kotlin.KtNodeTypes
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+
+class PropertyAccessorOnNewLine : Rule("property-get-new-line") {
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.elementType == KtNodeTypes.PROPERTY_ACCESSOR) {
+            if (!node.treePrev.text.contains("\n")) {
+                // fail
+                emit(node.startOffset, "Property accessor must be on a new line", false)
+            }
+        }
+    }
+}

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/PropertyAccessorOnNewLine.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/PropertyAccessorOnNewLine.kt
@@ -15,7 +15,6 @@ class PropertyAccessorOnNewLine : Rule("property-get-new-line") {
     ) {
         if (node.elementType == KtNodeTypes.PROPERTY_ACCESSOR) {
             if (!node.treePrev.text.contains("\n")) {
-                // fail
                 emit(node.startOffset, "Property accessor must be on a new line", false)
             }
         }

--- a/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/VisibilityModifiersOwnLineRule.kt
+++ b/plugins-experiments/src/ruleset/kotlin/org/gradle/kotlin/dsl/ktlint/ruleset/VisibilityModifiersOwnLineRule.kt
@@ -1,0 +1,92 @@
+package org.gradle.kotlin.dsl.ktlint.ruleset
+
+import com.github.shyiko.ktlint.core.Rule
+
+import org.jetbrains.kotlin.KtNodeTypes.PRIMARY_CONSTRUCTOR
+import org.jetbrains.kotlin.KtNodeTypes.VALUE_PARAMETER
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.lexer.KtTokens.WHITE_SPACE
+import org.jetbrains.kotlin.psi.KtDeclarationModifierList
+
+
+class VisibilityModifiersOwnLineRule : Rule("visibility-modifiers-own-line") {
+
+    private
+    val ownSingleLineModifierTokens = arrayOf(
+        KtTokens.PUBLIC_KEYWORD, KtTokens.PROTECTED_KEYWORD, KtTokens.PRIVATE_KEYWORD, KtTokens.INTERNAL_KEYWORD
+    )
+
+    private
+    val order = arrayOf(
+        KtTokens.PUBLIC_KEYWORD,
+        KtTokens.PROTECTED_KEYWORD,
+        KtTokens.PRIVATE_KEYWORD,
+        KtTokens.INTERNAL_KEYWORD,
+        KtTokens.EXPECT_KEYWORD,
+        KtTokens.ACTUAL_KEYWORD,
+        KtTokens.FINAL_KEYWORD,
+        KtTokens.OPEN_KEYWORD,
+        KtTokens.ABSTRACT_KEYWORD,
+        KtTokens.SEALED_KEYWORD,
+        KtTokens.CONST_KEYWORD,
+        KtTokens.EXTERNAL_KEYWORD,
+        KtTokens.OVERRIDE_KEYWORD,
+        KtTokens.LATEINIT_KEYWORD,
+        KtTokens.TAILREC_KEYWORD,
+        KtTokens.VARARG_KEYWORD,
+        KtTokens.SUSPEND_KEYWORD,
+        KtTokens.INNER_KEYWORD,
+        KtTokens.ENUM_KEYWORD,
+        KtTokens.ANNOTATION_KEYWORD,
+        KtTokens.COMPANION_KEYWORD,
+        KtTokens.INLINE_KEYWORD,
+        KtTokens.INFIX_KEYWORD,
+        KtTokens.OPERATOR_KEYWORD,
+        KtTokens.DATA_KEYWORD
+        // NOINLINE_KEYWORD, CROSSINLINE_KEYWORD, OUT_KEYWORD, IN_KEYWORD, REIFIED_KEYWORD
+        // HEADER_KEYWORD, IMPL_KEYWORD
+    )
+
+    private
+    val tokenSet = TokenSet.create(*order)
+
+    private
+    val skippedParents = listOf(PRIMARY_CONSTRUCTOR, VALUE_PARAMETER)
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+
+        if (node.psi is KtDeclarationModifierList && node.treeParent.elementType !in skippedParents) {
+
+            val modifierArr = node.getChildren(tokenSet)
+
+            val vizModifiers = modifierArr.filter { it.elementType in ownSingleLineModifierTokens }
+
+            if (vizModifiers.isNotEmpty()) {
+
+                val vizModifierExpectedText = vizModifiers.joinToString(separator = " ", postfix = "\n") { it.text }
+
+                if (!node.textIncludingSurroundingWhitespace.contains(vizModifierExpectedText)) {
+                    emit(
+                        node.startOffset,
+                        "Visibility modifiers must be on their own single line",
+                        false
+                    )
+                }
+            }
+        }
+    }
+
+    private
+    val ASTNode.textIncludingSurroundingWhitespace
+        get() = "${
+        if (treePrev?.elementType == WHITE_SPACE) treePrev.text else ""
+        }$text${
+        if (treeNext?.elementType == WHITE_SPACE) treeNext.text else ""
+        }"
+}

--- a/plugins-experiments/src/ruleset/resources/META-INF/services/com.github.shyiko.ktlint.core.RuleSetProvider
+++ b/plugins-experiments/src/ruleset/resources/META-INF/services/com.github.shyiko.ktlint.core.RuleSetProvider
@@ -1,0 +1,1 @@
+org.gradle.kotlin.dsl.ktlint.ruleset.GradleKotlinDslRuleSetProvider

--- a/plugins-experiments/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
+++ b/plugins-experiments/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
@@ -140,14 +140,32 @@ class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
         assertKtLintError("Needless blank line(s)", 10, 1)
 
         withSource("""
+            /*
+             * Copyright 2016 the original author or authors.
+             */
+
+            // Random words
+            @file:JvmName("Something")
+
+            /**
+             * Package kdoc.
+             */
             package some
 
             import org.gradle.kotlin.dsl.*
 
 
+            /*
+             * Some file documentation.
+             */
+
+
             val foo = "bar"
 
 
+            /**
+             * Interface kdoc.
+             */
             interface Foo
 
 

--- a/plugins-experiments/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
+++ b/plugins-experiments/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
@@ -16,18 +16,16 @@ class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
 
     @Before
     fun setup() {
-        withBuildScript(
-            """
-                plugins {
-                    kotlin("jvm") version "1.2.30"
-                    id("org.gradle.kotlin.ktlint-convention")
-                }
+        withBuildScript("""
+            plugins {
+                kotlin("jvm") version "1.2.30"
+                id("org.gradle.kotlin.ktlint-convention")
+            }
 
-                repositories {
-                    jcenter()
-                }
-            """
-        )
+            repositories {
+                jcenter()
+            }
+        """)
     }
 
     @Test
@@ -56,47 +54,43 @@ class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
     @Test
     fun `visibility modifiers on their own single line`() {
 
-        withSource(
-            """
+        withSource("""
 
-                private val bar = false
+            private val bar = false
 
 
-                class Bazar(private val name: String) {
+            class Bazar(private val name: String) {
 
-                    private lateinit
-                    var description: String
+                private lateinit
+                var description: String
 
-                    private inline
-                    fun something() = Unit
-                }
-            """
-        )
+                private inline
+                fun something() = Unit
+            }
+        """)
 
         buildAndFail("ktlintMainCheck")
 
         assertKtlintErrors(3)
-        assertKtLintError("Visibility modifiers must be on their own single line", 3, 17)
-        assertKtLintError("Visibility modifiers must be on their own single line", 8, 21)
-        assertKtLintError("Visibility modifiers must be on their own single line", 11, 21)
+        assertKtLintError("Visibility modifiers must be on their own single line", 3, 13)
+        assertKtLintError("Visibility modifiers must be on their own single line", 8, 17)
+        assertKtLintError("Visibility modifiers must be on their own single line", 11, 17)
 
-        withSource(
-            """
+        withSource("""
+
+            private
+            val bar = false
+
+
+            class Bazar(private val name: String) {
 
                 private
-                val bar = false
+                lateinit var description: String
 
-
-                class Bazar(private val name: String) {
-
-                    private
-                    lateinit var description: String
-
-                    private
-                    inline fun something() = Unit
-                }
-            """
-        )
+                private
+                inline fun something() = Unit
+            }
+        """)
 
         build("ktlintMainCheck")
     }
@@ -104,70 +98,64 @@ class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
     @Test
     fun `allowed wildcard imports`() {
 
-        withSource(
-            """
+        withSource("""
 
-                import java.util.*
-                import org.w3c.dom.*
+            import java.util.*
+            import org.w3c.dom.*
 
-                import org.gradle.kotlin.dsl.*
-                """
-        )
+            import org.gradle.kotlin.dsl.*
+        """)
 
         buildAndFail("ktlintMainCheck")
 
         assertKtlintErrors(1)
-        assertKtLintError("Wildcard import not allowed (org.w3c.dom.*)", 4, 17)
+        assertKtLintError("Wildcard import not allowed (org.w3c.dom.*)", 4, 13)
     }
 
     @Test
     fun `blank lines`() {
 
-        withSource(
-            """
-                package some
+        withSource("""
+            package some
 
-                import org.gradle.kotlin.dsl.*
+            import org.gradle.kotlin.dsl.*
 
-                val foo = "bar"
+            val foo = "bar"
 
-                interface Foo
-
+            interface Foo
 
 
-                object Bar
+
+            object Bar
 
 
-                data class Some(val name: String)
-                """
-        )
+            data class Some(val name: String)
+        """)
 
         buildAndFail("ktlintMainCheck")
 
         assertKtlintErrors(3)
-        assertKtLintError("Top level elements must be separated by two blank lines", 4, 47)
-        assertKtLintError("Top level elements must be separated by two blank lines", 6, 32)
+        assertKtLintError("Top level elements must be separated by two blank lines", 4, 43)
+        assertKtLintError("Top level elements must be separated by two blank lines", 6, 28)
         assertKtLintError("Needless blank line(s)", 10, 1)
 
-        withSource(
-            """
-                package some
+        withSource("""
+            package some
 
-                import org.gradle.kotlin.dsl.*
-
-
-                val foo = "bar"
+            import org.gradle.kotlin.dsl.*
 
 
-                interface Foo
+            val foo = "bar"
 
 
-                object Bar
+            interface Foo
 
 
-                data class Some(val name: String)
-                """
-        )
+            object Bar
+
+
+            data class Some(val name: String)
+        """)
 
         build("ktlintMainCheck")
     }
@@ -175,13 +163,11 @@ class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
     @Test
     fun `new lines starting with ANDAND are allowed`() {
 
-        withSource(
-            """
+        withSource("""
 
-                val foo = "bar".isNotEmpty()
-                    && "bazar".isNotEmpty() // either
-            """
-        )
+            val foo = "bar".isNotEmpty()
+                && "bazar".isNotEmpty() // either
+        """)
 
         build("ktlintMainCheck")
     }
@@ -189,33 +175,29 @@ class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
     @Test
     fun `property accessors on new line`() {
 
-        withSource(
-            """
+        withSource("""
 
-            val foo get() = "bar"
+        val foo get() = "bar"
 
 
-            val bar: String get() { return "bar" }
-            """
-        )
+        val bar: String get() { return "bar" }
+    """)
 
         buildAndFail("ktlintMainCheck")
 
         assertKtlintErrors(2)
-        assertKtLintError("Property accessor must be on a new line", 3, 21)
-        assertKtLintError("Property accessor must be on a new line", 6, 29)
+        assertKtLintError("Property accessor must be on a new line", 3, 17)
+        assertKtLintError("Property accessor must be on a new line", 6, 25)
 
-        withSource(
-            """
+        withSource("""
 
-            val foo
-                get() = "bar"
+        val foo
+            get() = "bar"
 
 
-            val bar: String
-                get() { return "bar" }
-            """
-        )
+        val bar: String
+            get() { return "bar" }
+    """)
 
         build("ktlintMainCheck")
     }
@@ -233,16 +215,11 @@ class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
         assertThat(
             "ktlint error count",
             ktlintReportFile.readLines().filter { it.contains("source.kt:") }.count(),
-            equalTo(
-                count
-            )
-        )
+            equalTo(count))
 
     private
-    fun assertKtLintError(error: String, line: Int, column: Int) {
+    fun assertKtLintError(error: String, line: Int, column: Int) =
         assertThat(
             ktlintReportFile.readText(),
-            containsString("source.kt:$line:$column: $error")
-        )
-    }
+            containsString("source.kt:$line:$column: $error"))
 }

--- a/plugins-experiments/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
+++ b/plugins-experiments/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
@@ -1,0 +1,248 @@
+package org.gradle.kotlin.dsl.experiments.plugins
+
+import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
+
+import org.gradle.testkit.runner.TaskOutcome
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.containsString
+
+import org.junit.Assert.assertThat
+import org.junit.Before
+import org.junit.Test
+
+
+class GradleKotlinDslKtlintConventionPluginTest : AbstractPluginTest() {
+
+    @Before
+    fun setup() {
+        withBuildScript(
+            """
+                plugins {
+                    kotlin("jvm") version "1.2.30"
+                    id("org.gradle.kotlin.ktlint-convention")
+                }
+
+                repositories {
+                    jcenter()
+                }
+            """
+        )
+    }
+
+    @Test
+    fun `ktlint check tasks are cacheable`() {
+
+        withSource("""val foo = "bar"""")
+
+        build("ktlintMainCheck", "--build-cache").apply {
+
+            assertThat(outcomeOf(":ktlintMainCheck"), equalTo(TaskOutcome.SUCCESS))
+        }
+
+        build("ktlintMainCheck", "--build-cache").apply {
+
+            assertThat(outcomeOf(":ktlintMainCheck"), equalTo(TaskOutcome.UP_TO_DATE))
+        }
+
+        build("clean")
+
+        build("ktlintMainCheck", "--build-cache").apply {
+
+            assertThat(outcomeOf(":ktlintMainCheck"), equalTo(TaskOutcome.FROM_CACHE))
+        }
+    }
+
+    @Test
+    fun `visibility modifiers on their own single line`() {
+
+        withSource(
+            """
+
+                private val bar = false
+
+
+                class Bazar(private val name: String) {
+
+                    private lateinit
+                    var description: String
+
+                    private inline
+                    fun something() = Unit
+                }
+            """
+        )
+
+        buildAndFail("ktlintMainCheck")
+
+        assertKtlintErrors(3)
+        assertKtLintError("Visibility modifiers must be on their own single line", 3, 17)
+        assertKtLintError("Visibility modifiers must be on their own single line", 8, 21)
+        assertKtLintError("Visibility modifiers must be on their own single line", 11, 21)
+
+        withSource(
+            """
+
+                private
+                val bar = false
+
+
+                class Bazar(private val name: String) {
+
+                    private
+                    lateinit var description: String
+
+                    private
+                    inline fun something() = Unit
+                }
+            """
+        )
+
+        build("ktlintMainCheck")
+    }
+
+    @Test
+    fun `allowed wildcard imports`() {
+
+        withSource(
+            """
+
+                import java.util.*
+                import org.w3c.dom.*
+
+                import org.gradle.kotlin.dsl.*
+                """
+        )
+
+        buildAndFail("ktlintMainCheck")
+
+        assertKtlintErrors(1)
+        assertKtLintError("Wildcard import not allowed (org.w3c.dom.*)", 4, 17)
+    }
+
+    @Test
+    fun `blank lines`() {
+
+        withSource(
+            """
+                package some
+
+                import org.gradle.kotlin.dsl.*
+
+                val foo = "bar"
+
+                interface Foo
+
+
+
+                object Bar
+
+
+                data class Some(val name: String)
+                """
+        )
+
+        buildAndFail("ktlintMainCheck")
+
+        assertKtlintErrors(3)
+        assertKtLintError("Top level elements must be separated by two blank lines", 4, 47)
+        assertKtLintError("Top level elements must be separated by two blank lines", 6, 32)
+        assertKtLintError("Needless blank line(s)", 10, 1)
+
+        withSource(
+            """
+                package some
+
+                import org.gradle.kotlin.dsl.*
+
+
+                val foo = "bar"
+
+
+                interface Foo
+
+
+                object Bar
+
+
+                data class Some(val name: String)
+                """
+        )
+
+        build("ktlintMainCheck")
+    }
+
+    @Test
+    fun `new lines starting with ANDAND are allowed`() {
+
+        withSource(
+            """
+
+                val foo = "bar".isNotEmpty()
+                    && "bazar".isNotEmpty() // either
+            """
+        )
+
+        build("ktlintMainCheck")
+    }
+
+    @Test
+    fun `property accessors on new line`() {
+
+        withSource(
+            """
+
+            val foo get() = "bar"
+
+
+            val bar: String get() { return "bar" }
+            """
+        )
+
+        buildAndFail("ktlintMainCheck")
+
+        assertKtlintErrors(2)
+        assertKtLintError("Property accessor must be on a new line", 3, 21)
+        assertKtLintError("Property accessor must be on a new line", 6, 29)
+
+        withSource(
+            """
+
+            val foo
+                get() = "bar"
+
+
+            val bar: String
+                get() { return "bar" }
+            """
+        )
+
+        build("ktlintMainCheck")
+    }
+
+
+    private
+    fun withSource(text: String) =
+        withFile("src/main/kotlin/source.kt", text)
+
+    private
+    val ktlintReportFile by lazy { existing("build/reports/ktlint/ktlint-main.txt") }
+
+    private
+    fun assertKtlintErrors(count: Int) =
+        assertThat(
+            "ktlint error count",
+            ktlintReportFile.readLines().filter { it.contains("source.kt:") }.count(),
+            equalTo(
+                count
+            )
+        )
+
+    private
+    fun assertKtLintError(error: String, line: Int, column: Int) {
+        assertThat(
+            ktlintReportFile.readText(),
+            containsString("source.kt:$line:$column: $error")
+        )
+    }
+}

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -1,10 +1,7 @@
 import build.futureKotlin
 
 plugins {
-    id("kotlin-dsl-module")
-    `maven-publish`
-    `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "0.9.10"
+    id("kotlin-dsl-plugin-bundle")
 }
 
 base {
@@ -22,76 +19,17 @@ dependencies {
 }
 
 
-// --- Plugins declaration ----------------------------------------------
+// plugins ------------------------------------------------------------
 
-data class GradlePlugin(val displayName: String, val id: String, val implementationClass: String)
-
-val plugins = listOf(
-    GradlePlugin(
-        "Embedded Kotlin Gradle Plugin",
-        "org.gradle.kotlin.embedded-kotlin",
-        "org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin"),
-    GradlePlugin(
-        "Gradle Kotlin DSL Plugin",
-        "org.gradle.kotlin.kotlin-dsl",
-        "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPlugin"))
-
-plugins.forEach { plugin ->
-
-    gradlePlugin {
-        (plugins) {
-            plugin.id {
-                id = plugin.id
-                implementationClass = plugin.implementationClass
-            }
-        }
+kotlinDslPlugins {
+    create("embeddedKotlin") {
+        displayName = "Embedded Kotlin Gradle Plugin"
+        id = "org.gradle.kotlin.embedded-kotlin"
+        implementationClass = "org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin"
     }
-
-    pluginBundle {
-        tags = listOf("Kotlin", "DSL")
-        website = "https://github.com/gradle/kotlin-dsl"
-        vcsUrl = "https://github.com/gradle/kotlin-dsl"
-        mavenCoordinates.artifactId = base.archivesBaseName
-        (plugins) {
-            plugin.id {
-                id = plugin.id
-                displayName = plugin.displayName
-                description = plugin.displayName
-            }
-        }
-    }
-}
-
-publishing {
-    repositories {
-        maven(url = "build/repository") {
-            name = "test"
-        }
-    }
-}
-
-val customInstallation by rootProject.tasks
-tasks {
-
-    val publishPluginsToTestRepository by creating {
-        dependsOn("publishPluginMavenPublicationToTestRepository")
-        dependsOn(
-            plugins.map {
-                "publish${it.id.capitalize()}PluginMarkerMavenPublicationToTestRepository"
-            })
-    }
-
-    val processTestResources: ProcessResources by getting
-
-    val writeTestProperties by creating(WriteProperties::class) {
-        outputFile = File(processTestResources.destinationDir, "test.properties")
-        property("version", version)
-    }
-
-    processTestResources.dependsOn(writeTestProperties)
-
-    "test" {
-        dependsOn(customInstallation)
-        dependsOn(publishPluginsToTestRepository)
+    create("kotlinDsl") {
+        displayName = "Gradle Kotlin DSL Plugin"
+        id = "org.gradle.kotlin.kotlin-dsl"
+        implementationClass = "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPlugin"
     }
 }

--- a/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -34,7 +34,8 @@ import javax.inject.Inject
  * and pins them to the embedded Kotlin version.
  */
 open class EmbeddedKotlinPlugin @Inject internal constructor(
-    private val embeddedKotlin: EmbeddedKotlinProvider) : Plugin<Project> {
+    private val embeddedKotlin: EmbeddedKotlinProvider
+) : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.run {

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -2,7 +2,7 @@ package org.gradle.kotlin.dsl.plugins.dsl
 
 import org.gradle.kotlin.dsl.fixtures.customDaemonRegistry
 import org.gradle.kotlin.dsl.fixtures.customInstallation
-import org.gradle.kotlin.dsl.plugins.AbstractPluginTest
+import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 
 import org.gradle.testkit.runner.TaskOutcome
 

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/PrecompiledScriptPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/PrecompiledScriptPluginTest.kt
@@ -7,10 +7,9 @@ import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 
+import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
 import org.gradle.kotlin.dsl.fixtures.classLoaderFor
-
-import org.gradle.kotlin.dsl.plugins.AbstractPluginTest
 
 import org.gradle.kotlin.dsl.precompile.PrecompiledInitScript
 import org.gradle.kotlin.dsl.precompile.PrecompiledProjectScript

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/PrecompiledScriptPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/PrecompiledScriptPluginTest.kt
@@ -90,8 +90,8 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
         compileKotlin()
     }
 
-    private inline
-    fun <reified T> instantiatePrecompiledScriptOf(target: T, className: String): Any =
+    private
+    inline fun <reified T> instantiatePrecompiledScriptOf(target: T, className: String): Any =
         loadCompiledKotlinClass(className)
             .getConstructor(T::class.java)
             .newInstance(target)

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -16,7 +16,7 @@
 package org.gradle.kotlin.dsl.plugins.embedded
 
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
-import org.gradle.kotlin.dsl.plugins.AbstractPluginTest
+import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 
 import org.gradle.testkit.runner.TaskOutcome
 

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -247,4 +247,3 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
             "$configuration(\"org.jetbrains.kotlin:kotlin-$it:${version ?: embeddedKotlinVersion}\")"
         }.joinToString("\n")
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurableFileCollectionExtensions.kt
@@ -37,4 +37,3 @@ operator fun ConfigurableFileCollection.getValue(receiver: Any?, property: KProp
  */
 operator fun ConfigurableFileCollection.setValue(receiver: Any?, property: KProperty<*>, value: Iterable<*>) =
     setFrom(value)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationExtensions.kt
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ModuleDependency
 
 import org.gradle.kotlin.dsl.support.excludeMapFor
 
+
 /**
  * Adds an exclude rule to exclude transitive dependencies for all dependencies of this configuration.
  * You can also add exclude rules per-dependency. See [ModuleDependency.exclude].

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
@@ -57,7 +57,10 @@ fun <T : Any> Convention.getPlugin(conventionType: KClass<T>) =
  * @see [Convention.getPlugin]
  */
 inline
-fun <ConventionType : Any, ReturnType> Any.withConvention(conventionType: KClass<ConventionType>, function: ConventionType.() -> ReturnType): ReturnType =
+fun <ConventionType : Any, ReturnType> Any.withConvention(
+    conventionType: KClass<ConventionType>,
+    function: ConventionType.() -> ReturnType
+): ReturnType =
     when (this) {
         is HasConvention -> convention.getPlugin(conventionType).run(function)
         else -> throw IllegalStateException("Object `$this` doesn't support conventions!")

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
@@ -65,4 +65,3 @@ fun <ConventionType : Any, ReturnType> Any.withConvention(
         is HasConvention -> convention.getPlugin(conventionType).run(function)
         else -> throw IllegalStateException("Object `$this` doesn't support conventions!")
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -50,7 +50,8 @@ fun DependencyHandler.create(
     version: String? = null,
     configuration: String? = null,
     classifier: String? = null,
-    ext: String? = null): ExternalModuleDependency =
+    ext: String? = null
+): ExternalModuleDependency =
 
     create(
         mapOfNonNullValuesOf(
@@ -82,7 +83,8 @@ fun DependencyHandler.module(
     version: String? = null,
     configuration: String? = null,
     classifier: String? = null,
-    ext: String? = null): ClientModule =
+    ext: String? = null
+): ClientModule =
 
     module(
         mapOfNonNullValuesOf(
@@ -115,7 +117,8 @@ fun DependencyHandler.module(
     configuration: String? = null,
     classifier: String? = null,
     ext: String? = null,
-    clientModuleConfiguration: ClientModuleScope.() -> Unit): ClientModule =
+    clientModuleConfiguration: ClientModuleScope.() -> Unit
+): ClientModule =
 
     configureClientModule(
         module(
@@ -138,7 +141,8 @@ fun DependencyHandler.module(
  */
 fun DependencyHandler.module(
     notation: Any,
-    clientModuleConfiguration: ClientModuleScope.() -> Unit): ClientModule =
+    clientModuleConfiguration: ClientModuleScope.() -> Unit
+): ClientModule =
 
     configureClientModule(module(notation) as ClientModule, clientModuleConfiguration)
 
@@ -146,7 +150,8 @@ fun DependencyHandler.module(
 private inline
 fun DependencyHandler.configureClientModule(
     module: ClientModule,
-    clientModuleConfiguration: ClientModuleScope.() -> Unit): ClientModule =
+    clientModuleConfiguration: ClientModuleScope.() -> Unit
+): ClientModule =
     module.apply {
         ClientModuleScope(this@configureClientModule, this@apply).clientModuleConfiguration()
     }
@@ -157,15 +162,19 @@ fun DependencyHandler.configureClientModule(
  */
 class ClientModuleScope(
     private val dependencyHandler: DependencyHandler,
-    val clientModule: ClientModule) : ClientModule by clientModule {
+    val clientModule: ClientModule
+) : ClientModule by clientModule {
 
-    fun module(group: String,
-               name: String,
-               version: String? = null,
-               configuration: String? = null,
-               classifier: String? = null,
-               ext: String? = null,
-               setup: ClientModuleScope.() -> Unit) {
+    fun module(
+        group: String,
+        name: String,
+        version: String? = null,
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null,
+        setup: ClientModuleScope.() -> Unit
+    ) {
+
         clientModule.addDependency(
             dependencyHandler.module(group, name, version, configuration, classifier, ext, setup))
     }
@@ -202,7 +211,8 @@ class ClientModuleScope(
  */
 fun DependencyHandler.project(
     path: String,
-    configuration: String? = null): ProjectDependency =
+    configuration: String? = null
+): ProjectDependency =
 
     uncheckedCast(
         project(
@@ -222,7 +232,8 @@ inline
 fun DependencyHandler.add(
     configuration: String,
     dependencyNotation: String,
-    dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
+    dependencyConfiguration: ExternalModuleDependency.() -> Unit
+): ExternalModuleDependency =
 
     add(configuration, create(dependencyNotation) as ExternalModuleDependency, dependencyConfiguration)
 
@@ -239,7 +250,8 @@ inline
 fun <T : ModuleDependency> DependencyHandler.add(
     configuration: String,
     dependency: T,
-    dependencyConfiguration: T.() -> Unit): T =
+    dependencyConfiguration: T.() -> Unit
+): T =
 
     dependency.apply {
         dependencyConfiguration()

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -147,8 +147,8 @@ fun DependencyHandler.module(
     configureClientModule(module(notation) as ClientModule, clientModuleConfiguration)
 
 
-private inline
-fun DependencyHandler.configureClientModule(
+private
+inline fun DependencyHandler.configureClientModule(
     module: ClientModule,
     clientModuleConfiguration: ClientModuleScope.() -> Unit
 ): ClientModule =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -283,4 +283,3 @@ fun <T : ModuleDependency> DependencyHandler.add(
  */
 fun <T : ModuleDependency> T.exclude(group: String? = null, module: String? = null): T =
     uncheckedCast(exclude(excludeMapFor(group, module)))
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 
+
 /**
  * Receiver for `dependencies` block providing convenient utilities for configuring dependencies.
  *

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -70,7 +70,8 @@ class DependencyHandlerScope(val dependencies: DependencyHandler) : DependencyHa
         version: String? = null,
         configuration: String? = null,
         classifier: String? = null,
-        ext: String? = null): ExternalModuleDependency =
+        ext: String? = null
+    ): ExternalModuleDependency =
         dependencies.create(group, name, version, configuration, classifier, ext).apply { add(this@invoke, this) }
 
     /**
@@ -96,7 +97,8 @@ class DependencyHandlerScope(val dependencies: DependencyHandler) : DependencyHa
         configuration: String? = null,
         classifier: String? = null,
         ext: String? = null,
-        dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
+        dependencyConfiguration: ExternalModuleDependency.() -> Unit
+    ): ExternalModuleDependency =
         dependencies.add(this, create(group, name, version, configuration, classifier, ext), dependencyConfiguration)
 
     /**
@@ -153,7 +155,8 @@ class DependencyHandlerScope(val dependencies: DependencyHandler) : DependencyHa
         version: String? = null,
         configuration: String? = null,
         classifier: String? = null,
-        ext: String? = null): ExternalModuleDependency =
+        ext: String? = null
+    ): ExternalModuleDependency =
         create(group, name, version, configuration, classifier, ext).apply { add(this@invoke.name, this) }
 
     /**
@@ -179,7 +182,8 @@ class DependencyHandlerScope(val dependencies: DependencyHandler) : DependencyHa
         configuration: String? = null,
         classifier: String? = null,
         ext: String? = null,
-        dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
+        dependencyConfiguration: ExternalModuleDependency.() -> Unit
+    ): ExternalModuleDependency =
         add(this.name, create(group, name, version, configuration, classifier, ext), dependencyConfiguration)
 
     /**

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DomainObjectCollectionExtensions.kt
@@ -47,4 +47,3 @@ fun <reified S : Any> DomainObjectCollection<in S>.withType(crossinline configur
 inline
 fun <reified S : Any> DomainObjectCollection<in S>.withType() =
     withType(S::class.java)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionContainerExtensions.kt
@@ -46,8 +46,8 @@ operator fun ExtensionContainer.get(name: String): Any =
  * @throws [UnknownDomainObjectException] When the given extension is not found.
  * @throws [IllegalStateException] When the given extension cannot be cast to the expected type.
  */
-inline
 @Suppress("extension_shadowed_by_member")
+inline
 fun <reified T : Any> ExtensionContainer.getByName(name: String) =
     getByName(name).let {
         it as? T

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensions.kt
@@ -64,7 +64,8 @@ operator fun <T> ExtraPropertiesExtension.invoke(initialValue: T): ExtraProperty
 
 class ExtraPropertyDelegateProvider<T>(
     val extra: ExtraPropertiesExtension,
-    val initialValue: T) {
+    val initialValue: T
+) {
 
     operator fun provideDelegate(thisRef: Any?, property: kotlin.reflect.KProperty<*>): ExtraPropertyDelegate<T> {
         extra.set(property.name, initialValue)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
@@ -66,7 +66,8 @@ fun <T> Any.delegateClosureOf(action: T.() -> Unit) =
 open class KotlinClosure0<V : Any>(
     val function: () -> V?,
     owner: Any? = null,
-    thisObject: Any? = null) : groovy.lang.Closure<V?>(owner, thisObject) {
+    thisObject: Any? = null
+) : groovy.lang.Closure<V?>(owner, thisObject) {
 
     @Suppress("unused") // to be called dynamically by Groovy
     fun doCall(): V? = function()
@@ -87,7 +88,8 @@ open class KotlinClosure0<V : Any>(
 class KotlinClosure1<in T : Any?, V : Any>(
     val function: T.() -> V?,
     owner: Any? = null,
-    thisObject: Any? = null) : Closure<V?>(owner, thisObject) {
+    thisObject: Any? = null
+) : Closure<V?>(owner, thisObject) {
 
     @Suppress("unused") // to be called dynamically by Groovy
     fun doCall(it: T): V? = it.function()
@@ -109,7 +111,8 @@ class KotlinClosure1<in T : Any?, V : Any>(
 class KotlinClosure2<in T : Any?, in U : Any?, V : Any>(
     val function: (T, U) -> V?,
     owner: Any? = null,
-    thisObject: Any? = null) : Closure<V?>(owner, thisObject) {
+    thisObject: Any? = null
+) : Closure<V?>(owner, thisObject) {
 
     @Suppress("unused") // to be called dynamically by Groovy
     fun doCall(t: T, u: U): V? = function(t, u)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
@@ -121,7 +121,9 @@ class KotlinClosure2<in T : Any?, in U : Any?, V : Any>(
 
 operator fun <T> Closure<T>.invoke(): T = call()
 
+
 operator fun <T> Closure<T>.invoke(x: Any?): T = call(x)
+
 
 operator fun <T> Closure<T>.invoke(vararg xs: Any?): T = call(*xs)
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
@@ -64,7 +64,7 @@ fun <T> Any.delegateClosureOf(action: T.() -> Unit) =
  * @see [Closure]
  */
 open class KotlinClosure0<V : Any>(
-    val function : () -> V?,
+    val function: () -> V?,
     owner: Any? = null,
     thisObject: Any? = null) : groovy.lang.Closure<V?>(owner, thisObject) {
 
@@ -164,7 +164,7 @@ interface GroovyBuilderScope : GroovyObject {
         fun of(value: Any): GroovyBuilderScope =
             when (value) {
                 is GroovyObject -> GroovyBuilderScopeForGroovyObject(value)
-                else            -> GroovyBuilderScopeForRegularObject(value)
+                else -> GroovyBuilderScopeForRegularObject(value)
             }
     }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -37,7 +37,8 @@ import kotlin.script.templates.ScriptTemplateDefinition
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 @GradleDsl
 abstract class KotlinBuildScript(
-    private val host: KotlinScriptHost<Project>) : Project by host.target {
+    private val host: KotlinScriptHost<Project>
+) : Project by host.target {
 
     /**
      * The [ScriptHandler] for this script.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -62,4 +62,3 @@ abstract class KotlinBuildScript(
     @Suppress("unused")
     fun plugins(@Suppress("unused_parameter") block: PluginDependenciesSpecScope.() -> Unit) = Unit
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -56,7 +56,8 @@ import kotlin.script.templates.ScriptTemplateDefinition
     scriptFilePattern = ".+\\.init\\.gradle\\.kts")
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 abstract class KotlinInitScript(
-    private val host: KotlinScriptHost<Gradle>) : Gradle by host.target {
+    private val host: KotlinScriptHost<Gradle>
+) : Gradle by host.target {
 
     /**
      * The [ScriptHandler] for this script.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -393,4 +393,3 @@ abstract class KotlinInitScript(
     val processOperations
         get() = host.operations
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -65,7 +65,8 @@ import kotlin.script.templates.ScriptTemplateDefinition
     scriptFilePattern = "^(settings|.+\\.settings)\\.gradle\\.kts$")
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 abstract class KotlinSettingsScript(
-    private val host: KotlinScriptHost<Settings>) : Settings by host.target {
+    private val host: KotlinScriptHost<Settings>
+) : Settings by host.target {
 
     private
     val fileOperations by lazy { fileOperationsFor(settings) }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
@@ -31,7 +31,8 @@ import kotlin.reflect.KProperty
  * `tasks { val jar by getting }`
  */
 inline
-val <T : Any, U : NamedDomainObjectCollection<in T>> U.getting: U get() = this
+val <T : Any, U : NamedDomainObjectCollection<in T>> U.getting: U
+    get() = this
 
 
 /**

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
@@ -46,7 +46,8 @@ fun <T : Any, U : NamedDomainObjectCollection<T>> U.getting(configuration: T.() 
 
 class NamedDomainObjectCollectionDelegateProvider<T>(
     val collection: NamedDomainObjectCollection<T>,
-    val configuration: T.() -> Unit) {
+    val configuration: T.() -> Unit
+) {
 
     operator fun provideDelegate(thisRef: Any?, property: kotlin.reflect.KProperty<*>): NamedDomainObjectCollection<T> =
         collection.apply {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -34,7 +34,8 @@ import kotlin.reflect.full.safeCast
  */
 inline
 operator fun <T : Any, C : NamedDomainObjectContainer<T>> C.invoke(
-    configuration: NamedDomainObjectContainerScope<T>.() -> Unit): C =
+    configuration: NamedDomainObjectContainerScope<T>.() -> Unit
+): C =
 
     apply {
         configuration(NamedDomainObjectContainerScope(this))
@@ -45,7 +46,8 @@ operator fun <T : Any, C : NamedDomainObjectContainer<T>> C.invoke(
  * Receiver for [NamedDomainObjectContainer] configuration blocks.
  */
 class NamedDomainObjectContainerScope<T : Any>(
-    private val container: NamedDomainObjectContainer<T>) : NamedDomainObjectContainer<T> by container {
+    private val container: NamedDomainObjectContainer<T>
+) : NamedDomainObjectContainer<T> by container {
 
     /**
      * @see [NamedDomainObjectContainer.maybeCreate]
@@ -131,7 +133,8 @@ fun <T : Any> NamedDomainObjectContainer<T>.creating(configuration: T.() -> Unit
  */
 class NamedDomainObjectContainerDelegateProvider<T : Any>(
     val container: NamedDomainObjectContainer<T>,
-    val configuration: T.() -> Unit) {
+    val configuration: T.() -> Unit
+) {
 
     operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) =
         container.apply {
@@ -168,7 +171,8 @@ fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.creating(type: Class<U>
 class PolymorphicDomainObjectContainerDelegateProvider<T : Any, U : T>(
     val container: PolymorphicDomainObjectContainer<T>,
     val type: Class<U>,
-    val configuration: U.() -> Unit) {
+    val configuration: U.() -> Unit
+) {
 
     @Suppress("unchecked_cast")
     operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) =
@@ -197,7 +201,8 @@ fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getting(type: KClass<U>
  */
 class PolymorphicDomainObjectContainerGettingDelegate<T : Any, U : T>(
     val container: PolymorphicDomainObjectContainer<T>,
-    val type: KClass<U>) {
+    val type: KClass<U>
+) {
 
     operator fun getValue(receiver: Any?, property: kotlin.reflect.KProperty<*>): U =
         container.getByName(property.name, type)
@@ -211,7 +216,8 @@ class PolymorphicDomainObjectContainerGettingDelegate<T : Any, U : T>(
 class PolymorphicDomainObjectContainerGettingDelegateProvider<T : Any, U : T>(
     val container: PolymorphicDomainObjectContainer<T>,
     val type: KClass<U>,
-    val configuration: U.() -> Unit) {
+    val configuration: U.() -> Unit
+) {
 
     @Suppress("unchecked_cast")
     operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ObjectConfigurationActionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ObjectConfigurationActionExtensions.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl
 import org.gradle.api.Plugin
 import org.gradle.api.plugins.ObjectConfigurationAction
 
+
 /**
  * Adds a Plugin to use to configure the target objects. This method may be called
  * multiple times, to use multiple plugins. Scripts and plugins are applied in the order

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
@@ -50,7 +50,7 @@ fun <reified U : Any> PolymorphicDomainObjectContainer<in U>.create(
  * exists or the container does not support creating a domain object with the specified
  * type
  */
-inline
 @Suppress("extension_shadowed_by_member")
+inline
 fun <reified U : Any> PolymorphicDomainObjectContainer<in U>.create(name: String) =
     create(name, U::class.java)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
@@ -35,7 +35,8 @@ import org.gradle.api.PolymorphicDomainObjectContainer
 inline
 fun <reified U : Any> PolymorphicDomainObjectContainer<in U>.create(
     name: String,
-    crossinline configuration: U.() -> Unit) =
+    crossinline configuration: U.() -> Unit
+) =
 
     this.create(name, U::class.java, { configuration(it) })
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -55,8 +55,8 @@ import kotlin.reflect.KProperty
  * Sets the default tasks of this project. These are used when no tasks names are provided when
  * starting the build.
  */
-inline
 @Suppress("nothing_to_inline")
+inline
 fun Project.defaultTasks(vararg tasks: Task) {
     defaultTasks(*tasks.map { it.name }.toTypedArray())
 }
@@ -117,8 +117,8 @@ fun <reified type : Task> Project.task(name: String, noinline configuration: typ
  * @see [Project.getTasks]
  * @see [TaskContainer.create]
  */
-inline
 @Suppress("extension_shadowed_by_member")
+inline
 fun <reified type : Task> Project.task(name: String) =
     tasks.create(name, type::class.java)
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -134,11 +134,12 @@ sealed class InaccessibilityReason {
     data class NonAvailable(val type: String) : InaccessibilityReason()
     data class Synthetic(val type: String) : InaccessibilityReason()
 
-    val explanation get() = when (this) {
-        is NonPublic    -> "`$type` is not public"
-        is NonAvailable -> "`$type` is not available"
-        is Synthetic    -> "`$type` is synthetic"
-    }
+    val explanation
+        get() = when (this) {
+            is NonPublic -> "`$type` is not public"
+            is NonAvailable -> "`$type` is not available"
+            is Synthetic -> "`$type` is synthetic"
+        }
 }
 
 
@@ -184,9 +185,9 @@ class TypeAccessibilityProvider(classPath: ClassPath) : Closeable {
         val classBytes = classBytesFor(className) ?: return nonAvailable(className)
         val access = classAccessFrom(classBytes)
         return when {
-            ACC_PUBLIC !in access   -> nonPublic(className)
+            ACC_PUBLIC !in access -> nonPublic(className)
             ACC_SYNTHETIC in access -> synthetic(className)
-            else                    -> null
+            else -> null
         }
     }
 
@@ -199,9 +200,9 @@ class TypeAccessibilityProvider(classPath: ClassPath) : Closeable {
     private
     fun classFileIndexFor(jarOrDir: File): ClassFileIndex =
         when {
-            jarOrDir.isFile      -> jarIndexFor(jarOrDir)
+            jarOrDir.isFile -> jarIndexFor(jarOrDir)
             jarOrDir.isDirectory -> directoryIndexFor(jarOrDir)
-            else                 -> { _ -> null }
+            else -> { _ -> null }
         }
 
     private
@@ -321,8 +322,8 @@ fun cacheKeyFor(projectSchema: ProjectSchema<String>): CacheKeySpec =
 private
 fun ProjectSchema<String>.toCacheKeyString(): String =
     (extensions.entries.asSequence()
-     + conventions.entries.asSequence()
-     + mapEntry("configurations", configurations.sorted().joinToString(",")))
+        + conventions.entries.asSequence()
+        + mapEntry("configurations", configurations.sorted().joinToString(",")))
         .map { "${it.key}=${it.value}" }
         .sorted()
         .joinToString(separator = ":")

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -281,8 +281,8 @@ fun documentInaccessibilityReasons(name: AccessorNameSpec, typeAccess: TypeAcces
     }}"
 
 
-private inline
-fun codeForAccessor(name: AccessorNameSpec, code: () -> String): String? =
+private
+inline fun codeForAccessor(name: AccessorNameSpec, code: () -> String): String? =
     if (isLegalAccessorName(name.kotlinIdentifier)) code().replaceIndent()
     else null
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -245,7 +245,9 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? = name.run {
 internal
 data class AccessorNameSpec(val original: String) {
 
-    val kotlinIdentifier get() = original
+    val kotlinIdentifier
+        get() = original
+
     val stringLiteral by lazy { stringLiteralFor(original) }
 }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -33,6 +33,7 @@ fun ProjectSchema<TypeAccessibility>.forEachAccessor(action: (String) -> Unit) {
     }
 }
 
+
 private
 fun extensionAccessorFor(spec: TypedAccessorSpec): String? = spec.run {
     codeForAccessor(name) {
@@ -85,6 +86,7 @@ fun inaccessibleExtensionAccessorFor(name: AccessorNameSpec, typeAccess: TypeAcc
     """
 }
 
+
 private
 fun conventionAccessorFor(spec: TypedAccessorSpec): String? = spec.run {
     codeForAccessor(name) {
@@ -114,6 +116,7 @@ fun accessibleConventionAccessorFor(name: AccessorNameSpec, type: String): Strin
     """
 }
 
+
 private
 fun inaccessibleConventionAccessorFor(name: AccessorNameSpec, typeAccess: TypeAccessibility.Inaccessible): String = name.run {
     """
@@ -135,6 +138,7 @@ fun inaccessibleConventionAccessorFor(name: AccessorNameSpec, typeAccess: TypeAc
 
     """
 }
+
 
 private
 fun configurationAccessorFor(name: AccessorNameSpec): String? = name.run {
@@ -245,6 +249,7 @@ data class AccessorNameSpec(val original: String) {
     val stringLiteral by lazy { stringLiteralFor(original) }
 }
 
+
 private
 data class TypedAccessorSpec(val name: AccessorNameSpec, val typeAccess: TypeAccessibility)
 
@@ -300,4 +305,3 @@ fun isKotlinIdentifier(candidate: String): Boolean =
             && tokenEnd == candidate.length
             && tokenType == KtTokens.IDENTIFIER
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchema.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchema.kt
@@ -32,7 +32,8 @@ internal
 data class ProjectSchema<out T>(
     val extensions: Map<String, T>,
     val conventions: Map<String, T>,
-    val configurations: List<String>) : Serializable {
+    val configurations: List<String>
+) : Serializable {
 
     fun <U> map(f: (T) -> U) =
         ProjectSchema(
@@ -64,7 +65,8 @@ internal
 fun accessibleProjectSchemaFrom(
     extensionSchema: ExtensionsSchema,
     conventionPlugins: Map<String, Any>,
-    configurationNames: List<String>): ProjectSchema<TypeOf<*>> =
+    configurationNames: List<String>
+): ProjectSchema<TypeOf<*>> =
 
     ProjectSchema(
         extensions = extensionSchema

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/SingletonProperties.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/SingletonProperties.kt
@@ -21,8 +21,8 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.extra
 
 
-internal inline
-fun <reified T : Any> ExtensionAware.getOrCreateSingletonProperty(crossinline create: () -> T): T =
+internal
+inline fun <reified T : Any> ExtensionAware.getOrCreateSingletonProperty(crossinline create: () -> T): T =
     extra.run {
         val property = T::class.qualifiedName!!
         if (has(property)) get(property) as T

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
@@ -19,7 +19,10 @@ package org.gradle.kotlin.dsl.accessors.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
-import org.gradle.kotlin.dsl.accessors.*
+import org.gradle.kotlin.dsl.accessors.accessible
+import org.gradle.kotlin.dsl.accessors.forEachAccessor
+import org.gradle.kotlin.dsl.accessors.schemaFor
+import org.gradle.kotlin.dsl.accessors.withKotlinTypeStrings
 
 
 open class PrintAccessors : DefaultTask() {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/UpdateProjectSchema.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/UpdateProjectSchema.kt
@@ -23,7 +23,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
-import org.gradle.kotlin.dsl.accessors.*
+import org.gradle.kotlin.dsl.accessors.multiProjectKotlinStringSchemaFor
+import org.gradle.kotlin.dsl.accessors.PROJECT_SCHEMA_RESOURCE_PATH
 
 import java.io.File
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/UpdateProjectSchema.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/UpdateProjectSchema.kt
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 import org.gradle.kotlin.dsl.accessors.multiProjectKotlinStringSchemaFor
+import org.gradle.kotlin.dsl.accessors.toJson
 import org.gradle.kotlin.dsl.accessors.PROJECT_SCHEMA_RESOURCE_PATH
 
 import java.io.File

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
@@ -29,7 +29,8 @@ object BuildServices {
     fun createScriptCache(
         cacheKeyBuilder: CacheKeyBuilder,
         cacheRepository: CacheRepository,
-        startParameters: StartParameter) =
+        startParameters: StartParameter
+    ) =
 
         ScriptCache(
             cacheRepository, cacheKeyBuilder, startParameters.isRecompileScripts)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
@@ -35,13 +35,15 @@ class ScriptCache(
     val cacheKeyBuilder: CacheKeyBuilder,
 
     private
-    val recompileScripts: Boolean) {
+    val recompileScripts: Boolean
+) {
 
     fun cacheDirFor(
         keySpec: CacheKeySpec,
         properties: Map<String, Any?>? = null,
         scope: Any? = null,
-        initializer: PersistentCache.() -> Unit): File =
+        initializer: PersistentCache.() -> Unit
+    ): File =
 
         cacheRepository
             .cache(scope, cacheKeyFor(keySpec))

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
@@ -63,4 +63,3 @@ class ScriptCache(
 internal
 operator fun CacheKeySpec.plus(files: List<File>) =
     files.fold(this, CacheKeySpec::plus)
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
@@ -38,7 +38,8 @@ interface KotlinFileCompiler {
 internal
 class ApiExtensionsJarGenerator(
     val compiler: KotlinFileCompiler = StandardKotlinFileCompiler,
-    val onProgress: () -> Unit = {}) {
+    val onProgress: () -> Unit = {}
+) {
 
     fun generate(outputFile: File, gradleJars: Collection<File> = emptyList()) {
         val tempDir = tempDirFor(outputFile)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/Constants.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/Constants.kt
@@ -45,4 +45,3 @@ const val licenseHeader = """/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */"""
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -27,17 +27,19 @@ import java.util.jar.JarFile
 
 internal
 fun writeBuiltinPluginIdExtensionsTo(file: File, gradleJars: Iterable<File>) {
-    file.bufferedWriter().use { it.apply {
-        write(fileHeader)
-        write("\n")
-        write("import ${PluginDependenciesSpec::class.qualifiedName}\n")
-        write("import ${PluginDependencySpec::class.qualifiedName}\n")
-        pluginIdExtensionDeclarationsFor(gradleJars).forEach {
+    file.bufferedWriter().use {
+        it.apply {
+            write(fileHeader)
             write("\n")
-            write(it)
-            write("\n")
+            write("import ${PluginDependenciesSpec::class.qualifiedName}\n")
+            write("import ${PluginDependencySpec::class.qualifiedName}\n")
+            pluginIdExtensionDeclarationsFor(gradleJars).forEach {
+                write("\n")
+                write(it)
+                write("\n")
+            }
         }
-    } }
+    }
 }
 
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -70,7 +70,8 @@ data class PluginExtension(
     val memberName: String,
     val pluginId: String,
     val website: String?,
-    val implementationClass: String)
+    val implementationClass: String
+)
 
 
 private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -259,4 +259,3 @@ fun pluginEntriesFrom(jar: File): List<PluginEntry> =
             PluginEntry(id, implementationClass)
         }.toList()
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
@@ -30,8 +30,8 @@ import kotlin.coroutines.experimental.suspendCoroutine
  *
  * Execution will continue on the TAPI executor thread.
  */
-internal inline
-suspend fun <T> tapi(crossinline computation: (ResultHandler<T>) -> Unit): T =
+internal
+suspend inline fun <T> tapi(crossinline computation: (ResultHandler<T>) -> Unit): T =
     suspendCoroutine { k: Continuation<T> ->
         computation(k.asResultHandler())
     }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/tapi.kt
@@ -42,7 +42,7 @@ fun <T> Continuation<T>.asResultHandler(): ResultHandler<T> =
     object : ResultHandler<T> {
         override fun onComplete(result: T) =
             resume(result)
+
         override fun onFailure(failure: GradleConnectionException) =
             resumeWithException(failure)
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledInitScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledInitScript.kt
@@ -39,5 +39,4 @@ import kotlin.script.templates.ScriptTemplateDefinition
 abstract class PrecompiledInitScript(target: Gradle) : InitScriptApi(target) {
 
     override val operations by lazy { fileOperationsFor(gradle, null) }
-
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledSettingsScript.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledSettingsScript.kt
@@ -39,6 +39,4 @@ import kotlin.script.templates.ScriptTemplateDefinition
 abstract class PrecompiledSettingsScript(target: Settings) : SettingsScriptApi(target) {
 
     override val fileOperations by lazy { fileOperationsFor(settings) }
-
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -35,7 +35,8 @@ object BuildServices {
     fun createCachingKotlinCompiler(
         scriptCache: ScriptCache,
         implicitImports: ImplicitImports,
-        progressLoggerFactory: ProgressLoggerFactory) =
+        progressLoggerFactory: ProgressLoggerFactory
+    ) =
 
         CachingKotlinCompiler(scriptCache, implicitImports, progressLoggerFactory)
 
@@ -44,7 +45,8 @@ object BuildServices {
         classPathRegistry: ClassPathRegistry,
         dependencyFactory: DependencyFactory,
         jarCache: GeneratedGradleJarCache,
-        progressLoggerFactory: ProgressLoggerFactory) =
+        progressLoggerFactory: ProgressLoggerFactory
+    ) =
 
         KotlinScriptClassPathProvider(
             classPathRegistry,
@@ -55,7 +57,8 @@ object BuildServices {
     @Suppress("unused")
     fun createPluginRequestsHandler(
         pluginRequestApplicator: PluginRequestApplicator,
-        autoAppliedPluginHandler: AutoAppliedPluginHandler) =
+        autoAppliedPluginHandler: AutoAppliedPluginHandler
+    ) =
 
         PluginRequestsHandler(pluginRequestApplicator, autoAppliedPluginHandler)
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtraction.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtraction.kt
@@ -21,8 +21,7 @@ import org.jetbrains.kotlin.lexer.KtTokens.*
 
 
 internal
-class UnexpectedBlock(val identifier: String, val location: IntRange)
-    : RuntimeException("Unexpected block found.")
+class UnexpectedBlock(val identifier: String, val location: IntRange) : RuntimeException("Unexpected block found.")
 
 
 internal

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtraction.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtraction.kt
@@ -17,7 +17,10 @@
 package org.gradle.kotlin.dsl.provider
 
 import org.jetbrains.kotlin.lexer.KotlinLexer
-import org.jetbrains.kotlin.lexer.KtTokens.*
+import org.jetbrains.kotlin.lexer.KtTokens.IDENTIFIER
+import org.jetbrains.kotlin.lexer.KtTokens.LBRACE
+import org.jetbrains.kotlin.lexer.KtTokens.RBRACE
+import org.jetbrains.kotlin.lexer.KtTokens.WHITE_SPACE_OR_COMMENT_BIT_SET
 
 
 internal

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CachingKotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/CachingKotlinCompiler.kt
@@ -51,7 +51,8 @@ data class ScriptBlock<out T>(
     val scriptTemplate: KClass<*>,
     val scriptPath: String,
     val source: String,
-    val metadata: T) {
+    val metadata: T
+) {
 
     val sourceHash: HashCode = Hashing.md5().hashString(source)
 }
@@ -61,7 +62,8 @@ internal
 data class CompiledScript<out T>(
     val location: File,
     val className: String,
-    val metadata: T)
+    val metadata: T
+)
 
 
 private
@@ -72,7 +74,8 @@ internal
 class CachingKotlinCompiler(
     private val scriptCache: ScriptCache,
     private val implicitImports: ImplicitImports,
-    private val progressLoggerFactory: ProgressLoggerFactory) {
+    private val progressLoggerFactory: ProgressLoggerFactory
+) {
 
     init {
         org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback()
@@ -109,7 +112,8 @@ class CachingKotlinCompiler(
         cacheKeySpec: CacheKeySpec,
         classPath: ClassPath,
         metadata: T,
-        compilationSpecFor: (File) -> ScriptCompilationSpec): CompiledScript<T> {
+        compilationSpecFor: (File) -> ScriptCompilationSpec
+    ): CompiledScript<T> {
 
         try {
             val cacheDir = cacheDirFor(cacheKeySpec + classPath) {
@@ -127,13 +131,15 @@ class CachingKotlinCompiler(
         val displayName: String,
         val scriptTemplate: KClass<out Any>,
         val originalPath: String,
-        val scriptFile: File)
+        val scriptFile: File
+    )
 
     private
     fun compileScriptTo(
         outputDir: File,
         spec: ScriptCompilationSpec,
-        classPath: ClassPath): String =
+        classPath: ClassPath
+    ): String =
 
         spec.run {
             withProgressLoggingFor(displayName) {
@@ -187,7 +193,8 @@ class CachingKotlinCompiler(
         object : DependenciesResolver {
             override fun resolve(
                 scriptContents: ScriptContents,
-                environment: Environment): DependenciesResolver.ResolveResult =
+                environment: Environment
+            ): DependenciesResolver.ResolveResult =
 
                 DependenciesResolver.ResolveResult.Success(
                     ScriptDependencies(imports = implicitImports.list), emptyList())

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchy.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchy.kt
@@ -41,7 +41,8 @@ internal
 fun classLoaderHierarchyJsonFor(
     klass: Class<*>,
     targetScope: ClassLoaderScope,
-    pathFormatter: PathStringFormatter = { it }) =
+    pathFormatter: PathStringFormatter = { it }
+) =
 
     classLoaderHierarchyJsonFor(
         hierarchyOf(klass.classLoader),
@@ -58,14 +59,16 @@ class ClassLoaderNode(
     val id: ClassLoaderId,
     val label: String,
     val classPath: MutableSet<URL> = LinkedHashSet(),
-    val parents: MutableSet<ClassLoaderId> = LinkedHashSet())
+    val parents: MutableSet<ClassLoaderId> = LinkedHashSet()
+)
 
 
 private
 fun classLoaderHierarchyJsonFor(
     classLoaders: List<ClassLoaderNode>,
     scopes: List<ClassLoaderScope>,
-    pathFormatter: PathStringFormatter): String {
+    pathFormatter: PathStringFormatter
+): String {
 
     fun labelFor(scope: ClassLoaderScope) =
         pathFormatter(if (scope is AbstractClassLoaderScope) scope.path else scope.toString())

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/GradleUserHomeServices.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/GradleUserHomeServices.kt
@@ -17,6 +17,7 @@ package org.gradle.kotlin.dsl.provider
 
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory
 
+
 internal
 object GradleUserHomeServices {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
@@ -24,9 +24,11 @@ import org.gradle.internal.progress.PercentageProgressFormatter
 
 import java.io.File
 
+
 interface JarGenerationProgressMonitorProvider {
     fun progressMonitorFor(outputJar: File, totalWork: Int): ProgressMonitor
 }
+
 
 internal
 class StandardJarGenerationProgressMonitorProvider(
@@ -40,6 +42,7 @@ class StandardJarGenerationProgressMonitorProvider(
             override fun onProgress() {
                 progressLogger.progress(progressFormatter.incrementAndGetProgress())
             }
+
             override fun close() {
                 progressLogger.completed()
             }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
@@ -30,7 +30,8 @@ interface JarGenerationProgressMonitorProvider {
 
 internal
 class StandardJarGenerationProgressMonitorProvider(
-    val progressLoggerFactory: ProgressLoggerFactory) : JarGenerationProgressMonitorProvider {
+    val progressLoggerFactory: ProgressLoggerFactory
+) : JarGenerationProgressMonitorProvider {
 
     override fun progressMonitorFor(outputJar: File, totalWork: Int): ProgressMonitor {
         val progressLogger = progressLoggerFor(outputJar)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -301,10 +301,12 @@ class KotlinBuildScriptCompiler(
         "Unexpected `${block.identifier}` block found. Only one `${block.identifier}` block is allowed per script."
 
     private
-    val scriptPath get() = scriptSource.scriptPath
+    val scriptPath
+        get() = scriptSource.scriptPath
 
     private
-    val script get() = scriptSource.script
+    val script
+        get() = scriptSource.script
 }
 
 
@@ -423,13 +425,16 @@ class BuildscriptBlockEvaluator(
         }
 
     private
-    val scriptPath get() = scriptSource.scriptPath
+    val scriptPath
+        get() = scriptSource.scriptPath
 
     private
-    val script get() = scriptSource.script
+    val script
+        get() = scriptSource.script
 
     private
-    val buildscriptBlockName get() = scriptTarget.buildscriptBlockName
+    val buildscriptBlockName
+        get() = scriptTarget.buildscriptBlockName
 }
 
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -277,16 +277,16 @@ class KotlinBuildScriptCompiler(
     fun classLoaderScopeIdFor(stage: String) =
         scriptSource.classLoaderScopeIdFor(stage)
 
-    private inline
-    fun ignoringErrors(action: () -> Unit) = classPathModeExceptionCollector.ignoringErrors(action)
+    private
+    inline fun ignoringErrors(action: () -> Unit) = classPathModeExceptionCollector.ignoringErrors(action)
 
     private
     fun <T : Any> instantiate(scriptClass: Class<*>, targetType: KClass<*>, target: T) {
         scriptClass.getConstructor(targetType.java).newInstance(target)
     }
 
-    private inline
-    fun withUnexpectedBlockHandling(action: () -> Unit) {
+    private
+    inline fun withUnexpectedBlockHandling(action: () -> Unit) {
         try {
             action()
         } catch (unexpectedBlock: UnexpectedBlock) {
@@ -366,8 +366,8 @@ class BuildscriptBlockEvaluator(
             compileScriptBlock(scriptBlock, classPath)
         }
 
-    private inline
-    fun ignoringErrors(action: () -> Unit) = classPathModeExceptionCollector.ignoringErrors(action)
+    private
+    inline fun ignoringErrors(action: () -> Unit) = classPathModeExceptionCollector.ignoringErrors(action)
 
     private
     fun buildscriptBlockClassLoaderScope() =
@@ -433,8 +433,8 @@ class BuildscriptBlockEvaluator(
 }
 
 
-private inline
-fun ClassPathModeExceptionCollector.ignoringErrors(action: () -> Unit) {
+private
+inline fun ClassPathModeExceptionCollector.ignoringErrors(action: () -> Unit) {
     try {
         action()
     } catch (e: Exception) {
@@ -444,8 +444,8 @@ fun ClassPathModeExceptionCollector.ignoringErrors(action: () -> Unit) {
 }
 
 
-private inline
-fun <T> KotlinScriptSource.withLocationAwareExceptionHandling(action: () -> T): T =
+private
+inline fun <T> KotlinScriptSource.withLocationAwareExceptionHandling(action: () -> T): T =
     try {
         action()
     } catch (e: ScriptCompilationException) {
@@ -453,8 +453,8 @@ fun <T> KotlinScriptSource.withLocationAwareExceptionHandling(action: () -> T): 
     }
 
 
-private inline
-fun <T> LoadedScriptClass<T>.eval(action: LoadedScriptClass<T>.() -> Unit) =
+private
+inline fun <T> LoadedScriptClass<T>.eval(action: LoadedScriptClass<T>.() -> Unit) =
     withContextClassLoader(scriptClass.classLoader) {
         try {
             action()
@@ -464,8 +464,8 @@ fun <T> LoadedScriptClass<T>.eval(action: LoadedScriptClass<T>.() -> Unit) =
     }
 
 
-private inline
-fun withContextClassLoader(classLoader: ClassLoader, block: () -> Unit) {
+private
+inline fun withContextClassLoader(classLoader: ClassLoader, block: () -> Unit) {
     val currentThread = Thread.currentThread()
     val previous = currentThread.contextClassLoader
     try {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -82,7 +82,8 @@ class KotlinBuildScriptCompiler(
     private val targetScope: ClassLoaderScope,
     private val classPathProvider: KotlinScriptClassPathProvider,
     private val embeddedKotlinProvider: EmbeddedKotlinProvider,
-    private val classPathModeExceptionCollector: ClassPathModeExceptionCollector) {
+    private val classPathModeExceptionCollector: ClassPathModeExceptionCollector
+) {
 
     private
     val buildscriptBlockCompilationClassPath: ClassPath = classPathProvider.compilationClassPathOf(targetScope.parent)
@@ -182,7 +183,8 @@ class KotlinBuildScriptCompiler(
     private
     fun executeCompiledPluginsBlockOn(
         pluginRequestCollector: PluginRequestCollector,
-        loadedPluginsBlockClass: LoadedScriptClass<PluginsBlockMetadata>) {
+        loadedPluginsBlockClass: LoadedScriptClass<PluginsBlockMetadata>
+    ) {
 
         val pluginDependenciesSpec = pluginRequestCollector.createSpec(loadedPluginsBlockClass.compiledScript.metadata.lineNumber)
         loadedPluginsBlockClass.eval {
@@ -309,7 +311,8 @@ class KotlinBuildScriptCompiler(
 fun initScriptClassPathFor(
     gradle: GradleInternal,
     scriptHandler: ScriptHandlerInternal,
-    scriptSource: ScriptSource): ClassPath {
+    scriptSource: ScriptSource
+): ClassPath {
 
     val baseScope = gradle.classLoaderScope
     val scriptTarget = gradleInitScriptTarget(gradle, scriptHandler, scriptSource, baseScope)
@@ -339,7 +342,8 @@ class BuildscriptBlockEvaluator(
     val kotlinCompiler: CachingKotlinCompiler,
     val embeddedKotlinProvider: EmbeddedKotlinProvider,
     val classloadingCache: KotlinScriptClassloadingCache,
-    val classPathModeExceptionCollector: ClassPathModeExceptionCollector) {
+    val classPathModeExceptionCollector: ClassPathModeExceptionCollector
+) {
 
     fun evaluateForClassPath() {
         ignoringErrors {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinGradleApiSpecProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinGradleApiSpecProvider.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.provider
 
 import org.gradle.initialization.GradleApiSpecProvider
 
+
 class KotlinGradleApiSpecProvider : GradleApiSpecProvider {
 
     override fun get() = KotlinSpec

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -68,7 +68,8 @@ class KotlinScriptClassPathProvider(
     val classPathRegistry: ClassPathRegistry,
     val gradleApiJarsProvider: JarsProvider,
     val jarCache: JarCache,
-    val progressMonitorProvider: JarGenerationProgressMonitorProvider) {
+    val progressMonitorProvider: JarGenerationProgressMonitorProvider
+) {
 
     /**
      * Generated Gradle API jar plus supporting libraries such as groovy-all.jar and generated API extensions.

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassloadingCache.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassloadingCache.kt
@@ -36,7 +36,8 @@ import javax.inject.Inject
 internal
 data class LoadedScriptClass<out T>(
     val compiledScript: CompiledScript<T>,
-    val scriptClass: Class<*>)
+    val scriptClass: Class<*>
+)
 
 
 private
@@ -53,7 +54,8 @@ class KotlinScriptClassloadingCache @Inject constructor(cacheFactory: CrossBuild
         scriptBlock: ScriptBlock<T>,
         parentClassLoader: ClassLoader,
         createClassLoaderScope: () -> ClassLoaderScope,
-        compile: (ScriptBlock<T>) -> CompiledScript<T>): LoadedScriptClass<T> {
+        compile: (ScriptBlock<T>) -> CompiledScript<T>
+    ): LoadedScriptClass<T> {
 
         val key = cacheKeyFor(scriptBlock, parentClassLoader)
         val cached = cache.get(key)
@@ -97,7 +99,8 @@ private
 class ScriptCacheKey(
     private val templateId: String,
     private val sourceHash: HashCode,
-    parentClassLoader: ClassLoader) {
+    parentClassLoader: ClassLoader
+) {
 
     private
     val parentClassLoader = WeakReference(parentClassLoader)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
@@ -22,7 +22,8 @@ import org.gradle.kotlin.dsl.support.loggerFor
 
 class KotlinScriptPlugin(
     private val scriptSource: ScriptSource,
-    private val script: (Any) -> Unit) : ScriptPlugin {
+    private val script: (Any) -> Unit
+) : ScriptPlugin {
 
     private
     val logger = loggerFor<KotlinScriptPlugin>()

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
@@ -20,6 +20,7 @@ import org.gradle.configuration.ScriptPlugin
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.kotlin.dsl.support.loggerFor
 
+
 class KotlinScriptPlugin(
     private val scriptSource: ScriptSource,
     private val script: (Any) -> Unit

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
@@ -68,10 +68,8 @@ class KotlinScriptPluginFactory @Inject internal constructor(
 
         compilerFor(scriptTarget, scriptSource, scriptHandler, targetScope, baseScope).run {
 
-            if (inClassPathMode())
-                compileForClassPath()
-            else
-                compile()
+            if (inClassPathMode()) compileForClassPath()
+            else compile()
         }
 
     private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
@@ -36,12 +36,16 @@ class KotlinScriptPluginFactory @Inject internal constructor(
     val classloadingCache: KotlinScriptClassloadingCache,
     val pluginRequestsHandler: PluginRequestsHandler,
     val embeddedKotlinProvider: EmbeddedKotlinProvider,
-    val classPathModeExceptionCollector: ClassPathModeExceptionCollector) : ScriptPluginFactory {
+    val classPathModeExceptionCollector: ClassPathModeExceptionCollector
+) : ScriptPluginFactory {
 
     override fun create(
-        scriptSource: ScriptSource, scriptHandler: ScriptHandler,
-        targetScope: ClassLoaderScope, baseScope: ClassLoaderScope,
-        topLevelScript: Boolean): ScriptPlugin =
+        scriptSource: ScriptSource,
+        scriptHandler: ScriptHandler,
+        targetScope: ClassLoaderScope,
+        baseScope: ClassLoaderScope,
+        topLevelScript: Boolean
+    ): ScriptPlugin =
 
         KotlinScriptPlugin(
             scriptSource,
@@ -49,9 +53,12 @@ class KotlinScriptPluginFactory @Inject internal constructor(
 
     private
     fun createScriptAction(
-        scriptSource: ScriptSource, scriptHandler: ScriptHandler,
-        targetScope: ClassLoaderScope, baseScope: ClassLoaderScope,
-        topLevelScript: Boolean): (Any) -> Unit = { target ->
+        scriptSource: ScriptSource,
+        scriptHandler: ScriptHandler,
+        targetScope: ClassLoaderScope,
+        baseScope: ClassLoaderScope,
+        topLevelScript: Boolean
+    ): (Any) -> Unit = { target ->
 
         val scriptTarget = kotlinScriptTargetFor(target, scriptSource, scriptHandler, baseScope, topLevelScript)
         val script = compile(scriptTarget, scriptSource, scriptHandler, targetScope, baseScope)
@@ -64,7 +71,8 @@ class KotlinScriptPluginFactory @Inject internal constructor(
         scriptSource: ScriptSource,
         scriptHandler: ScriptHandler,
         targetScope: ClassLoaderScope,
-        baseScope: ClassLoaderScope): KotlinScript =
+        baseScope: ClassLoaderScope
+    ): KotlinScript =
 
         compilerFor(scriptTarget, scriptSource, scriptHandler, targetScope, baseScope).run {
 
@@ -75,8 +83,11 @@ class KotlinScriptPluginFactory @Inject internal constructor(
     private
     fun compilerFor(
         scriptTarget: KotlinScriptTarget<Any>,
-        scriptSource: ScriptSource, scriptHandler: ScriptHandler,
-        targetScope: ClassLoaderScope, baseScope: ClassLoaderScope) =
+        scriptSource: ScriptSource,
+        scriptHandler: ScriptHandler,
+        targetScope: ClassLoaderScope,
+        baseScope: ClassLoaderScope
+    ) =
 
         KotlinBuildScriptCompiler(
             kotlinCompiler,

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
@@ -32,7 +32,11 @@ import org.gradle.kotlin.dsl.KotlinInitScript
 import org.gradle.kotlin.dsl.KotlinSettingsScript
 import org.gradle.kotlin.dsl.accessors.AccessorsClassPath
 import org.gradle.kotlin.dsl.accessors.accessorsClassPathFor
-import org.gradle.kotlin.dsl.support.*
+import org.gradle.kotlin.dsl.support.KotlinBuildscriptBlock
+import org.gradle.kotlin.dsl.support.KotlinInitscriptBlock
+import org.gradle.kotlin.dsl.support.KotlinPluginsBlock
+import org.gradle.kotlin.dsl.support.KotlinScriptHost
+import org.gradle.kotlin.dsl.support.KotlinSettingsBuildscriptBlock
 
 import java.lang.IllegalArgumentException
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
@@ -48,10 +48,10 @@ fun kotlinScriptTargetFor(
     topLevelScript: Boolean): KotlinScriptTarget<Any> =
 
     when (target) {
-        is Project  -> projectScriptTarget(target, scriptSource, scriptHandler, baseScope, topLevelScript)
+        is Project -> projectScriptTarget(target, scriptSource, scriptHandler, baseScope, topLevelScript)
         is Settings -> settingsScriptTarget(target, scriptSource, scriptHandler, baseScope, topLevelScript)
-        is Gradle   -> gradleInitScriptTarget(target, scriptHandler, scriptSource, baseScope)
-        else        -> unsupportedTarget(target)
+        is Gradle -> gradleInitScriptTarget(target, scriptHandler, scriptSource, baseScope)
+        else -> unsupportedTarget(target)
     }
 
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptTarget.kt
@@ -45,7 +45,8 @@ fun kotlinScriptTargetFor(
     scriptSource: ScriptSource,
     scriptHandler: ScriptHandler,
     baseScope: ClassLoaderScope,
-    topLevelScript: Boolean): KotlinScriptTarget<Any> =
+    topLevelScript: Boolean
+): KotlinScriptTarget<Any> =
 
     when (target) {
         is Project -> projectScriptTarget(target, scriptSource, scriptHandler, baseScope, topLevelScript)
@@ -66,7 +67,8 @@ fun settingsScriptTarget(
     scriptSource: ScriptSource,
     scriptHandler: ScriptHandler,
     baseScope: ClassLoaderScope,
-    topLevelScript: Boolean) =
+    topLevelScript: Boolean
+) =
 
     KotlinScriptTarget(
         host = KotlinScriptHost(settings, scriptSource, serviceRegistryOf(settings), baseScope, scriptHandler),
@@ -80,7 +82,8 @@ fun projectScriptTarget(
     scriptSource: ScriptSource,
     scriptHandler: ScriptHandler,
     baseScope: ClassLoaderScope,
-    topLevelScript: Boolean): KotlinScriptTarget<Project> =
+    topLevelScript: Boolean
+): KotlinScriptTarget<Project> =
 
     KotlinScriptTarget(
         host = KotlinScriptHost(project, scriptSource, serviceRegistryOf(project), baseScope, scriptHandler),
@@ -100,7 +103,8 @@ fun gradleInitScriptTarget(
     gradle: Gradle,
     scriptHandler: ScriptHandler,
     scriptSource: ScriptSource,
-    baseScope: ClassLoaderScope): KotlinScriptTarget<Gradle> =
+    baseScope: ClassLoaderScope
+): KotlinScriptTarget<Gradle> =
 
     KotlinScriptTarget(
         host = KotlinScriptHost(gradle, scriptSource, serviceRegistryOf(gradle), baseScope, scriptHandler),
@@ -131,7 +135,8 @@ data class KotlinScriptTarget<out T : Any>(
     val pluginsBlockTemplate: KClass<*>? = null,
     val accessorsClassPath: AccessorsClassPathProvider = emptyAccessorsClassPathProvider,
     val buildscriptBlockName: String = "buildscript",
-    private val onPrepare: T.() -> Unit = {}) {
+    private val onPrepare: T.() -> Unit = {}
+) {
 
     val `object`
         get() = host.target

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/PluginRequestsHandler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/PluginRequestsHandler.kt
@@ -31,13 +31,15 @@ import javax.inject.Inject
 internal
 class PluginRequestsHandler @Inject constructor(
     private val pluginRequestApplicator: PluginRequestApplicator,
-    private val autoAppliedPluginHandler: AutoAppliedPluginHandler) {
+    private val autoAppliedPluginHandler: AutoAppliedPluginHandler
+) {
 
     fun handle(
         pluginRequests: PluginRequests?,
         scriptHandler: ScriptHandlerInternal,
         target: PluginAwareInternal,
-        targetScope: ClassLoaderScope) {
+        targetScope: ClassLoaderScope
+    ) {
 
         val effectivePluginRequests = pluginRequests
             ?.let { withAutoAppliedPluginsFor(target, it) }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/PluginRequestsHandler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/PluginRequestsHandler.kt
@@ -28,6 +28,7 @@ import org.gradle.plugin.use.internal.PluginRequestApplicator
 
 import javax.inject.Inject
 
+
 internal
 class PluginRequestsHandler @Inject constructor(
     private val pluginRequestApplicator: PluginRequestApplicator,
@@ -55,5 +56,4 @@ class PluginRequestsHandler @Inject constructor(
     private
     fun withAutoAppliedPluginsFor(target: Any, pluginRequests: PluginRequests): PluginRequests =
         autoAppliedPluginHandler.mergeWithAutoAppliedPlugins(pluginRequests, target)
-
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ScriptApi.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ScriptApi.kt
@@ -32,6 +32,7 @@ import org.gradle.process.JavaExecSpec
 import java.io.File
 import java.net.URI
 
+
 /**
  * Base contract for all Gradle Kotlin DSL scripts.
  *

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/CompactTree.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/CompactTree.kt
@@ -43,18 +43,21 @@ sealed class CompactTree {
                 .map { (label, remaining) ->
                     val subTree = CompactTree.Companion.of(remaining)
                     when (subTree) {
-                        is CompactTree.Empty  -> CompactTree.Label(label)
-                        is CompactTree.Label  -> CompactTree.Label(
-                            label + subTree.label)
+                        is CompactTree.Empty -> CompactTree.Label(label)
+                        is CompactTree.Label -> CompactTree.Label(
+                            label + subTree.label
+                        )
                         is CompactTree.Branch -> CompactTree.Edge(
-                            Label(label), subTree)
-                        is CompactTree.Edge   -> CompactTree.Edge(
-                            Label(label + subTree.label), subTree.tree)
+                            Label(label), subTree
+                        )
+                        is CompactTree.Edge -> CompactTree.Edge(
+                            Label(label + subTree.label), subTree.tree
+                        )
                     }
                 }.let {
                     when (it.size) {
-                        0    -> CompactTree.Empty
-                        1    -> it.first()
+                        0 -> CompactTree.Empty
+                        1 -> it.first()
                         else -> CompactTree.Branch(it)
                     }
                 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ExtractGradleSourcesTransform.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ExtractGradleSourcesTransform.kt
@@ -22,6 +22,7 @@ import org.gradle.kotlin.dsl.support.unzipTo
 
 import java.io.File
 
+
 /**
  * This dependency transform is responsible for extracting the sources from
  * a downloaded ZIP of the Gradle sources, and will return the list of main sources

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -43,7 +43,8 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
         script: ScriptContents,
         environment: Map<String, Any?>?,
         report: (ScriptDependenciesResolver.ReportSeverity, String, ScriptContents.Position?) -> Unit,
-        previousDependencies: KotlinScriptExternalDependencies?) = future {
+        previousDependencies: KotlinScriptExternalDependencies?
+    ) = future {
 
         try {
             log(ResolutionRequest(script.file, environment, previousDependencies))
@@ -75,7 +76,8 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
         scriptFile: File?,
         environment: Environment,
         previousDependencies: KotlinScriptExternalDependencies?,
-        buildscriptBlockHash: ByteArray?): KotlinScriptExternalDependencies {
+        buildscriptBlockHash: ByteArray?
+    ): KotlinScriptExternalDependencies {
 
         val request = modelRequestFrom(scriptFile, environment)
         log(SubmittedModelRequest(scriptFile, request))
@@ -130,7 +132,8 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
     private
     fun dependenciesFrom(
         response: KotlinBuildScriptModel,
-        hash: ByteArray?) =
+        hash: ByteArray?
+    ) =
 
         KotlinBuildScriptDependencies(
             response.classPath,
@@ -165,7 +168,8 @@ object ResolverCoordinator {
     fun selectNextActionFor(
         script: ScriptContents,
         environment: Environment?,
-        previousDependencies: KotlinScriptExternalDependencies?): ResolverAction {
+        previousDependencies: KotlinScriptExternalDependencies?
+    ): ResolverAction {
 
         if (environment == null) {
             return ResolverAction.ReturnPrevious
@@ -232,7 +236,8 @@ class KotlinBuildScriptDependencies(
     override val classpath: Iterable<File>,
     override val sources: Iterable<File>,
     override val imports: Iterable<String>,
-    val buildscriptBlockHash: ByteArray?) : KotlinScriptExternalDependencies
+    val buildscriptBlockHash: ByteArray?
+) : KotlinScriptExternalDependencies
 
 
 internal

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -49,15 +49,19 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
             log(ResolutionRequest(script.file, environment, previousDependencies))
             val action = ResolverCoordinator.selectNextActionFor(script, environment, previousDependencies)
             when (action) {
-                is ResolverAction.Return         -> {
+                is ResolverAction.Return -> {
                     action.dependencies
                 }
                 is ResolverAction.ReturnPrevious -> {
                     log(ResolvedToPrevious(script.file, previousDependencies))
                     previousDependencies
                 }
-                is ResolverAction.RequestNew     -> {
-                    assembleDependenciesFrom(script.file, environment!!, previousDependencies, action.buildscriptBlockHash)
+                is ResolverAction.RequestNew -> {
+                    assembleDependenciesFrom(
+                        script.file,
+                        environment!!,
+                        previousDependencies,
+                        action.buildscriptBlockHash)
                 }
             }
         } catch (e: Exception) {
@@ -80,7 +84,7 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
         log(ReceivedModelResponse(scriptFile, response))
 
         return when {
-            response.exceptions.isEmpty()                                                                    ->
+            response.exceptions.isEmpty() ->
                 dependenciesFrom(response, buildscriptBlockHash).also {
                     log(ResolvedDependencies(scriptFile, it))
                 }
@@ -88,7 +92,7 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
                 previousDependencies.also {
                     log(ResolvedToPreviousWithErrors(scriptFile, previousDependencies, response.exceptions))
                 }
-            else                                                                                             ->
+            else ->
                 dependenciesFrom(response, buildscriptBlockHash).also {
                     log(ResolvedDependenciesWithErrors(scriptFile, it, response.exceptions))
                 }
@@ -245,12 +249,12 @@ fun projectRootOf(scriptFile: File, importedProjectRoot: File): File {
     tailrec fun test(dir: File): File =
         when {
             dir == importedProjectRoot -> importedProjectRoot
-            isProjectRoot(dir)         -> dir
-            else                       -> {
+            isProjectRoot(dir) -> dir
+            else -> {
                 val parentDir = dir.parentFile
                 when (parentDir) {
                     null, dir -> scriptFile.parentFile // external project
-                    else      -> test(parentDir)
+                    else -> test(parentDir)
                 }
             }
         }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -187,7 +187,8 @@ object ResolverCoordinator {
 
     private
     fun sameBuildscriptBlockHashAs(previousDependencies: KotlinScriptExternalDependencies?, hash: ByteArray?) =
-        hash?.let { nonNullHash -> buildscriptBlockHashOf(previousDependencies)?.let { equals(it, nonNullHash) } } ?: false
+        hash?.let { nonNullHash -> buildscriptBlockHashOf(previousDependencies)?.let { equals(it, nonNullHash) } }
+            ?: false
 
     private
     fun buildscriptBlockHashOf(previousDependencies: KotlinScriptExternalDependencies?) =

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -44,7 +44,8 @@ data class KotlinBuildScriptModelRequest(
     val gradleUserHome: java.io.File? = null,
     val javaHome: java.io.File? = null,
     val options: List<String> = emptyList(),
-    val jvmOptions: List<String> = emptyList())
+    val jvmOptions: List<String> = emptyList()
+)
 
 
 internal
@@ -54,8 +55,8 @@ typealias ModelBuilderCustomization = ModelBuilder<KotlinBuildScriptModel>.() ->
 internal
 suspend fun fetchKotlinBuildScriptModelFor(
     request: KotlinBuildScriptModelRequest,
-    modelBuilderCustomization: ModelBuilderCustomization = {}): KotlinBuildScriptModel
-{
+    modelBuilderCustomization: ModelBuilderCustomization = {}
+): KotlinBuildScriptModel {
 
     val connection = projectConnectionFor(request)
     try {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -113,4 +113,3 @@ fun applyGradleInstallationTo(connector: org.gradle.tooling.GradleConnector, req
             GradleInstallation.Wrapper -> connector.useBuildDistribution()
         }
     }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -106,10 +106,10 @@ private
 fun applyGradleInstallationTo(connector: org.gradle.tooling.GradleConnector, request: KotlinBuildScriptModelRequest): org.gradle.tooling.GradleConnector =
     request.gradleInstallation.run {
         when (this) {
-            is GradleInstallation.Local   -> connector.useInstallation(dir)
-            is GradleInstallation.Remote  -> connector.useDistribution(uri)
+            is GradleInstallation.Local -> connector.useInstallation(dir)
+            is GradleInstallation.Remote -> connector.useDistribution(uri)
             is GradleInstallation.Version -> connector.useGradleVersion(number)
-            GradleInstallation.Wrapper    -> connector.useBuildDistribution()
+            GradleInstallation.Wrapper -> connector.useBuildDistribution()
         }
     }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
@@ -31,54 +31,63 @@ internal
 data class ResolutionRequest(
     val scriptFile: File?,
     val environment: Map<String, Any?>?,
-    val previousDependencies: KotlinScriptExternalDependencies?) : ResolverEvent()
+    val previousDependencies: KotlinScriptExternalDependencies?
+) : ResolverEvent()
 
 
 internal
 data class ResolutionFailure(
     val scriptFile: File?,
-    val failure: Exception) : ResolverEvent()
+    val failure: Exception
+) : ResolverEvent()
 
 
 internal
 data class ResolutionProgress(
     val scriptFile: File?,
-    val description: String) : ResolverEvent()
+    val description: String
+) : ResolverEvent()
 
 
 internal
 data class ResolvedToPrevious(
     val scriptFile: File?,
-    val previousDependencies: KotlinScriptExternalDependencies?) : ResolverEvent()
+    val previousDependencies: KotlinScriptExternalDependencies?
+) : ResolverEvent()
 
 
 internal
 data class SubmittedModelRequest(
     val scriptFile: File?,
-    val request: KotlinBuildScriptModelRequest) : ResolverEvent()
+    val request: KotlinBuildScriptModelRequest
+) : ResolverEvent()
 
 
 internal
 data class ReceivedModelResponse(
     val scriptFile: File?,
-    val response: KotlinBuildScriptModel) : ResolverEvent()
+    val response: KotlinBuildScriptModel
+) : ResolverEvent()
 
 
 internal
 data class ResolvedDependencies(
     val scriptFile: File?,
-    val dependencies: KotlinScriptExternalDependencies) : ResolverEvent()
+    val dependencies: KotlinScriptExternalDependencies
+) : ResolverEvent()
 
 
 internal
 data class ResolvedDependenciesWithErrors(
     val scriptFile: File?,
     val dependencies: KotlinScriptExternalDependencies,
-    val exceptions: List<Exception>) : ResolverEvent()
+    val exceptions: List<Exception>
+) : ResolverEvent()
 
 
 internal
 data class ResolvedToPreviousWithErrors(
     val scriptFile: File?,
     val dependencies: KotlinScriptExternalDependencies,
-    val exceptions: List<Exception>) : ResolverEvent()
+    val exceptions: List<Exception>
+) : ResolverEvent()

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -190,4 +190,3 @@ object ResolverEventLogger {
             else -> "\t\t"
         }
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -94,9 +94,9 @@ object ResolverEventLogger {
     fun logDirForOperatingSystem() =
         OperatingSystem.current().run {
             when {
-                isMacOsX  -> "Library/Logs/gradle-kotlin-dsl"
+                isMacOsX -> "Library/Logs/gradle-kotlin-dsl"
                 isWindows -> "Application Data/gradle-kotlin-dsl/log"
-                else      -> ".gradle-kotlin-dsl/log"
+                else -> ".gradle-kotlin-dsl/log"
             }
         }
 
@@ -120,12 +120,13 @@ object ResolverEventLogger {
                         "scriptFile" to scriptFile,
                         "response" to prettyPrint(response, indentation = 2)))
 
-            is ResolutionFailure     ->
-                prettyPrint("ResolutionFailure",
+            is ResolutionFailure ->
+                prettyPrint(
+                    "ResolutionFailure",
                     sequenceOf(
                         "scriptFile" to scriptFile,
                         "failure" to stringForException(failure, indentation = 2)))
-            else                     ->
+            else ->
                 prettyPrintAny(this)
         }
     }
@@ -186,7 +187,7 @@ object ResolverEventLogger {
     fun indentationStringFor(indentation: Int?) =
         when (indentation) {
             null, 1 -> "\t"
-            else    -> "\t\t"
+            else -> "\t\t"
         }
 }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
@@ -29,7 +29,8 @@ object SourcePathProvider {
         classPath: ClassPath,
         projectDir: File,
         gradleHomeDir: File?,
-        sourceDistributionResolver: SourceDistributionProvider): ClassPath {
+        sourceDistributionResolver: SourceDistributionProvider
+    ): ClassPath {
 
         val gradleKotlinDslJar = classPath.filter { it.name.startsWith("gradle-kotlin-dsl-") }
         val projectBuildSrcRoots = buildSrcRootsOf(projectDir)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
@@ -64,7 +64,5 @@ object SourcePathProvider {
 
 internal
 fun subDirsOf(dir: File): Collection<File> =
-    if (dir.isDirectory)
-        dir.listFiles().filter { it.isDirectory }
-    else
-        emptyList()
+    if (dir.isDirectory) dir.listFiles().filter { it.isDirectory }
+    else emptyList()

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServiceRegistry.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/services/KotlinScriptServiceRegistry.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.services
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry
 
+
 internal
 class KotlinScriptServiceRegistry : AbstractPluginServiceRegistry() {
 
@@ -36,4 +37,3 @@ class KotlinScriptServiceRegistry : AbstractPluginServiceRegistry() {
         registration.addProvider(org.gradle.kotlin.dsl.provider.GradleUserHomeServices)
     }
 }
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassLoaderScopeExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassLoaderScopeExtensions.kt
@@ -34,7 +34,8 @@ fun exportClassPathFromHierarchyOf(scope: ClassLoaderScope): ClassPath {
 
 
 private
-val ClassLoaderScope.root get() = foldHierarchy(this) { _, scope -> scope }
+val ClassLoaderScope.root
+    get() = foldHierarchy(this) { _, scope -> scope }
 
 
 internal

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassLoaderScopeExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassLoaderScopeExtensions.kt
@@ -37,23 +37,23 @@ private
 val ClassLoaderScope.root get() = foldHierarchy(this) { _, scope -> scope }
 
 
-internal inline
-fun <T> ClassLoaderScope.foldHierarchy(initial: T, operation: (T, ClassLoaderScope) -> T): T {
+internal
+inline fun <T> ClassLoaderScope.foldHierarchy(initial: T, operation: (T, ClassLoaderScope) -> T): T {
     var result = initial
     traverseHierarchy { result = operation(result, it) }
     return result
 }
 
 
-internal inline
-fun ClassLoaderScope.traverseHierarchy(action: (ClassLoaderScope) -> Unit) {
+internal
+inline fun ClassLoaderScope.traverseHierarchy(action: (ClassLoaderScope) -> Unit) {
     action(this)
     traverseAncestors(action)
 }
 
 
-internal inline
-fun ClassLoaderScope.traverseAncestors(action: (ClassLoaderScope) -> Unit) {
+internal
+inline fun ClassLoaderScope.traverseAncestors(action: (ClassLoaderScope) -> Unit) {
     var scope = this
     while (scope.parent != scope) {
         scope = scope.parent

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -42,7 +42,8 @@ data class EmbeddedModule(
     val group: String,
     val name: String,
     val version: String,
-    val dependencies: List<EmbeddedModule> = emptyList()) {
+    val dependencies: List<EmbeddedModule> = emptyList()
+) {
 
     val notation = "$group:$name:$version"
     val jarRepoPath = "${group.replace(".", "/")}/$name/$version/$name-$version.jar"
@@ -76,7 +77,8 @@ val embeddedModules: List<EmbeddedModule> by lazy {
 
 class EmbeddedKotlinProvider constructor(
     private val cacheRepository: CacheRepository,
-    private val moduleRegistry: ModuleRegistry) {
+    private val moduleRegistry: ModuleRegistry
+) {
 
     fun addRepositoryTo(repositories: RepositoryHandler) {
 
@@ -89,7 +91,8 @@ class EmbeddedKotlinProvider constructor(
     fun addDependenciesTo(
         dependencies: DependencyHandler,
         configuration: String,
-        vararg kotlinModules: String) {
+        vararg kotlinModules: String
+    ) {
 
         embeddedKotlinModulesFor(kotlinModules).forEach { embeddedKotlinModule ->
             dependencies.add(configuration, clientModuleFor(dependencies, embeddedKotlinModule))

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleUserHomeServices.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleUserHomeServices.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.support
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.cache.CacheRepository
 
+
 internal
 object GradleUserHomeServices {
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
@@ -18,6 +18,6 @@ package org.gradle.kotlin.dsl.support
 
 import java.io.File
 
+
 internal
 fun userHome() = File(System.getProperty("user.home"))
-

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -150,8 +150,8 @@ val kotlinStdlibJar: File
     get() = PathUtil.getResourcePathForClass(Unit::class.java)
 
 
-private inline
-fun <T> withRootDisposable(action: (Disposable) -> T): T {
+private
+inline fun <T> withRootDisposable(action: (Disposable) -> T): T {
     val rootDisposable = newDisposable()
     try {
         return action(rootDisposable)
@@ -161,8 +161,8 @@ fun <T> withRootDisposable(action: (Disposable) -> T): T {
 }
 
 
-private inline
-fun <T> withMessageCollectorFor(log: Logger, action: (MessageCollector) -> T): T {
+private
+inline fun <T> withMessageCollectorFor(log: Logger, action: (MessageCollector) -> T): T {
     val messageCollector = messageCollectorFor(log)
     withCompilationExceptionHandler(messageCollector) {
         return action(messageCollector)
@@ -170,8 +170,8 @@ fun <T> withMessageCollectorFor(log: Logger, action: (MessageCollector) -> T): T
 }
 
 
-private inline
-fun <T> withCompilationExceptionHandler(messageCollector: MessageCollector, action: () -> T): T {
+private
+inline fun <T> withCompilationExceptionHandler(messageCollector: MessageCollector, action: () -> T): T {
     try {
         return action()
     } catch (ex: CompilationException) {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -34,8 +34,15 @@ import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer.dispose
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer.newDisposable
 
-import org.jetbrains.kotlin.config.*
-import org.jetbrains.kotlin.config.JVMConfigurationKeys.*
+import org.jetbrains.kotlin.config.addKotlinSourceRoot
+import org.jetbrains.kotlin.config.addKotlinSourceRoots
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_JAR
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY
 
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor.Companion.registerExtension
 import org.jetbrains.kotlin.name.NameUtils

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -58,7 +58,8 @@ fun compileKotlinScriptToDirectory(
     scriptFile: File,
     scriptDef: KotlinScriptDefinition,
     classPath: List<File>,
-    messageCollector: LoggingMessageCollector): String =
+    messageCollector: LoggingMessageCollector
+): String =
 
     withRootDisposable { rootDisposable ->
 
@@ -102,7 +103,8 @@ fun compileToJar(
     outputJar: File,
     sourceFiles: Iterable<File>,
     logger: Logger,
-    classPath: Iterable<File> = emptyList()): Boolean =
+    classPath: Iterable<File> = emptyList()
+): Boolean =
 
     compileTo(OUTPUT_JAR, outputJar, sourceFiles, logger, classPath)
 
@@ -112,7 +114,8 @@ fun compileToDirectory(
     outputDirectory: File,
     sourceFiles: Iterable<File>,
     logger: Logger,
-    classPath: Iterable<File> = emptyList()): Boolean =
+    classPath: Iterable<File> = emptyList()
+): Boolean =
 
     compileTo(OUTPUT_DIRECTORY, outputDirectory, sourceFiles, logger, classPath)
 
@@ -123,7 +126,8 @@ fun compileTo(
     output: File,
     sourceFiles: Iterable<File>,
     logger: Logger,
-    classPath: Iterable<File>): Boolean {
+    classPath: Iterable<File>
+): Boolean {
 
     withRootDisposable { disposable ->
         withMessageCollectorFor(logger) { messageCollector ->
@@ -275,7 +279,8 @@ const val indent = "  "
 internal
 class LoggingMessageCollector(
     private val log: Logger,
-    private val pathTranslation: (String) -> String) : MessageCollector {
+    private val pathTranslation: (String) -> String
+) : MessageCollector {
 
     val errors = arrayListOf<ScriptCompilationError>()
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
@@ -35,7 +35,8 @@ class KotlinScriptHost<out T : Any>(
     private val scriptSource: ScriptSource,
     private val serviceRegistry: ServiceRegistry,
     private val baseScope: ClassLoaderScope,
-    val scriptHandler: ScriptHandler) {
+    val scriptHandler: ScriptHandler
+) {
 
     internal
     val operations by lazy {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Logger.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Logger.kt
@@ -20,30 +20,30 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 
-internal inline
-fun <reified T : Any> loggerFor(): Logger =
+internal
+inline fun <reified T : Any> loggerFor(): Logger =
     LoggerFactory.getLogger(T::class.java)
 
 
-internal inline
-fun Logger.trace(msg: () -> String) {
+internal
+inline fun Logger.trace(msg: () -> String) {
     if (isTraceEnabled) trace(msg())
 }
 
 
-internal inline
-fun Logger.debug(msg: () -> String) {
+internal
+inline fun Logger.debug(msg: () -> String) {
     if (isDebugEnabled) debug(msg())
 }
 
 
-internal inline
-fun Logger.info(msg: () -> String) {
+internal
+inline fun Logger.info(msg: () -> String) {
     if (isInfoEnabled) info(msg())
 }
 
 
-internal inline
-fun Logger.error(msg: () -> String) {
+internal
+inline fun Logger.error(msg: () -> String) {
     if (isErrorEnabled) error(msg())
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ProgressMonitor.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ProgressMonitor.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.support
 
 import java.io.Closeable
 
+
 interface ProgressMonitor : Closeable {
     fun onProgress()
 }

--- a/provider/src/main/kotlin/org/gradle/script/lang/kotlin/KotlinBuildScript.kt
+++ b/provider/src/main/kotlin/org/gradle/script/lang/kotlin/KotlinBuildScript.kt
@@ -35,4 +35,5 @@ import kotlin.script.templates.ScriptTemplateDefinition
 @SamWithReceiverAnnotations("org.gradle.api.HasImplicitReceiver")
 @GradleDsl
 abstract class KotlinBuildScript(
-    host: KotlinScriptHost<Project>) : org.gradle.kotlin.dsl.KotlinBuildScript(host)
+    host: KotlinScriptHost<Project>
+) : org.gradle.kotlin.dsl.KotlinBuildScript(host)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ComponentSelectionRulesTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ComponentSelectionRulesTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 
 import org.mockito.invocation.InvocationOnMock
 
+
 class ComponentSelectionRulesTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/ConfigurationExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/ConfigurationExtensionsTest.kt
@@ -10,6 +10,7 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
+
 class ConfigurationExtensionsTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -20,6 +20,7 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
+
 class DependencyHandlerExtensionsTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/GroovyInteroperabilityTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/GroovyInteroperabilityTest.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
+
 class GroovyInteroperabilityTest {
 
     @Test
@@ -45,6 +46,7 @@ class GroovyInteroperabilityTest {
         }
         assertEquals(42, list.first())
     }
+
     @Test
     fun `can use closure with a null delegate call`() {
         var passedIntoClosure: Any? = "Something non null"
@@ -234,4 +236,3 @@ class GroovyInteroperabilityTest {
         verify(delegate).withKeywordArguments(expectedKeywordArguments)
     }
 }
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/GroovyInteroperabilityTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/GroovyInteroperabilityTest.kt
@@ -31,7 +31,7 @@ class GroovyInteroperabilityTest {
 
     @Test
     fun `can use closure with single nullable argument call`() {
-        var passedIntoClosure : Any? = "Something non null"
+        var passedIntoClosure: Any? = "Something non null"
         closureOf<Any?> { passedIntoClosure = this }.call(null)
         assertNull(passedIntoClosure)
     }
@@ -47,7 +47,7 @@ class GroovyInteroperabilityTest {
     }
     @Test
     fun `can use closure with a null delegate call`() {
-        var passedIntoClosure : Any? = "Something non null"
+        var passedIntoClosure: Any? = "Something non null"
         delegateClosureOf<Any?> { passedIntoClosure = this }.apply {
             delegate = null
             call()

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 
 import java.util.regex.Pattern
 
+
 class NamedDomainObjectCollectionExtensionsTest {
 
     data class DomainObject(var foo: String? = null)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScopeTest.kt
@@ -12,6 +12,7 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
+
 class PluginDependenciesSpecScopeTest {
 
     @Test
@@ -72,7 +73,6 @@ class PluginDependenciesSpecScopeTest {
             kotlin("jvm") version "1.1.1"
         }
     }
-
 }
 
 
@@ -82,13 +82,15 @@ fun expecting(vararg expected: Plugin, block: PluginDependenciesSpec.() -> Unit)
         equalTo(expected.asList()))
 }
 
+
 fun plugins(block: PluginDependenciesSpecScope.() -> Unit): List<PluginRequestInternal> =
     PluginRequestCollector(StringScriptSource("script", "")).run {
         PluginDependenciesSpecScope(createSpec(1)).block()
         pluginRequests.toList()
     }
 
+
 fun plugin(id: String, version: String? = null, isApply: Boolean = true) = Plugin(id, version, isApply)
 
-data class Plugin(val id: String, val version: String?, val isApply: Boolean)
 
+data class Plugin(val id: String, val version: String?, val isApply: Boolean)

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
@@ -75,8 +75,8 @@ class RepositoryHandlerExtensionsTest {
         verify(repository).name = "repo name"
     }
 
-    private inline
-    operator fun RepositoryHandler.invoke(action: RepositoryHandler.() -> Unit) = apply(action)
+    private
+    inline operator fun RepositoryHandler.invoke(action: RepositoryHandler.() -> Unit) = apply(action)
 
     private
     fun mavenRepositoryHandlerMockFor(repository: MavenArtifactRepository) = mock<RepositoryHandler> {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/RepositoryHandlerExtensionsTest.kt
@@ -10,6 +10,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.junit.Test
 import org.mockito.invocation.InvocationOnMock
 
+
 class RepositoryHandlerExtensionsTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/GenerateProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/GenerateProjectSchemaTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
+
 class GenerateProjectSchemaTest : AbstractIntegrationTest() {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
@@ -36,8 +36,8 @@ class KotlinTypeStringTest {
         assertPrimitiveTypeName<Double>(java.lang.Double.TYPE)
     }
 
-    private inline
-    fun <reified T> assertPrimitiveTypeName(primitiveTypeClass: Class<*>) {
+    private
+    inline fun <reified T> assertPrimitiveTypeName(primitiveTypeClass: Class<*>) {
         assertThat(
             kotlinTypeStringFor(typeOf(primitiveTypeClass)),
             equalTo(T::class.simpleName))

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
@@ -7,6 +7,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
+
 class KotlinTypeStringTest {
 
     @Test
@@ -45,6 +46,7 @@ class KotlinTypeStringTest {
             equalTo(T::class.simpleName))
     }
 }
+
 
 inline
 fun <reified T> typeOf(): TypeOf<T> =

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -13,8 +13,14 @@ import org.objectweb.asm.Opcodes.*
 
 @Suppress("unused")
 class PublicGenericType<T>
+
+
 class PublicComponentType
-private class PrivateComponentType
+
+
+private
+class PrivateComponentType
+
 
 class ProjectSchemaTest : TestWithClassPath() {
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -8,7 +8,8 @@ import org.junit.Assert.assertThat
 import org.junit.Assert.assertFalse
 import org.junit.Test
 
-import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
+import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 
 
 @Suppress("unused")

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
@@ -7,8 +7,13 @@ import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.classEntriesFor
 import org.gradle.kotlin.dsl.support.zipTo
 
-import org.objectweb.asm.*
-import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes.ACC_PUBLIC
+import org.objectweb.asm.Opcodes.ACC_PRIVATE
+import org.objectweb.asm.Opcodes.ALOAD
+import org.objectweb.asm.Opcodes.INVOKESPECIAL
+import org.objectweb.asm.Opcodes.RETURN
+import org.objectweb.asm.Opcodes.V1_7
 
 import java.io.File
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 
 import java.io.File
 
+
 class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
 
     @Test
@@ -774,4 +775,3 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
     val fixturesRepository: File
         get() = File(rootProjectDir, "fixtures/repository").absoluteFile
 }
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptModelIntegrationTest.kt
@@ -83,8 +83,8 @@ class KotlinBuildScriptModelIntegrationTest : ScriptModelIntegrationTest() {
             withClassJar("libs/$fixture.jar", DeepThought::class.java)
 
         val parentJar = withFixture("parent")
-        val fooJar    = withFixture("foo")
-        val barJar    = withFixture("bar")
+        val fooJar = withFixture("foo")
+        val barJar = withFixture("bar")
 
         fun String.withBuildscriptDependencyOn(fixture: File) =
             withFile(this, """
@@ -94,8 +94,8 @@ class KotlinBuildScriptModelIntegrationTest : ScriptModelIntegrationTest() {
             """)
 
         val parentBuildScript = "build.gradle".withBuildscriptDependencyOn(parentJar)
-        val fooBuildScript    = "foo/build.gradle.kts".withBuildscriptDependencyOn(fooJar)
-        val barBuildScript    = "bar/build.gradle.kts".withBuildscriptDependencyOn(barJar)
+        val fooBuildScript = "foo/build.gradle.kts".withBuildscriptDependencyOn(fooJar)
+        val barBuildScript = "bar/build.gradle.kts".withBuildscriptDependencyOn(barJar)
 
         assertClassPathFor(
             parentBuildScript,

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
@@ -98,4 +98,3 @@ class KotlinInitScriptIntegrationTest : AbstractIntegrationTest() {
         }
     }
 }
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptCachingIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptCachingIntegrationTest.kt
@@ -374,7 +374,7 @@ class CompilationCache(val result: BuildResult) {
 
     fun assertCompilations(cachedScript: CachedScript, count: Int) =
         when (cachedScript) {
-            is CachedScript.WholeFile        -> cachedScript.stages.forEach { assertCompilations(it, count) }
+            is CachedScript.WholeFile -> cachedScript.stages.forEach { assertCompilations(it, count) }
             is CachedScript.CompilationStage -> assertCompilations(cachedScript, count)
         }
 
@@ -399,7 +399,7 @@ class ClassLoadingCache(val result: BuildResult) {
 
     fun assertClassLoads(cachedScript: CachedScript, count: Int) =
         when (cachedScript) {
-            is CachedScript.WholeFile        -> cachedScript.stages.forEach { assertClassLoads(it, count) }
+            is CachedScript.WholeFile -> cachedScript.stages.forEach { assertClassLoads(it, count) }
             is CachedScript.CompilationStage -> assertClassLoads(cachedScript, count)
         }
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptCachingIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptCachingIntegrationTest.kt
@@ -278,7 +278,8 @@ data class MultiProjectCachedScripts(
     val settingsFile: CachedScript.WholeFile,
     val rootBuildFile: CachedScript.WholeFile,
     val leftBuildFile: CachedScript.WholeFile,
-    val rightBuildFile: CachedScript.WholeFile)
+    val rightBuildFile: CachedScript.WholeFile
+)
 
 
 private
@@ -287,14 +288,18 @@ sealed class CachedScript {
     class WholeFile(
         val buildscript: CompilationStage? = null,
         val plugins: CompilationStage? = null,
-        val body: CompilationStage) : CachedScript() {
+        val body: CompilationStage
+    ) : CachedScript() {
 
         val stages = listOfNotNull(buildscript, plugins, body)
     }
 
     class CompilationStage(
-        sourceDescription: String, file: File,
-        templateClass: KClass<*>, val enabled: Boolean = true) : CachedScript() {
+        sourceDescription: String,
+        file: File,
+        templateClass: KClass<*>,
+        val enabled: Boolean = true
+    ) : CachedScript() {
 
         val source = "$sourceDescription '$file'"
         val template = templateClass.simpleName!!

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptModelIntegrationTest.kt
@@ -1,4 +1,5 @@
 package org.gradle.kotlin.dsl.integration
+
 import org.gradle.kotlin.dsl.concurrent.future
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptModelIntegrationTest.kt
@@ -59,7 +59,8 @@ abstract class ScriptModelIntegrationTest : AbstractIntegrationTest() {
     fun assertSourcePathGiven(
         rootProjectScript: String,
         subProjectScript: String,
-        matches: Matcher<Iterable<String>>) {
+        matches: Matcher<Iterable<String>>
+    ) {
 
         val subProjectName = "sub"
         withSettings("include(\"$subProjectName\")")

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtractionTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/BuildscriptBlockExtractionTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Test
 
+
 class BuildscriptBlockExtractionTest {
 
     @Test
@@ -105,4 +106,3 @@ class BuildscriptBlockExtractionTest {
         assertNull(extractBuildscriptBlockFrom(script))
     }
 }
-

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ChildFirstClassLoader.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ChildFirstClassLoader.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.provider
 import org.gradle.internal.classloader.VisitableURLClassLoader
 import org.gradle.internal.classpath.ClassPath
 
+
 /**
  * A [VisitableURLClassLoader] that tries to load classes locally before delegating to its parent.
  */

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchyTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ClassLoaderHierarchyTest.kt
@@ -64,11 +64,21 @@ class ClassLoaderHierarchyTest : TestWithTempFiles() {
     }
 
     data class ClassLoaderHierarchy(
-        val classLoaders: List<ClassLoaderNode>, val scopes: List<ScopeNode>)
+        val classLoaders: List<ClassLoaderNode>,
+        val scopes: List<ScopeNode>
+    )
 
     data class ClassLoaderNode(
-        val id: String, val label: String, val parents: Set<String>, val classPath: List<String>)
+        val id: String,
+        val label: String,
+        val parents: Set<String>,
+        val classPath: List<String>
+    )
 
     data class ScopeNode(
-        val label: String, val localClassLoader: String, val exportClassLoader: String, val isLocked: Boolean)
+        val label: String,
+        val localClassLoader: String,
+        val exportClassLoader: String,
+        val isLocked: Boolean
+    )
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -17,6 +17,7 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
+
 class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/LineAndColumnFromRangeTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/LineAndColumnFromRangeTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+
 @RunWith(Parameterized::class)
 class LineAndColumnFromRangeTest(val given: LineAndColumnFromRangeTest.Given) {
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/LinePreservingSubstringTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/LinePreservingSubstringTest.kt
@@ -5,6 +5,7 @@ import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Test
 
+
 class LinePreservingSubstringTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/PluginRequestsHandlerTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/PluginRequestsHandlerTest.kt
@@ -15,6 +15,7 @@ import org.gradle.plugin.use.internal.PluginRequestApplicator
 
 import org.junit.Test
 
+
 class PluginRequestsHandlerTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
@@ -31,7 +31,6 @@ import kotlin.reflect.jvm.jvmErasure
 import org.hamcrest.CoreMatchers.equalTo
 
 import org.junit.Assert.assertThat
-import org.junit.Ignore
 import org.junit.Test
 
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
@@ -49,13 +49,13 @@ class ScriptApiTest {
 }
 
 
-private inline
-fun <reified T> assertScriptApiOf() =
+private
+inline fun <reified T> assertScriptApiOf() =
     assertApiOf<T>(ScriptApi::class)
 
 
-private inline
-fun <reified T> assertApiOf(expectedApi: KClass<*>) =
+private
+inline fun <reified T> assertApiOf(expectedApi: KClass<*>) =
     assertThat(
         expectedApi.apiMembers.missingMembersFrom(T::class),
         equalTo(emptyList()))

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/ScriptApiTest.kt
@@ -97,7 +97,7 @@ fun KCallable<*>.isCompatibleWith(api: KCallable<*>) =
     when (this) {
         is KFunction -> isCompatibleWith(api)
         is KProperty -> isCompatibleWith(api)
-        else         -> false
+        else -> false
     }
 
 
@@ -112,8 +112,8 @@ private
 fun KFunction<*>.isCompatibleWith(api: KCallable<*>) =
     when {
         api is KProperty && api !is KMutableProperty && isCompatibleWithGetterOf(api) -> true
-        api is KFunction && isCompatibleWith(api)                                     -> true
-        else                                                                          -> false
+        api is KFunction && isCompatibleWith(api) -> true
+        else -> false
     }
 
 
@@ -135,18 +135,18 @@ private
 fun List<KParameter>.isCompatibleWith(api: List<KParameter>) =
     when {
         size != api.size -> false
-        isEmpty()        -> true
-        else             -> (0..(size - 1)).all { idx -> this[idx].isCompatibleWith(api[idx]) }
+        isEmpty() -> true
+        else -> (0..(size - 1)).all { idx -> this[idx].isCompatibleWith(api[idx]) }
     }
 
 
 private
 fun KParameter.isCompatibleWith(api: KParameter) =
     when {
-        isVarargCompatibleWith(api)                  -> true
-        isGradleActionCompatibleWith(api)            -> true
+        isVarargCompatibleWith(api) -> true
+        isGradleActionCompatibleWith(api) -> true
         type.isParameterTypeCompatibleWith(api.type) -> true
-        else                                         -> false
+        else -> false
     }
 
 
@@ -171,10 +171,10 @@ fun KParameter.isVarargCompatibleWith(api: KParameter) =
 private
 fun KType.isParameterTypeCompatibleWith(apiParameterType: KType) =
     when {
-        this == apiParameterType                     -> true
-        classifier != apiParameterType.classifier    -> false
+        this == apiParameterType -> true
+        classifier != apiParameterType.classifier -> false
         hasCompatibleTypeArguments(apiParameterType) -> true
-        else                                         -> false
+        else -> false
     }
 
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/CompactTreeTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/CompactTreeTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Assert.assertThat
 import org.junit.Test
 
+
 class CompactTreeTest {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ProjectRootOfTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ProjectRootOfTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+
 @RunWith(Parameterized::class)
 class ProjectRootOfTest(private val settingsFileName: String) : FolderBasedTest() {
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
@@ -2,6 +2,7 @@ package org.gradle.kotlin.dsl.resolver
 
 import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
 
+
 class ResolverCoordinatorTest {
 
     @org.junit.Test
@@ -73,6 +74,7 @@ class ResolverCoordinatorTest {
     fun environmentWithGetScriptSectionTokens(function: (CharSequence, String) -> Sequence<String>) =
         mapOf<String, Any?>("getScriptSectionTokens" to function)
 }
+
 
 private
 object EmptyScriptContents : kotlin.script.dependencies.ScriptContents {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
@@ -63,8 +63,7 @@ class ResolverCoordinatorTest {
 
     private
     fun ResolverAction.RequestNew.scriptDependencies() =
-        KotlinBuildScriptDependencies(emptyList(), emptyList(), emptyList(),
-                                                                             buildscriptBlockHash)
+        KotlinBuildScriptDependencies(emptyList(), emptyList(), emptyList(), buildscriptBlockHash)
 
     private
     fun environmentWithGetScriptSectionTokensReturning(vararg sections: Pair<String, Sequence<String>>) =
@@ -76,8 +75,7 @@ class ResolverCoordinatorTest {
 }
 
 private
-object EmptyScriptContents : kotlin.script.dependencies.ScriptContents
-{
+object EmptyScriptContents : kotlin.script.dependencies.ScriptContents {
     override val file: java.io.File? = null
     override val text: CharSequence? = ""
     override val annotations: Iterable<Annotation> = emptyList()

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -14,7 +14,7 @@ class EmbeddedKotlinProviderTest : AbstractIntegrationTest() {
 
         val result = build("buildEnvironment")
 
-        assertThat(result.output, containsString("No dependencies"));
+        assertThat(result.output, containsString("No dependencies"))
     }
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
@@ -5,6 +5,7 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
+
 class ImplicitImportsTest : AbstractIntegrationTest() {
 
     @Test

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerTest.kt
@@ -11,6 +11,7 @@ import java.io.File
 
 import java.net.URLClassLoader
 
+
 class KotlinCompilerTest : TestWithTempFiles() {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/BuildCacheSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/BuildCacheSampleTest.kt
@@ -5,6 +5,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Assert.assertThat
 import org.junit.Test
 
+
 class BuildCacheSampleTest : AbstractSampleTest("build-cache") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/BuildScanSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/BuildScanSampleTest.kt
@@ -3,11 +3,11 @@ package org.gradle.kotlin.dsl.samples
 import org.gradle.kotlin.dsl.fixtures.canPublishBuildScan
 import org.junit.Test
 
+
 class BuildScanSampleTest : AbstractSampleTest("build-scan") {
 
     @Test
     fun `publishes build scan`() {
         canPublishBuildScan()
     }
-
 }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/JavaScriptSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/JavaScriptSampleTest.kt
@@ -1,6 +1,5 @@
 package org.gradle.kotlin.dsl.samples
 
-
 import org.junit.Test
 import java.io.File
 import java.io.FileReader
@@ -10,6 +9,7 @@ import org.junit.Assert.assertThat
 import org.hamcrest.CoreMatchers.equalTo
 import java.io.Writer
 import javax.script.ScriptEngine
+
 
 class JavaScriptSampleTest : AbstractSampleTest("hello-js") {
 

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MavenPluginSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MavenPluginSampleTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertThat
 import org.xmlunit.matchers.CompareMatcher.isIdenticalTo
 import java.io.File
 
+
 class MavenPluginSampleTest : AbstractSampleTest("maven-plugin") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MavenPublishSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MavenPublishSampleTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import java.io.File
 import java.util.jar.JarFile
 
+
 class MavenPublishSampleTest : AbstractSampleTest("maven-publish") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ModularitySampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ModularitySampleTest.kt
@@ -12,7 +12,8 @@ class ModularitySampleTest : AbstractSampleTest("modularity") {
     fun `modularity`() {
         assertThat(
             build("foo", "bar").output,
-            allOf(containsString("Foo!"),
-                  containsString("Bar!")))
+            allOf(
+                containsString("Foo!"),
+                containsString("Bar!")))
     }
 }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectWithBuildSrcSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/MultiKotlinProjectWithBuildSrcSampleTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
+
 class MultiKotlinProjectWithBuildSrcSampleTest : AbstractSampleTest("multi-kotlin-project-with-buildSrc") {
 
     @Test

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SamplesSmokeTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SamplesSmokeTest.kt
@@ -18,7 +18,8 @@ import java.io.File
 @RunWith(Parameterized::class)
 class SamplesSmokeTest(
     private val sampleName: String,
-    private val sampleDir: File) : AbstractIntegrationTest() {
+    private val sampleDir: File
+) : AbstractIntegrationTest() {
 
     companion object {
         @Parameterized.Parameters(name = "{0}")

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SamplesSmokeTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SamplesSmokeTest.kt
@@ -46,8 +46,9 @@ class SamplesSmokeTest(
         val buildsToCheck =
             if (File(sampleDir, "buildSrc").isDirectory) {
                 projectBuilds + listOf(buildSpec("-p", "buildSrc", "buildEnvironment"))
-            } else
+            } else {
                 projectBuilds
+            }
 
         val foundKotlinGradlePlugin = buildsToCheck.map(::assertKotlinGradlePluginVersion)
 
@@ -71,8 +72,9 @@ class SamplesSmokeTest(
             if (output.contains(":kotlin-gradle-plugin:")) {
                 assertThat(output, containsString(":kotlin-gradle-plugin:$embeddedKotlinVersion"))
                 true
-            } else
+            } else {
                 false
+            }
         }
 
     private

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SourceControlSampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/SourceControlSampleTest.kt
@@ -4,6 +4,7 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
+
 class SourceControlSampleTest : AbstractSampleTest("source-control") {
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,5 +5,6 @@ include(
     "tooling-models",
     "tooling-builders",
     "plugins",
+    "plugins-experiments",
     "test-fixtures",
     "samples-tests")

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
@@ -168,9 +168,9 @@ fun customDaemonRegistry() =
 
 fun customInstallation() =
     customInstallationBuildDir.listFiles()?.let {
-        it.singleOrNull { it.name.startsWith("gradle") } ?:
-            throw IllegalStateException(
-                "Expected 1 custom installation but found ${it.size}. Run `./gradlew clean customInstallation`.")
+        it.singleOrNull { it.name.startsWith("gradle") } ?: throw IllegalStateException(
+            "Expected 1 custom installation but found ${it.size}. Run `./gradlew clean customInstallation`."
+        )
     } ?: throw IllegalStateException("Custom installation not found. Run `./gradlew customInstallation`.")
 
 

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
@@ -95,7 +95,7 @@ open class AbstractIntegrationTest {
         existing(fileName).let {
             when {
                 it.isFile -> it
-                else      -> newFile(fileName)
+                else -> newFile(fileName)
             }
         }
 

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractPluginTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractPluginTest.kt
@@ -1,6 +1,4 @@
-package org.gradle.kotlin.dsl.plugins
-
-import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+package org.gradle.kotlin.dsl.fixtures
 
 import org.gradle.util.TextUtil.normaliseFileSeparators
 
@@ -9,6 +7,11 @@ import org.junit.Before
 import java.io.File
 import java.util.*
 
+
+/**
+ * Base class for Gradle plugins tests.
+ * You must apply the `kotlin-dsl-plugin-bundle` plugin for this to work.
+ */
 open class AbstractPluginTest : AbstractIntegrationTest() {
 
     @Before
@@ -19,7 +22,7 @@ open class AbstractPluginTest : AbstractIntegrationTest() {
             pluginManagement {
                 repositories {
                     maven { url = uri("$testRepository") }
-                    jcenter()
+                    gradlePluginPortal()
                 }
                 resolutionStrategy {
                     eachPlugin {

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
@@ -4,6 +4,7 @@ import org.junit.Rule
 
 import java.io.File
 
+
 abstract class FolderBasedTest {
 
     @JvmField
@@ -29,10 +30,13 @@ abstract class FolderBasedTest {
         }
 }
 
+
 typealias FoldersDslExpression = FoldersDsl.() -> Unit
+
 
 fun File.withFolders(folders: FoldersDslExpression) =
     apply { FoldersDsl(this).folders() }
+
 
 class FoldersDsl(val root: File) {
 
@@ -48,5 +52,4 @@ class FoldersDsl(val root: File) {
     private
     fun String.asCanonicalFile(): File =
         File(root, this).canonicalFile
-
 }

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
@@ -4,6 +4,7 @@ import org.junit.Rule
 
 import java.io.File
 
+
 abstract class TestWithTempFiles {
 
     @JvmField

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.fail
 
 import kotlin.reflect.KClass
 
+
 fun <T : Throwable> assertFailsWith(exception: KClass<out T>, block: () -> Unit): T {
     try {
         block()
@@ -19,14 +20,15 @@ fun <T : Throwable> assertFailsWith(exception: KClass<out T>, block: () -> Unit)
     throw IllegalStateException()
 }
 
+
 inline
 fun <reified T> withInstanceOf(o: Any, block: T.() -> Unit) {
     block(assertInstanceOf<T>(o))
 }
+
 
 inline
 fun <reified T> assertInstanceOf(o: Any): T {
     assertThat(o, instanceOf(T::class.java))
     return o as T
 }
-

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/zipUtils.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/zipUtils.kt
@@ -3,11 +3,13 @@ package org.gradle.kotlin.dsl.fixtures
 import org.gradle.kotlin.dsl.support.zipTo
 import java.io.ByteArrayOutputStream
 
+
 fun zipOf(entries: Sequence<Pair<String, ByteArray>>): ByteArray =
     ByteArrayOutputStream().run {
         zipTo(this, entries)
         toByteArray()
     }
+
 
 fun classEntriesFor(vararg classes: Class<*>): Sequence<Pair<String, ByteArray>> =
     classes.asSequence().map {

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -63,7 +63,8 @@ data class StandardKotlinBuildScriptModel(
     override val classPath: List<File>,
     override val sourcePath: List<File>,
     override val implicitImports: List<String>,
-    override val exceptions: List<Exception>) : KotlinBuildScriptModel, Serializable
+    override val exceptions: List<Exception>
+) : KotlinBuildScriptModel, Serializable
 
 
 internal
@@ -159,7 +160,8 @@ data class KotlinScriptTargetModelBuilder<T : Any>(
     val project: Project,
     val scriptClassPath: ClassPath,
     val accessorsClassPath: (ClassPath) -> AccessorsClassPath = { AccessorsClassPath.empty },
-    val sourceLookupScriptHandlers: List<ScriptHandler>) {
+    val sourceLookupScriptHandlers: List<ScriptHandler>
+) {
 
     fun buildModel(): KotlinBuildScriptModel {
         val accessorsClassPath = accessorsClassPath(scriptClassPath)

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -260,4 +260,3 @@ val Project.hierarchy: Sequence<Project>
 private
 fun canonicalFile(path: String): File =
     File(path).canonicalFile
-

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -84,10 +84,10 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
     private
     fun scriptModelBuilderFor(modelRequestProject: Project, parameter: KotlinBuildScriptModelParameter) =
         when {
-            parameter.noScriptPath   -> projectScriptModelBuilder(modelRequestProject)
+            parameter.noScriptPath -> projectScriptModelBuilder(modelRequestProject)
             parameter.settingsScript -> settingsScriptModelBuilder(modelRequestProject)
-            parameter.initScript     -> initScriptModelBuilder(parameter.scriptFile!!, modelRequestProject)
-            else                     -> resolveScriptModelBuilderFor(parameter.scriptFile!!, modelRequestProject)
+            parameter.initScript -> initScriptModelBuilder(parameter.scriptFile!!, modelRequestProject)
+            else -> resolveScriptModelBuilderFor(parameter.scriptFile!!, modelRequestProject)
         }
 
     private

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelBuilder.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelBuilder.kt
@@ -51,4 +51,5 @@ object KotlinBuildScriptTemplateModelBuilder : ToolingModelBuilder {
 
 internal
 data class StandardKotlinBuildScriptTemplateModel(
-    override val classPath: List<File>) : KotlinBuildScriptTemplateModel, Serializable
+    override val classPath: List<File>
+) : KotlinBuildScriptTemplateModel, Serializable

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinScriptingModelBuildersRegistrationAction.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinScriptingModelBuildersRegistrationAction.kt
@@ -23,6 +23,7 @@ import org.gradle.kotlin.dsl.support.serviceOf
 
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 
+
 class KotlinScriptingModelBuildersRegistrationAction : ProjectConfigureAction {
 
     override fun execute(project: ProjectInternal) {

--- a/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptTemplateModel.kt
+++ b/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptTemplateModel.kt
@@ -17,6 +17,7 @@ package org.gradle.kotlin.dsl.tooling.models
 
 import java.io.File
 
+
 /**
  * Kotlin build script template model.
  */


### PR DESCRIPTION
This PR introduces an experimental Gradle plugin that lints Kotlin code using ktlint.

The goal of this PR is to have basic `ktlint` checks run as part of the build and a selected few custom rules, the set of linting rules can then be enhanced as further steps.

The convention plugin applies [org.jlleitschuh.gradle.ktlint](https://github.com/JLLeitschuh/ktlint-gradle) and contains a custom set of ktlint rules.

A first `0.1.0` version of the plugin has been published at https://plugins.gradle.org/plugin/org.gradle.kotlin.ktlint-convention

This PR also contains a set of commits that apply the plugin to this build and apply the enforced rules to this repository codebase.

Run `./gradlew ktlintCheck --continue` to run the checks on this repository.