### PR TITLE
Let Gradle distribution sources resolution be lenient in face of errors

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -45,6 +45,15 @@ class SourceDistributionResolver(val project: Project) : SourceDistributionProvi
     }
 
     override fun sourceDirs(): Collection<File> =
+        try {
+            collectSourceDirs()
+        } catch (ex: Exception) {
+            project.logger.warn("Unexpected exception while resolving Gradle distribution sources: ${ex.message}", ex)
+            emptyList()
+        }
+
+    private
+    fun collectSourceDirs() =
         withSourceRepository {
             registerTransforms()
             transientConfigurationForSourcesDownload().files


### PR DESCRIPTION
Follow up to #759 

This PR makes Gradle source resolution lenient while logging exceptions.

This code will run in a Gradle daemon behind the TAPI builders that the IntelliJ script dependencies resolver will invoke. The log will end up in the daemon logs.