### PR TITLE
Allow adding a dependency on a `Configuration` instance

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -37,7 +37,7 @@ class DependencyHandlerScope(val dependencies: DependencyHandler) : DependencyHa
      * @return The dependency.
      * @see [DependencyHandler.add]
      */
-    operator fun String.invoke(dependencyNotation: Any): Dependency =
+    operator fun String.invoke(dependencyNotation: Any): Dependency? =
         dependencies.add(this, dependencyNotation)
 
     /**
@@ -119,7 +119,7 @@ class DependencyHandlerScope(val dependencies: DependencyHandler) : DependencyHa
      * @return The dependency.
      * @see [DependencyHandler.add]
      */
-    operator fun Configuration.invoke(dependencyNotation: Any): Dependency =
+    operator fun Configuration.invoke(dependencyNotation: Any): Dependency? =
         add(name, dependencyNotation)
 
     /**

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -158,7 +158,7 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? = name.run {
              *
              * @see [DependencyHandler.add]
              */
-            fun DependencyHandler.`$kotlinIdentifier`(dependencyNotation: Any): Dependency =
+            fun DependencyHandler.`$kotlinIdentifier`(dependencyNotation: Any): Dependency? =
                 add("$stringLiteral", dependencyNotation)
 
             /**

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -204,4 +204,42 @@ class DependencyHandlerExtensionsTest {
         verify(antModule).addDependency(antLauncherDependency)
         verify(antModule).addDependency(antJUnitDependency)
     }
+
+    @Test
+    fun `dependency on configuration using string notation doesn't cause IllegalStateException`() {
+
+        val dependencyHandler = mock<DependencyHandler> {
+            on { add(any(), any()) }.thenReturn(null)
+        }
+
+        val baseConfig = mock<Configuration>()
+
+        val dependencies = DependencyHandlerScope(dependencyHandler)
+        dependencies {
+            "configuration"(baseConfig)
+        }
+
+        verify(dependencyHandler).add("configuration", baseConfig)
+    }
+
+    @Test
+    fun `dependency on configuration doesn't cause IllegalStateException`() {
+
+        val dependencyHandler = mock<DependencyHandler> {
+            on { add(any(), any()) }.thenReturn(null)
+        }
+
+        val configuration = mock<Configuration>() {
+            on { name } doReturn "configuration"
+        }
+
+        val baseConfig = mock<Configuration>()
+
+        val dependencies = DependencyHandlerScope(dependencyHandler)
+        dependencies {
+            configuration(baseConfig)
+        }
+
+        verify(dependencyHandler).add("configuration", baseConfig)
+    }
 }


### PR DESCRIPTION
By taking into account that `DependencyHandler.add(String, Any)` will
return `null` when given a `Configuration`.

See #797