### PR TITLE
Let the embedded kotlin repository be registered as artifacts-only

### DIFF
--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -241,6 +241,26 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
         }
     }
 
+    @Test
+    fun `can be used with GRADLE_METADATA feature preview enabled`() {
+
+        withSettings("""enableFeaturePreview("GRADLE_METADATA")""")
+
+        withBuildScript("""
+
+            plugins {
+                `embedded-kotlin`
+            }
+
+        """)
+
+        withFile("src/main/kotlin/source.kt", """var foo = "bar"""")
+
+        val result = buildWithPlugin("assemble")
+
+        assertThat(result.outcomeOf(":compileKotlin"), equalTo(TaskOutcome.SUCCESS))
+    }
+
     private
     fun dependencyDeclarationsFor(configuration: String, modules: List<String>, version: String? = null) =
         modules.map {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -85,6 +85,9 @@ class EmbeddedKotlinProvider constructor(
         repositories.maven { repo ->
             repo.name = "Embedded Kotlin Repository"
             repo.url = embeddedKotlinRepositoryURI()
+            repo.metadataSources { sources ->
+                sources.artifact()
+            }
         }
     }
 


### PR DESCRIPTION
allowing to use it when GRADLE_METADATA feature preview is enabled

See #754