### PR TITLE
Provide correct classpath for precompiled script plugins to the IDE

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConventionExtensions.kt
@@ -42,8 +42,17 @@ fun <reified T : Any> Convention.getPlugin() =
     getPlugin(T::class)
 
 
-fun <T : Any> Convention.getPlugin(conventionType: KClass<T>) =
+fun <T : Any> Convention.getPlugin(conventionType: KClass<T>): T =
     getPlugin(conventionType.java)
+
+
+inline
+fun <reified T : Any> Convention.findPlugin() =
+    findPlugin(T::class)
+
+
+fun <T : Any> Convention.findPlugin(conventionType: KClass<T>): T? =
+    findPlugin(conventionType.java)
 
 
 /**

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -93,7 +93,7 @@ inline
 fun <reified T : Any> Project.configure(noinline configuration: T.() -> Unit): Unit =
     typeOf<T>().let { type ->
         convention.findByType(type)?.let(configuration)
-            ?: convention.findPlugin(T::class.java)?.let(configuration)
+            ?: convention.findPlugin<T>()?.let(configuration)
             ?: convention.configure(type, configuration)
     }
 
@@ -105,7 +105,7 @@ inline
 fun <reified T : Any> Project.the(): T =
     typeOf<T>().let { type ->
         convention.findByType(type)
-            ?: convention.findPlugin(T::class.java)
+            ?: convention.findPlugin()
             ?: convention.getByType(type)
     }
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginModelIntegrationTest.kt
@@ -13,8 +13,8 @@ class PrecompiledScriptPluginModelIntegrationTest : ScriptModelIntegrationTest()
     @Test
     fun `given a single project build, the classpath of a precompiled script plugin is the compile classpath of its enclosing source-set`() {
 
-        val compileDependency =
-            withFile("compile.jar")
+        val implementationDependency =
+            withFile("implementation.jar")
 
         val classpathDependency =
             withFile("classpath.jar")
@@ -31,7 +31,7 @@ class PrecompiledScriptPluginModelIntegrationTest : ScriptModelIntegrationTest()
             }
 
             dependencies {
-                compile(files("${compileDependency.name}"))
+                implementation(files("${implementationDependency.name}"))
             }
         """)
 
@@ -40,7 +40,7 @@ class PrecompiledScriptPluginModelIntegrationTest : ScriptModelIntegrationTest()
 
         assertClassPathFor(
             precompiledScriptPlugin,
-            includes = setOf(compileDependency),
+            includes = setOf(implementationDependency),
             excludes = setOf(classpathDependency))
     }
 
@@ -64,14 +64,14 @@ class PrecompiledScriptPluginModelIntegrationTest : ScriptModelIntegrationTest()
                 "src/main/kotlin" {
                     withFile("my-plugin-a.gradle.kts")
                 }
-                withCompileDependencyOn(dependencyA)
+                withImplementationDependencyOn(dependencyA)
             }
 
             "project-b" {
                 "src/main/kotlin" {
                     withFile("my-plugin-b.gradle.kts")
                 }
-                withCompileDependencyOn(dependencyB)
+                withImplementationDependencyOn(dependencyB)
             }
         }
 
@@ -87,14 +87,14 @@ class PrecompiledScriptPluginModelIntegrationTest : ScriptModelIntegrationTest()
     }
 
     private
-    fun FoldersDsl.withCompileDependencyOn(file: File) {
+    fun FoldersDsl.withImplementationDependencyOn(file: File) {
         withFile("build.gradle.kts", """
             plugins {
                 `kotlin-dsl`
             }
 
             dependencies {
-                compile(files("${file.name}"))
+                implementation(files("${file.name}"))
             }
         """)
     }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginModelIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginModelIntegrationTest.kt
@@ -1,0 +1,101 @@
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.FoldersDsl
+import org.gradle.kotlin.dsl.fixtures.withFolders
+
+import org.junit.Test
+
+import java.io.File
+
+
+class PrecompiledScriptPluginModelIntegrationTest : ScriptModelIntegrationTest() {
+
+    @Test
+    fun `given a single project build, the classpath of a precompiled script plugin is the compile classpath of its enclosing source-set`() {
+
+        val compileDependency =
+            withFile("compile.jar")
+
+        val classpathDependency =
+            withFile("classpath.jar")
+
+        withBuildScript("""
+            plugins {
+                `kotlin-dsl`
+            }
+
+            buildscript {
+                dependencies {
+                    classpath(files("${classpathDependency.name}"))
+                }
+            }
+
+            dependencies {
+                compile(files("${compileDependency.name}"))
+            }
+        """)
+
+        val precompiledScriptPlugin =
+            withFile("src/main/kotlin/my-plugin.gradle.kts")
+
+        assertClassPathFor(
+            precompiledScriptPlugin,
+            includes = setOf(compileDependency),
+            excludes = setOf(classpathDependency))
+    }
+
+    @Test
+    fun `given a multi-project build, the classpath of a precompiled script plugin is the compile classpath of its enclosing source-set`() {
+
+        val dependencyA =
+            withFile("a.jar")
+
+        val dependencyB =
+            withFile("b.jar")
+
+        projectRoot.withFolders {
+
+            withFile("settings.gradle.kts", """
+                include("project-a")
+                include("project-b")
+            """)
+
+            "project-a" {
+                "src/main/kotlin" {
+                    withFile("my-plugin-a.gradle.kts")
+                }
+                withCompileDependencyOn(dependencyA)
+            }
+
+            "project-b" {
+                "src/main/kotlin" {
+                    withFile("my-plugin-b.gradle.kts")
+                }
+                withCompileDependencyOn(dependencyB)
+            }
+        }
+
+        assertClassPathFor(
+            existing("project-a/src/main/kotlin/my-plugin-a.gradle.kts"),
+            includes = setOf(dependencyA),
+            excludes = setOf(dependencyB))
+
+        assertClassPathFor(
+            existing("project-b/src/main/kotlin/my-plugin-b.gradle.kts"),
+            includes = setOf(dependencyB),
+            excludes = setOf(dependencyA))
+    }
+
+    private
+    fun FoldersDsl.withCompileDependencyOn(file: File) {
+        withFile("build.gradle.kts", """
+            plugins {
+                `kotlin-dsl`
+            }
+
+            dependencies {
+                compile(files("${file.name}"))
+            }
+        """)
+    }
+}

--- a/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -142,8 +142,7 @@ private
 fun precompiledScriptPluginModelBuilder(enclosingSourceSet: SourceSet, modelRequestProject: Project): KotlinScriptTargetModelBuilder =
     KotlinScriptTargetModelBuilder(
         project = modelRequestProject,
-        scriptClassPath = DefaultClassPath(enclosingSourceSet.compileClasspath),
-        sourceLookupScriptHandlers = emptyList())
+        scriptClassPath = DefaultClassPath(enclosingSourceSet.compileClasspath))
 
 
 private


### PR DESCRIPTION
The classpath of a precompiled script plugin is the compile classpath of its enclosing source-set.

This PR doesn't change the source path behaviour which will be improved in a separate PR.