### PR TITLE
Fix Gradle sources resolution in face of -bin snapshot distribution with GRADLE_METADATA feature preview enabled

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -92,6 +92,9 @@ class SourceDistributionResolver(val project: Project) : SourceDistributionProvi
         val repoName = repositoryNameFor(gradleVersion)
         name = "Gradle $repoName"
         setUrl("https://services.gradle.org/$repoName")
+        metadataSources { sources ->
+            sources.artifact()
+        }
         layout("pattern") {
             val layout = it as IvyPatternRepositoryLayout
             if (isSnapshot(gradleVersion)) {


### PR DESCRIPTION
Before this change,
with a snapshot Gradle distro `-bin`,
and `enableFeaturePreview("GRADLE_METADATA")` in `settings.gradle.kts`,
when opening a script in IntelliJ,
the script dependencies resolver throws: https://gist.github.com/eskatos/170932f5aeaf92495d6ae19e89bbe6ac,
no dependencies are returned to IntelliJ,
which highlight the whole file red.

This PR fixes the synthetic repository used to resolve Gradle sources to declare it contains artifacts only. This is basically the same fix as for #754.

I confirmed manually that it fixes the issue at hand with `enableFeaturePreview("GRADLE_METADATA")`.
