### PR TITLE
Location aware exceptions for script evaluation errors

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPluginFactory.kt
@@ -61,14 +61,15 @@ class KotlinScriptPluginFactory @Inject internal constructor(
     ): (Any) -> Unit = { target ->
 
         val scriptTarget = kotlinScriptTargetFor(target, scriptSource, scriptHandler, baseScope, topLevelScript)
-        val script = compile(scriptTarget, scriptSource, scriptHandler, targetScope, baseScope)
+        val kotlinScriptSource = KotlinScriptSource(scriptSource)
+        val script = compile(scriptTarget, kotlinScriptSource, scriptHandler, targetScope, baseScope)
         script(scriptTarget.`object`)
     }
 
     private
     fun compile(
         scriptTarget: KotlinScriptTarget<Any>,
-        scriptSource: ScriptSource,
+        scriptSource: KotlinScriptSource,
         scriptHandler: ScriptHandler,
         targetScope: ClassLoaderScope,
         baseScope: ClassLoaderScope
@@ -83,7 +84,7 @@ class KotlinScriptPluginFactory @Inject internal constructor(
     private
     fun compilerFor(
         scriptTarget: KotlinScriptTarget<Any>,
-        scriptSource: ScriptSource,
+        scriptSource: KotlinScriptSource,
         scriptHandler: ScriptHandler,
         targetScope: ClassLoaderScope,
         baseScope: ClassLoaderScope
@@ -92,7 +93,7 @@ class KotlinScriptPluginFactory @Inject internal constructor(
         KotlinBuildScriptCompiler(
             kotlinCompiler,
             classloadingCache,
-            KotlinScriptSource(scriptSource),
+            scriptSource,
             scriptTarget,
             scriptHandler as ScriptHandlerInternal,
             pluginRequestsHandler,

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
     private
-    val boom = """throw InternalError("BOUM!")"""
+    val boom = """throw InternalError("BOOM!")"""
 
     @Test
     fun `location of exception thrown from build script is reported`() {

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
@@ -18,7 +18,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withSettings("""include("a")""")
         val script = withBuildScriptIn("a", boom)
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Build file '${script.canonicalPath}' line: 1
@@ -32,7 +32,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withBuildScript("""apply(from = "other.gradle.kts")""")
         val script = withFile("other.gradle.kts", boom)
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Script '${script.canonicalPath}' line: 1
@@ -46,7 +46,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withBuildScript("""apply(from = "other/build.gradle.kts")""")
         val script = withFile("other/build.gradle.kts", boom)
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Script '${script.canonicalPath}' line: 1
@@ -59,7 +59,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withBuildScript("buildscript { $boom }")
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Build file '${script.canonicalPath}' line: 1
@@ -72,7 +72,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withBuildScript("plugins { $boom }")
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Build file '${script.canonicalPath}' line: 1
@@ -85,7 +85,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withSettings(boom)
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Settings file '${script.canonicalPath}' line: 1
@@ -98,7 +98,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withFile("my.init.gradle.kts", boom)
 
-        assertFailingBuildOutputContains("help", "-I", script.absolutePath) {
+        assertFailingBuildOutputOf("help", "-I", script.absolutePath) {
             """
             * Where:
             Initialization script '${script.canonicalPath}' line: 1
@@ -112,7 +112,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withBuildScript("""apply(from = "present.gradle.kts")""")
         val present = withFile("present.gradle.kts", """apply(from = "absent.gradle.kts")""")
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Script '${present.canonicalPath}' line: 1
@@ -132,7 +132,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
             $boom
         """)
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Script '${script.canonicalPath}' line: 3
@@ -158,7 +158,7 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
             throw new InternalError("BOOM!")
         """)
 
-        assertFailingBuildOutputContains("help") {
+        assertFailingBuildOutputOf("help") {
             """
             * Where:
             Build file '${kotlinScript.canonicalPath}' line: 1
@@ -167,6 +167,6 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
     }
 
     private
-    fun assertFailingBuildOutputContains(vararg arguments: String, string: () -> String) =
+    fun assertFailingBuildOutputOf(vararg arguments: String, string: () -> String) =
         assertThat(buildAndFail(*arguments).output, containsMultiLineString(string()))
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
@@ -18,10 +18,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withSettings("""include("a")""")
         val script = withBuildScriptIn("a", boom)
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Build file '${script.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
 
     @Test
@@ -30,10 +32,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withBuildScript("""apply(from = "other.gradle.kts")""")
         val script = withFile("other.gradle.kts", boom)
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Script '${script.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
 
     @Test
@@ -42,10 +46,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withBuildScript("""apply(from = "other/build.gradle.kts")""")
         val script = withFile("other/build.gradle.kts", boom)
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Script '${script.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
 
     @Test
@@ -53,10 +59,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withBuildScript("buildscript { $boom }")
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Build file '${script.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
 
     @Test
@@ -64,10 +72,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withBuildScript("plugins { $boom }")
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Build file '${script.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
 
     @Test
@@ -75,10 +85,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withSettings(boom)
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Settings file '${script.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
 
     @Test
@@ -86,10 +98,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
 
         val script = withFile("my.init.gradle.kts", boom)
 
-        assertThat(buildAndFail("help", "-I", script.absolutePath).output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help", "-I", script.absolutePath) {
+            """
             * Where:
             Initialization script '${script.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
 
     @Test
@@ -98,13 +112,15 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
         withBuildScript("""apply(from = "present.gradle.kts")""")
         val present = withFile("present.gradle.kts", """apply(from = "absent.gradle.kts")""")
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Script '${present.canonicalPath}' line: 1
 
             * What went wrong:
             Could not read script '${existing("absent.gradle.kts").canonicalPath}' as it does not exist.
-        """))
+            """
+        }
     }
 
     @Test
@@ -116,10 +132,12 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
             $boom
         """)
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Script '${script.canonicalPath}' line: 3
-        """))
+            """
+        }
     }
 
     /**
@@ -140,9 +158,15 @@ class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
             throw new InternalError("BOOM!")
         """)
 
-        assertThat(buildAndFail("help").output, containsMultiLineString("""
+        assertFailingBuildOutputContains("help") {
+            """
             * Where:
             Build file '${kotlinScript.canonicalPath}' line: 1
-        """))
+            """
+        }
     }
+
+    private
+    fun assertFailingBuildOutputContains(vararg arguments: String, string: () -> String) =
+        assertThat(buildAndFail(*arguments).output, containsMultiLineString(string()))
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/LocationAwareScriptEvaluationIntegrationTest.kt
@@ -1,0 +1,148 @@
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+
+class LocationAwareScriptEvaluationIntegrationTest : AbstractIntegrationTest() {
+
+    private
+    val boom = """throw InternalError("BOUM!")"""
+
+    @Test
+    fun `location of exception thrown from build script is reported`() {
+
+        withSettings("""include("a")""")
+        val script = withBuildScriptIn("a", boom)
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Build file '${script.canonicalPath}' line: 1
+        """))
+    }
+
+    @Test
+    fun `location of exception thrown from applied script is reported`() {
+
+        withBuildScript("""apply(from = "other.gradle.kts")""")
+        val script = withFile("other.gradle.kts", boom)
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Script '${script.canonicalPath}' line: 1
+        """))
+    }
+
+    @Test
+    fun `location of exception thrown from applied script with same filename is reported`() {
+
+        withBuildScript("""apply(from = "other/build.gradle.kts")""")
+        val script = withFile("other/build.gradle.kts", boom)
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Script '${script.canonicalPath}' line: 1
+        """))
+    }
+
+    @Test
+    fun `location of exception thrown from buildscript block is reported`() {
+
+        val script = withBuildScript("buildscript { $boom }")
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Build file '${script.canonicalPath}' line: 1
+        """))
+    }
+
+    @Test
+    fun `location of exception thrown from plugins block is reported`() {
+
+        val script = withBuildScript("plugins { $boom }")
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Build file '${script.canonicalPath}' line: 1
+        """))
+    }
+
+    @Test
+    fun `location of exception thrown from settings script is reported`() {
+
+        val script = withSettings(boom)
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Settings file '${script.canonicalPath}' line: 1
+        """))
+    }
+
+    @Test
+    fun `location of exception thrown from initialization script is reported`() {
+
+        val script = withFile("my.init.gradle.kts", boom)
+
+        assertThat(buildAndFail("help", "-I", script.absolutePath).output, containsMultiLineString("""
+            * Where:
+            Initialization script '${script.canonicalPath}' line: 1
+        """))
+    }
+
+    @Test
+    fun `location of missing script application is reported`() {
+
+        withBuildScript("""apply(from = "present.gradle.kts")""")
+        val present = withFile("present.gradle.kts", """apply(from = "absent.gradle.kts")""")
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Script '${present.canonicalPath}' line: 1
+
+            * What went wrong:
+            Could not read script '${existing("absent.gradle.kts").canonicalPath}' as it does not exist.
+        """))
+    }
+
+    @Test
+    fun `location of exception thrown by kotlin script applied from groovy script is reported`() {
+
+        withFile("build.gradle", "apply from: 'other.gradle.kts'")
+        val script = withFile("other.gradle.kts", """
+            println("In Kotlin Script")
+            $boom
+        """)
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Script '${script.canonicalPath}' line: 3
+        """))
+    }
+
+    /**
+     * This is a caveat.
+     * The Groovy DSL provider relies on exceptions being analyzed up the stack.
+     * See [org.gradle.initialization.DefaultExceptionAnalyser.transform], note the comments.
+     * The Kotlin DSL provider handles this in isolation,
+     * thus hiding the location of exceptions thrown by groovy scripts applied from kotlin scripts.
+     *
+     * This test exercises the current behavior.
+     */
+    @Test
+    fun `location of exception thrown by groovy script applied from kotlin script shadowed by the kotlin location`() {
+
+        val kotlinScript = withBuildScript("""apply(from = "other.gradle")""")
+        withFile("other.gradle", """
+            println("In Groovy Script")
+            throw new InternalError("BOOM!")
+        """)
+
+        assertThat(buildAndFail("help").output, containsMultiLineString("""
+            * Where:
+            Build file '${kotlinScript.canonicalPath}' line: 1
+        """))
+    }
+}


### PR DESCRIPTION
This PR let script evaluation errors throw a `LocationAwareException` when applicable, allowing for contextual error reporting on the console, IntelliJ to add a link to the offending line on errors etc...

`KotlinScriptSource` instantiation had to be moved up the stack in order to eagerly propagate exceptions thrown when the script doesn't exist.