### PR TITLE
[WIP] Spike - Generate Kotlin extensions for Gradle API

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchema.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchema.kt
@@ -122,7 +122,7 @@ fun kotlinTypeStringFor(type: TypeOf<*>): String =
     }
 
 
-private
+internal
 val primitiveTypeStrings =
     mapOf(
         "java.lang.Object" to "Any",

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
@@ -86,10 +86,19 @@ class ApiExtensionsJarGenerator(
 internal
 object StandardKotlinFileCompiler : KotlinFileCompiler {
     override fun compileToDirectory(outputDirectory: File, sourceFiles: Collection<File>, classPath: Collection<File>) {
-        compileToDirectory(
+
+        val success = compileToDirectory(
             outputDirectory,
             sourceFiles,
             loggerFor<StandardKotlinFileCompiler>(),
             classPath = classPath)
+
+        if (!success) {
+            throw IllegalStateException(
+                "Unable to compile Gradle Kotlin DSL API Extensions Jar\n" +
+                    "\tFrom:\n" +
+                    sourceFiles.joinToString("\n\t- ", prefix = "\t- ", postfix = "\n") +
+                    "\tSee compiler logs for details.")
+        }
     }
 }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
@@ -57,7 +57,9 @@ class ApiExtensionsJarGenerator(
     fun compileExtensionsTo(outputDir: File, gradleJars: Collection<File>) {
         compiler.compileToDirectory(
             outputDir,
-            listOf(builtinPluginIdExtensionsSourceFileFor(gradleJars, outputDir)),
+            listOf(
+                builtinPluginIdExtensionsSourceFileFor(gradleJars, outputDir),
+                gradleApiExtensionsSourceFileFor(gradleJars, outputDir)),
             classPath = gradleJars)
     }
 
@@ -65,6 +67,13 @@ class ApiExtensionsJarGenerator(
     fun builtinPluginIdExtensionsSourceFileFor(gradleJars: Iterable<File>, outputDir: File) =
         generatedSourceFile(outputDir, "BuiltinPluginIdExtensions.kt").apply {
             writeBuiltinPluginIdExtensionsTo(this, gradleJars)
+            onProgress()
+        }
+
+    private
+    fun gradleApiExtensionsSourceFileFor(gradleJars: Iterable<File>, outputDir: File) =
+        generatedSourceFile(outputDir, "GradleApiGeneratedExtensions.kt").apply {
+            writeGradleApiExtensionsTo(this, gradleJars)
             onProgress()
         }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
@@ -61,6 +61,7 @@ class ApiExtensionsJarGenerator(
                 builtinPluginIdExtensionsSourceFileFor(gradleJars, outputDir),
                 gradleApiExtensionsSourceFileFor(gradleJars, outputDir)),
             classPath = gradleJars)
+        onProgress()
     }
 
     private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -102,6 +102,9 @@ class ApiType(
     val isPublic: Boolean =
         (ACC_PUBLIC and delegate.access) > 0
 
+    val isDeprecated: Boolean
+        get() = delegate.visibleAnnotations.hasDeprecated
+
     val formalTypeParameters: List<ApiTypeUsage> by lazy(NONE) {
         visitedSignature?.formalTypeParameterDeclarations(typeIndex) ?: emptyList()
     }
@@ -135,6 +138,9 @@ class ApiFunction(
 
     val isPublic: Boolean =
         (ACC_PUBLIC and delegate.access) > 0
+
+    val isDeprecated: Boolean
+        get() = owner.isDeprecated || delegate.visibleAnnotations.hasDeprecated
 
     val isStatic: Boolean =
         (ACC_STATIC and delegate.access) > 0
@@ -174,6 +180,11 @@ class ApiFunction(
     val List<AnnotationNode>?.hasNullable: Boolean
         get() = this?.any { it.desc == "Ljavax/annotation/Nullable;" } ?: false
 }
+
+
+private
+val List<AnnotationNode>?.hasDeprecated: Boolean
+    get() = this?.any { it.desc == "Ljava/lang/Deprecated;" } ?: false
 
 
 internal

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -21,13 +21,18 @@ import org.gradle.kotlin.dsl.accessors.primitiveTypeStrings
 import org.gradle.kotlin.dsl.support.ClassBytesRepository
 import org.gradle.kotlin.dsl.support.classPathBytecodeRepositoryFor
 
+import org.jetbrains.org.objectweb.asm.AnnotationVisitor
+import org.jetbrains.org.objectweb.asm.Attribute
 import org.jetbrains.org.objectweb.asm.ClassReader
+import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_CODE
 import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG
 import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
+import org.jetbrains.org.objectweb.asm.FieldVisitor
 import org.jetbrains.org.objectweb.asm.Opcodes.ACC_PUBLIC
 import org.jetbrains.org.objectweb.asm.Opcodes.ACC_STATIC
 import org.jetbrains.org.objectweb.asm.Opcodes.ASM6
 import org.jetbrains.org.objectweb.asm.Type
+import org.jetbrains.org.objectweb.asm.TypePath
 import org.jetbrains.org.objectweb.asm.signature.SignatureReader
 import org.jetbrains.org.objectweb.asm.signature.SignatureVisitor
 import org.jetbrains.org.objectweb.asm.tree.AnnotationNode
@@ -95,8 +100,8 @@ class ApiTypeProvider(private val repository: ClassBytesRepository) : Closeable 
 
     private
     fun classNodeFor(classBytes: ByteArray) =
-        ClassNode().also {
-            ClassReader(classBytes).accept(it, SKIP_DEBUG and SKIP_FRAMES)
+        ApiTypeClassNode().also {
+            ClassReader(classBytes).accept(it, SKIP_DEBUG or SKIP_CODE or SKIP_FRAMES)
         }
 }
 
@@ -458,3 +463,15 @@ val collectionTypeStrings =
         "java.util.Map" to "kotlin.collections.Map",
         "java.util.HashMap" to "kotlin.collections.HashMap",
         "java.util.LinkedHashMap" to "kotlin.collections.LinkedHashMap")
+
+
+internal
+class ApiTypeClassNode : ClassNode(ASM6) {
+
+    override fun visitSource(file: String?, debug: String?) = Unit
+    override fun visitOuterClass(owner: String?, name: String?, desc: String?) = Unit
+    override fun visitTypeAnnotation(typeRef: Int, typePath: TypePath?, desc: String?, visible: Boolean): AnnotationVisitor? = null
+    override fun visitAttribute(attr: Attribute?) = Unit
+    override fun visitInnerClass(name: String?, outerName: String?, innerName: String?, access: Int) = Unit
+    override fun visitField(access: Int, name: String?, desc: String?, signature: String?, value: Any?): FieldVisitor? = null
+}

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -105,6 +105,9 @@ class ApiType(
     val isDeprecated: Boolean
         get() = delegate.visibleAnnotations.hasDeprecated
 
+    val isIncubating: Boolean
+        get() = delegate.visibleAnnotations.hasIncubating
+
     val formalTypeParameters: List<ApiTypeUsage> by lazy(NONE) {
         visitedSignature?.formalTypeParameterDeclarations(typeIndex) ?: emptyList()
     }
@@ -128,7 +131,7 @@ class ApiType(
 
 internal
 class ApiFunction(
-    val owner: ApiType,
+    private val owner: ApiType,
     private val delegate: MethodNode,
     private val typeIndex: ApiTypeIndex
 ) {
@@ -141,6 +144,9 @@ class ApiFunction(
 
     val isDeprecated: Boolean
         get() = owner.isDeprecated || delegate.visibleAnnotations.hasDeprecated
+
+    val isIncubating: Boolean
+        get() = owner.isIncubating || delegate.visibleAnnotations.hasIncubating
 
     val isStatic: Boolean =
         (ACC_STATIC and delegate.access) > 0
@@ -185,6 +191,11 @@ class ApiFunction(
 private
 val List<AnnotationNode>?.hasDeprecated: Boolean
     get() = this?.any { it.desc == "Ljava/lang/Deprecated;" } ?: false
+
+
+private
+val List<AnnotationNode>?.hasIncubating: Boolean
+    get() = this?.any { it.desc == "Lorg/gradle/api/Incubating;" } ?: false
 
 
 internal

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -15,6 +15,8 @@
  */
 package org.gradle.kotlin.dsl.codegen
 
+import org.gradle.api.Action
+
 import org.gradle.kotlin.dsl.accessors.primitiveTypeStrings
 import org.gradle.kotlin.dsl.support.ClassBytesRepository
 
@@ -242,6 +244,7 @@ fun Map<String, ApiTypeUsage>.toFunctionParametersString(): String =
         ?.entries
         ?.mapIndexed { index, entry ->
             if (index == size - 1 && entry.value.sourceName == "Array") "vararg ${entry.key}: ${entry.value.typeParameters.single()}"
+            else if (entry.value.sourceName == Action::class.java.canonicalName) "noinline ${entry.key}: ${entry.value.typeParameters.single()}.() -> Unit"
             else "${entry.key}: ${entry.value}"
         }
         ?.joinToString(separator = ", ")

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -17,7 +17,7 @@ package org.gradle.kotlin.dsl.codegen
 
 import org.gradle.kotlin.dsl.accessors.primitiveTypeStrings
 import org.gradle.kotlin.dsl.support.ClassBytesRepository
-import org.gradle.kotlin.dsl.support.classPathBytecodeRepositoryFor
+import org.gradle.kotlin.dsl.support.classPathBytesRepositoryFor
 
 import org.jetbrains.org.objectweb.asm.AnnotationVisitor
 import org.jetbrains.org.objectweb.asm.Attribute
@@ -45,7 +45,7 @@ import kotlin.LazyThreadSafetyMode.NONE
 
 internal
 fun apiTypeProviderFor(jarsOrDirs: List<File>): ApiTypeProvider =
-    ApiTypeProvider(classPathBytecodeRepositoryFor(jarsOrDirs))
+    ApiTypeProvider(classPathBytesRepositoryFor(jarsOrDirs))
 
 
 private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.kotlin.dsl.codegen
+
+import org.gradle.kotlin.dsl.accessors.primitiveTypeStrings
+import org.gradle.kotlin.dsl.support.ClassBytesRepository
+
+import org.jetbrains.org.objectweb.asm.ClassReader
+import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG
+import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
+import org.jetbrains.org.objectweb.asm.Opcodes.ACC_PUBLIC
+import org.jetbrains.org.objectweb.asm.Opcodes.ACC_STATIC
+import org.jetbrains.org.objectweb.asm.Opcodes.ASM6
+import org.jetbrains.org.objectweb.asm.Type
+import org.jetbrains.org.objectweb.asm.signature.SignatureReader
+import org.jetbrains.org.objectweb.asm.signature.SignatureVisitor
+import org.jetbrains.org.objectweb.asm.tree.AnnotationNode
+import org.jetbrains.org.objectweb.asm.tree.ClassNode
+import org.jetbrains.org.objectweb.asm.tree.MethodNode
+
+import java.io.Closeable
+
+import kotlin.LazyThreadSafetyMode.NONE
+
+
+private
+typealias ApiTypeIndex = (String) -> ApiType?
+
+
+private
+typealias ApiTypeSupplier = () -> ApiType
+
+
+/**
+ * Provides [ApiType] instances by Kotlin source name from a class path.
+ *
+ * Keeps JAR files open for fast lookup, must be closed.
+ * Once closed, type graph navigation from [ApiType] and [ApiFunction] instances will throw.
+ */
+internal
+class ApiTypeProvider(private val repository: ClassBytesRepository) : Closeable {
+
+    private
+    var closed = false
+
+    private
+    val apiTypesBySourceName = mutableMapOf<String, ApiTypeSupplier?>()
+
+    override fun close() =
+        try {
+            repository.close()
+        } finally {
+            closed = true
+        }
+
+    fun type(sourceName: String): ApiType? =
+        if (closed) throw IllegalStateException("ApiTypeProvider closed!")
+        else apiTypesBySourceName.computeIfAbsent(sourceName) { sourceName ->
+            repository.classBytesFor(sourceName)?.let { { apiTypeFor(sourceName, it) } }
+        }?.invoke()
+
+    fun allTypes(): Sequence<ApiType> =
+        if (closed) throw IllegalStateException("ApiTypeProvider closed!")
+        else repository.allClassesBytesBySourceName().mapNotNull { (sourceName, classBytes) ->
+            apiTypesBySourceName.computeIfAbsent(sourceName) {
+                { apiTypeFor(sourceName, classBytes()) }
+            }
+        }.map { it() }
+
+    private
+    fun apiTypeFor(sourceName: String, classBytes: ByteArray) =
+        ApiType(sourceName, classNodeFor(classBytes), { type(it) })
+
+    private
+    fun classNodeFor(classBytes: ByteArray) =
+        ClassNode().also {
+            ClassReader(classBytes).accept(it, SKIP_DEBUG and SKIP_FRAMES)
+        }
+}
+
+
+internal
+class ApiType(
+    val sourceName: String,
+    private val delegate: ClassNode,
+    private val typeIndex: ApiTypeIndex
+) {
+
+    val isPublic: Boolean =
+        (ACC_PUBLIC and delegate.access) > 0
+
+    val formalTypeParameters: List<ApiTypeUsage> by lazy(NONE) {
+        visitedSignature?.formalTypeParameterDeclarations(typeIndex) ?: emptyList()
+    }
+
+    val functions: List<ApiFunction> by lazy(NONE) {
+        delegate.methods.map { ApiFunction(this, it, typeIndex) }
+    }
+
+    override fun toString(): String {
+        return "$sourceName${formalTypeParameters.toTypeParametersString(this)}"
+    }
+
+    private
+    val visitedSignature: ClassSignatureVisitor? by lazy(NONE) {
+        delegate.signature?.let { signature ->
+            ClassSignatureVisitor().also { SignatureReader(signature).accept(it) }
+        }
+    }
+}
+
+
+internal
+class ApiFunction(
+    val owner: ApiType,
+    private val delegate: MethodNode,
+    private val typeIndex: ApiTypeIndex
+) {
+
+    val name: String =
+        delegate.name
+
+    val isPublic: Boolean =
+        (ACC_PUBLIC and delegate.access) > 0
+
+    val isStatic: Boolean =
+        (ACC_STATIC and delegate.access) > 0
+
+    val formalTypeParameters: List<ApiTypeUsage> by lazy(NONE) {
+        visitedSignature?.formalTypeParameterDeclarations(typeIndex)
+            ?: emptyList()
+    }
+
+    val parameters: Map<String, ApiTypeUsage> by lazy(NONE) {
+        delegate.visibleParameterAnnotations?.map { it.hasNullable }.let { nullability ->
+            visitedSignature?.parameters(typeIndex, nullability)
+                ?: Type.getArgumentTypes(delegate.desc).mapIndexed { idx, p ->
+                    val isNullable = nullability?.get(idx) == true
+                    Pair("p$idx", createApiTypeUsage(typeIndex, p.className, isNullable, emptyList(), emptyList()))
+                }.toMap()
+        }
+    }
+
+    val returnType: ApiTypeUsage by lazy(NONE) {
+        delegate.visibleAnnotations.hasNullable.let { isNullable ->
+            visitedSignature?.returnType(typeIndex, isNullable)
+                ?: sourceNameOfBinaryName(Type.getReturnType(delegate.desc).className).let {
+                    ApiTypeUsage(it, isNullable, typeIndex(it))
+                }
+        }
+    }
+
+    private
+    val visitedSignature: MethodSignatureVisitor? by lazy(NONE) {
+        delegate.signature?.let { signature ->
+            MethodSignatureVisitor().also { visitor -> SignatureReader(signature).accept(visitor) }
+        }
+    }
+
+    private
+    val List<AnnotationNode>?.hasNullable: Boolean
+        get() = this?.any { it.desc == "Ljavax/annotation/Nullable;" } ?: false
+}
+
+
+internal
+open class ApiTypeUsage(
+    val sourceName: String,
+    val isNullable: Boolean,
+    val type: ApiType?,
+    val typeParameters: List<ApiTypeUsage> = emptyList(),
+    val bounds: List<ApiTypeUsage> = emptyList()
+) {
+
+    val isRaw: Boolean
+        get() = typeParameters.isEmpty() && type?.formalTypeParameters?.isEmpty() != false
+
+    override fun toString(): String {
+        return "$sourceName$boundsString${typeParameters.toTypeParametersString(type)}$nullabilityString"
+    }
+
+    private
+    val boundsString: String
+        get() = bounds.takeIf { it.isNotEmpty() }?.joinToString(separator = ", ", prefix = " : ") ?: ""
+
+    private
+    val nullabilityString
+        get() = if (isNullable) "?" else ""
+}
+
+
+internal
+fun List<ApiTypeUsage>.toTypeParametersString(type: ApiType? = null, reified: Boolean = false): String =
+    when {
+        isNotEmpty() -> this
+        type?.formalTypeParameters?.isNotEmpty() == true -> "*".repeat(type.formalTypeParameters.size).asIterable().toList()
+        else -> emptyList()
+    }
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(separator = ", ${if (reified) "reified " else ""}", prefix = "<${if (reified) "reified " else ""}", postfix = ">")
+        ?: ""
+
+
+internal
+fun Map<String, ApiTypeUsage>.toFunctionParametersString(): String =
+    takeIf { it.isNotEmpty() }?.entries?.joinToString(separator = ", ") { (n, t) -> "$n: $t" } ?: ""
+
+
+private
+fun createApiTypeUsage(
+    typeIndex: ApiTypeIndex,
+    binaryName: String,
+    nullable: Boolean,
+    typeParameterSignatures: List<TypeSignatureVisitor>,
+    boundsSignatures: List<TypeSignatureVisitor> = emptyList()
+): ApiTypeUsage =
+
+    sourceNameOfBinaryName(binaryName).let { sourceName ->
+        ApiTypeUsage(
+            sourceName,
+            nullable,
+            typeIndex(sourceName),
+            typeParameterSignatures.map { createApiTypeUsage(typeIndex, it.binaryName, false, it.typeParameters[it.binaryName]!!) },
+            boundsSignatures
+                .filter { it.binaryName != "java.lang.Object" }
+                .map { createApiTypeUsage(typeIndex, it.binaryName, false, it.typeParameters[it.binaryName]!!) })
+    }
+
+
+internal
+abstract class BaseSignatureVisitor : SignatureVisitor(ASM6) {
+
+    private
+    val formalTypeParameters: MutableMap<String, MutableList<TypeSignatureVisitor>> = mutableMapOf()
+
+    private
+    var currentFormalTypeParameter: String? = null
+
+    fun formalTypeParameterDeclarations(typeIndex: ApiTypeIndex): List<ApiTypeUsage> =
+        formalTypeParameters.map { (binaryName, boundsSignatures) ->
+            createApiTypeUsage(typeIndex, binaryName, false, emptyList(), boundsSignatures)
+        }
+
+    override fun visitFormalTypeParameter(name: String) {
+        formalTypeParameters[name] = mutableListOf()
+        currentFormalTypeParameter = name
+    }
+
+    override fun visitClassBound(): SignatureVisitor {
+        return TypeSignatureVisitor().also { formalTypeParameters[currentFormalTypeParameter]!!.add(it) }
+    }
+
+    override fun visitInterfaceBound(): SignatureVisitor {
+        return TypeSignatureVisitor().also { formalTypeParameters[currentFormalTypeParameter]!!.add(it) }
+    }
+}
+
+
+internal
+class ClassSignatureVisitor : BaseSignatureVisitor()
+
+
+internal
+class MethodSignatureVisitor : BaseSignatureVisitor() {
+
+    private
+    val parametersSignatures = mutableListOf<TypeSignatureVisitor>()
+
+    private
+    val returnSignature = TypeSignatureVisitor()
+
+    fun parameters(typeIndex: ApiTypeIndex, nullability: List<Boolean>?): Map<String, ApiTypeUsage> =
+        parametersSignatures.mapIndexed { idx, parameterSignature ->
+            val isNullable = nullability?.get(idx) == true
+            Pair(
+                "p$idx",
+                createApiTypeUsage(typeIndex, parameterSignature.binaryName, isNullable, parameterSignature.typeParameters[parameterSignature.binaryName]!!))
+        }.toMap()
+
+    fun returnType(typeIndex: ApiTypeIndex, nullableReturn: Boolean): ApiTypeUsage =
+        createApiTypeUsage(
+            typeIndex,
+            returnSignature.binaryName,
+            nullableReturn,
+            returnSignature.typeParameters[returnSignature.binaryName]!!)
+
+    override fun visitParameterType(): SignatureVisitor {
+        // println(" visitParameterType")
+        return TypeSignatureVisitor().also { parametersSignatures.add(it) }
+    }
+
+    override fun visitReturnType(): SignatureVisitor {
+        // println(" visitReturnType")
+        return returnSignature
+    }
+}
+
+
+internal
+class TypeSignatureVisitor : SignatureVisitor(ASM6) {
+
+    lateinit var binaryName: String
+
+    val typeParameters = linkedMapOf<String, MutableList<TypeSignatureVisitor>>()
+
+    private
+    var expectingTypeParameter = false
+
+    override fun visitBaseType(descriptor: Char) {
+        visitBinaryName(binaryNameForBaseType(descriptor))
+    }
+
+    override fun visitClassType(name: String) {
+        visitBinaryName(binaryNameOfInternalName(name))
+    }
+
+    override fun visitInnerClassType(localName: String) {
+        binaryName += "${'$'}$localName"
+    }
+
+    override fun visitTypeArgument() {
+        expectingTypeParameter = true
+    }
+
+    override fun visitTypeArgument(wildcard: Char): SignatureVisitor {
+        expectingTypeParameter = true
+        return TypeSignatureVisitor().also { typeParameters[binaryName]!!.add(it) }
+    }
+
+    override fun visitTypeVariable(name: String) {
+        visitBinaryName(binaryNameOfInternalName(name))
+    }
+
+    private
+    fun visitBinaryName(binaryName: String) {
+        if (expectingTypeParameter) {
+            typeParameters[binaryName]!!.add(TypeSignatureVisitor().also { SignatureReader(binaryName).accept(it) })
+            expectingTypeParameter = false
+        } else {
+            this.binaryName = binaryName
+            typeParameters[binaryName] = mutableListOf()
+        }
+    }
+}
+
+
+private
+fun binaryNameForBaseType(descriptor: Char) =
+    when (Type.getType(descriptor.toString())) {
+        Type.BOOLEAN_TYPE -> Type.BOOLEAN_TYPE.className
+        Type.BYTE_TYPE -> Type.BYTE_TYPE.className
+        Type.SHORT_TYPE -> Type.SHORT_TYPE.className
+        Type.INT_TYPE -> Type.INT_TYPE.className
+        Type.CHAR_TYPE -> Type.CHAR_TYPE.className
+        Type.LONG_TYPE -> Type.LONG_TYPE.className
+        Type.FLOAT_TYPE -> Type.FLOAT_TYPE.className
+        Type.DOUBLE_TYPE -> Type.DOUBLE_TYPE.className
+        else -> Type.VOID_TYPE.className
+    }
+
+
+private
+fun binaryNameOfInternalName(internalName: String): String =
+    Type.getObjectType(internalName).className
+
+
+private
+fun sourceNameOfBinaryName(binaryName: String): String =
+    when (binaryName) {
+        "void" -> "Unit"
+        in primitiveTypeStrings.keys -> primitiveTypeStrings[binaryName]!!
+        else -> binaryName.replace('$', '.')
+    }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -266,9 +266,7 @@ fun createApiTypeUsage(
             nullable,
             typeIndex(sourceName),
             typeParameterSignatures.map { createApiTypeUsage(typeIndex, it.binaryName, false, it.typeParameters) },
-            boundsSignatures
-                .filter { it.binaryName != "java.lang.Object" }
-                .map { createApiTypeUsage(typeIndex, it.binaryName, false, it.typeParameters) })
+            boundsSignatures.map { createApiTypeUsage(typeIndex, it.binaryName, false, it.typeParameters) })
     }
 
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
@@ -62,7 +62,11 @@ val reifiedTypeParametersExtensionsGenerator = { type: ApiType ->
         }
         .flatMap { f ->
 
-            val deprecation = if (f.isDeprecated) """@Deprecated("Deprecated Gradle API")""" else ""
+            val annotations =
+                if (f.isDeprecated && f.isIncubating) "@Deprecated(\"Deprecated Gradle API\")\n@org.gradle.api.Incubating"
+                else if (f.isDeprecated) "@Deprecated(\"Deprecated Gradle API\")"
+                else if (f.isIncubating) "@org.gradle.api.Incubating"
+                else ""
             val reifiedFormalTypeParameter = f.formalTypeParameters[0]
             val extensionFormalTypeParameters = (listOf("reified $reifiedFormalTypeParameter") + type.formalTypeParameters.map { "$it" })
                 .joinToString(separator = ", ", prefix = "<", postfix = ">")
@@ -77,7 +81,7 @@ val reifiedTypeParametersExtensionsGenerator = { type: ApiType ->
 
             sequenceOf(
                 """
-                |$deprecation
+                |$annotations
                 |inline fun ${extensionFormalTypeParameters.takeIf { it.isNotEmpty() }?.let { "$it " }
                     ?: ""}${type.sourceName}$extendedTypeTypeParameters.${f.name}(${params.toFunctionParametersString()})${f.returnType.let { ": $it" }} =
                 |   ${f.name}($invocationParams)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
@@ -25,7 +25,7 @@ fun writeGradleApiExtensionsTo(file: File, gradleJars: Iterable<File>) {
     file.bufferedWriter().use {
         it.apply {
             write(fileHeader)
-            apiTypeProviderFor(gradleJars.toList()).use { api ->
+            apiTypeProviderFor(gradleJars.filter { it.name.startsWith("gradle-") }.toList()).use { api ->
                 gradleApiExtensionDeclarationsFor(api).forEach {
                     write("\n")
                     write(it)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
@@ -91,7 +91,7 @@ val ApiType.isGradleApi: Boolean
         && isPublic
 
 
-internal
+private
 val ApiType.gradleApiFunctions: List<ApiFunction>
     get() = functions.filter { it.isGradleApi && !it.isStatic }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.kotlin.dsl.codegen
+
+import org.gradle.kotlin.dsl.support.classPathBytecodeRepositoryFor
+
+import java.io.File
+
+
+internal
+fun writeGradleApiExtensionsTo(file: File, gradleJars: Iterable<File>) {
+    file.bufferedWriter().use {
+        it.apply {
+            write(fileHeader)
+            ApiTypeProvider(classPathBytecodeRepositoryFor(gradleJars.toList())).use { api ->
+                gradleApiExtensionDeclarationsFor(api).forEach {
+                    write("\n")
+                    write(it)
+                    write("\n")
+                }
+            }
+        }
+    }
+}
+
+
+internal
+fun gradleApiExtensionDeclarationsFor(api: ApiTypeProvider): Sequence<String> =
+    api.allTypes().filter { it.isGradleApi }.flatMap { type ->
+        sequenceOf(reifiedTypeParametersExtensionsGenerator)
+            .flatMap { generator -> generator(type) }
+    }
+
+
+private
+val reifiedTypeParametersExtensionsGenerator = { type: ApiType ->
+
+    fun ApiTypeUsage.isClassParameterOf(formalTypeParameter: ApiTypeUsage) =
+        sourceName == "java.lang.Class" && !isRaw && typeParameters[0].sourceName == formalTypeParameter.sourceName
+
+    type.gradleApiFunctions.asSequence()
+        .filter {
+            if (it.formalTypeParameters.size != 1) false
+            else {
+                val formalTypeParameter = it.formalTypeParameters[0]
+                it.parameters.asSequence().singleOrNull { (_, type) -> type.isClassParameterOf(formalTypeParameter) } != null
+            }
+        }
+        .flatMap { f ->
+
+            val reifiedFormalTypeParameter = f.formalTypeParameters[0]
+            val extensionFormalTypeParameters = (listOf("reified $reifiedFormalTypeParameter") + type.formalTypeParameters.map { "$it" })
+                .joinToString(separator = ", ", prefix = "<", postfix = ">")
+            val extendedTypeTypeParameters = type.formalTypeParameters.takeIf { it.isNotEmpty() }
+                ?.joinToString(separator = ", ", prefix = "<", postfix = ">") { it.sourceName }
+                ?: ""
+            val params = f.parameters.filterNot { it.value.isClassParameterOf(reifiedFormalTypeParameter) }
+            val invocationParams = f.parameters.map {
+                if (it.value.isClassParameterOf(reifiedFormalTypeParameter)) "${reifiedFormalTypeParameter.sourceName}::class.java"
+                else it.key
+            }.joinToString(", ")
+
+            sequenceOf(
+                """
+                |inline fun ${extensionFormalTypeParameters.takeIf { it.isNotEmpty() }?.let { "$it " }
+                    ?: ""}${type.sourceName}$extendedTypeTypeParameters.${f.name}(${params.toFunctionParametersString()})${f.returnType.let { ": $it" }} =
+                |   ${f.name}($invocationParams)
+                """.trimMargin())
+        }
+}
+
+
+internal
+val ApiType.isGradleApi: Boolean
+    get() = sourceName !in typeSourceNameBlackList
+        && PublicApi.excludes.none { it.matches(sourceName) }
+        && PublicApi.includes.any { it.matches(sourceName) }
+        && isPublic
+
+
+internal
+val ApiType.gradleApiFunctions: List<ApiFunction>
+    get() = functions.filter { it.isGradleApi && !it.isStatic }
+
+
+private
+val ApiFunction.isGradleApi: Boolean
+    get() = name !in functionNameBlackList && isPublic
+
+
+private
+val typeSourceNameBlackList = emptyList<String>()
+
+
+private
+val functionNameBlackList = listOf("apply")
+
+
+private
+object PublicApi {
+    val includes = listOf(
+        "org/gradle/*",
+        "org/gradle/api/**",
+        "org/gradle/authentication/**",
+        "org/gradle/buildinit/**",
+        "org/gradle/caching/**",
+        "org/gradle/concurrent/**",
+        "org/gradle/deployment/**",
+        "org/gradle/external/javadoc/**",
+        "org/gradle/ide/**",
+        "org/gradle/includedbuild/**",
+        "org/gradle/ivy/**",
+        "org/gradle/jvm/**",
+        "org/gradle/language/**",
+        "org/gradle/maven/**",
+        "org/gradle/nativeplatform/**",
+        "org/gradle/normalization/**",
+        "org/gradle/platform/**",
+        "org/gradle/play/**",
+        "org/gradle/plugin/devel/**",
+        "org/gradle/plugin/repository/*",
+        "org/gradle/plugin/use/*",
+        "org/gradle/plugin/management/*",
+        "org/gradle/plugins/**",
+        "org/gradle/process/**",
+        "org/gradle/testfixtures/**",
+        "org/gradle/testing/jacoco/**",
+        "org/gradle/tooling/**",
+        "org/gradle/swiftpm/**",
+        "org/gradle/model/**",
+        "org/gradle/testkit/**",
+        "org/gradle/testing/**",
+        "org/gradle/vcs/**",
+        "org/gradle/workers/**")
+        .map { it.replace("/", "\\.") }
+        .map {
+            when {
+                it.endsWith("**") -> Regex("${it.dropLast(2)}.*")
+                it.endsWith("*") -> Regex("${it.dropLast(1)}[A-Z].*")
+                else -> throw InternalError("Should not happen")
+            }
+        }
+
+    val excludes = listOf(
+        Regex(".*\\.internal\\..*"),
+        Regex("org\\.gradle\\.kotlin\\..*"))
+}

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -31,8 +31,6 @@ fun writeBuiltinPluginIdExtensionsTo(file: File, gradleJars: Iterable<File>) {
         it.apply {
             write(fileHeader)
             write("\n")
-            write("import ${PluginDependenciesSpec::class.qualifiedName}\n")
-            write("import ${PluginDependencySpec::class.qualifiedName}\n")
             pluginIdExtensionDeclarationsFor(gradleJars).forEach {
                 write("\n")
                 write(it)
@@ -45,8 +43,8 @@ fun writeBuiltinPluginIdExtensionsTo(file: File, gradleJars: Iterable<File>) {
 
 private
 fun pluginIdExtensionDeclarationsFor(jars: Iterable<File>): Sequence<String> {
-    val extendedType = PluginDependenciesSpec::class.simpleName
-    val extensionType = PluginDependencySpec::class.simpleName
+    val extendedType = PluginDependenciesSpec::class.qualifiedName!!
+    val extensionType = PluginDependencySpec::class.qualifiedName!!
     return pluginExtensionsFrom(jars)
         .map { (memberName, pluginId, website, implementationClass) ->
             """

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -108,7 +108,7 @@ class KotlinScriptClassPathProvider(
     private
     fun produceFrom(id: String, generate: JarGeneratorWithProgress): File =
         jarCache(id) { outputFile ->
-            progressMonitorFor(outputFile, 1).use { progressMonitor ->
+            progressMonitorFor(outputFile, 2).use { progressMonitor ->
                 generateAtomically(outputFile, { generate(it, progressMonitor::onProgress) })
             }
         }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -108,7 +108,7 @@ class KotlinScriptClassPathProvider(
     private
     fun produceFrom(id: String, generate: JarGeneratorWithProgress): File =
         jarCache(id) { outputFile ->
-            progressMonitorFor(outputFile, 2).use { progressMonitor ->
+            progressMonitorFor(outputFile, 3).use { progressMonitor ->
                 generateAtomically(outputFile, { generate(it, progressMonitor::onProgress) })
             }
         }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.internal.classpath.ClassPath
+import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.util.TextUtil.normaliseFileSeparators
+
+import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
+
+import java.io.Closeable
+import java.io.File
+import java.util.jar.JarFile
+
+
+internal
+fun classPathBytecodeRepositoryFor(jarsOrDirs: List<File>) =
+    ClassBytesRepository(DefaultClassPath.of(jarsOrDirs))
+
+
+private
+typealias ClassBytesSupplier = () -> ByteArray
+
+
+private
+typealias ClassBytesIndex = (String) -> ClassBytesSupplier?
+
+
+/**
+ * Repository providing access to class bytes by Kotlin source names.
+ *
+ * Follows the one directory per package name segment convention.
+ * Keeps JAR files open for fast lookup, must be closed.
+ */
+internal
+class ClassBytesRepository(classPath: ClassPath) : Closeable {
+
+    private
+    val openJars = mutableMapOf<File, JarFile>()
+
+    private
+    val classPathFiles: List<File> = classPath.asFiles
+
+    private
+    val classBytesIndex = classPathFiles.map { classBytesIndexFor(it) }
+
+    /**
+     * Class file bytes for Kotlin source name, if found.
+     */
+    fun classBytesFor(sourceName: String): ByteArray? =
+        classBytesSupplierForSourceName(sourceName)?.let { it() }
+
+    /**
+     * All found class files bytes by Kotlin source name.
+     */
+    fun allClassesBytesBySourceName(): Sequence<Pair<String, ClassBytesSupplier>> =
+        classPathFiles.asSequence()
+            .flatMap { sourceNamesFrom(it) }
+            .mapNotNull { sourceName ->
+                classBytesSupplierForSourceName(sourceName)?.let { Pair(sourceName, it) }
+            }
+
+    private
+    fun classBytesSupplierForSourceName(sourceName: String): ClassBytesSupplier? =
+        classFilePathCandidatesFor(sourceName).firstNotNullResult { classBytesSupplierForFilePath(it) }
+
+    private
+    fun classBytesSupplierForFilePath(classFilePath: String): ClassBytesSupplier? =
+        classBytesIndex.firstNotNullResult { it(classFilePath) }
+
+    private
+    fun sourceNamesFrom(jarOrDir: File): Sequence<String> =
+        when {
+            jarOrDir.isFile -> sourceNamesFromJar(jarOrDir)
+            jarOrDir.isDirectory -> sourceNamesFromDir(jarOrDir)
+            else -> emptySequence()
+        }
+
+    private
+    fun sourceNamesFromJar(jar: File): Sequence<String> =
+        openJarFile(jar).run {
+            entries().asSequence()
+                .filter { it.name.isClassFilePath }
+                .map { kotlinSourceNameOf(it.name) }
+        }
+
+    private
+    fun sourceNamesFromDir(dir: File): Sequence<String> =
+        dir.walkTopDown()
+            .filter { it.name.isClassFilePath }
+            .map { kotlinSourceNameOf(normaliseFileSeparators(it.relativeTo(dir).path)) }
+
+    private
+    fun classBytesIndexFor(jarOrDir: File): ClassBytesIndex =
+        when {
+            jarOrDir.isFile -> jarClassBytesIndexFor(jarOrDir)
+            jarOrDir.isDirectory -> directoryClassBytesIndexFor(jarOrDir)
+            else -> { _ -> null }
+        }
+
+    private
+    fun jarClassBytesIndexFor(jar: File): ClassBytesIndex = { classFilePath ->
+        openJarFile(jar).run {
+            getJarEntry(classFilePath)?.let { jarEntry ->
+                {
+                    getInputStream(jarEntry).use { jarInput ->
+                        jarInput.readBytes()
+                    }
+                }
+            }
+        }
+    }
+
+    private
+    fun directoryClassBytesIndexFor(dir: File): ClassBytesIndex = { classFilePath ->
+        File(dir, classFilePath).takeIf { it.isFile }?.let { classFile -> { classFile.readBytes() } }
+    }
+
+    private
+    fun openJarFile(file: File) =
+        openJars.computeIfAbsent(file, ::JarFile)
+
+    override fun close() {
+        openJars.values.forEach(JarFile::close)
+    }
+}
+
+
+private
+val String.isClassFilePath
+    get() = endsWith(classFilePathSuffix)
+
+
+private
+const val classFilePathSuffix = ".class"
+
+
+internal
+fun kotlinSourceNameOf(classFilePath: String): String =
+    classFilePath.let {
+        if (it.endsWith("Kt$classFilePathSuffix")) it.dropLast(8)
+        else it.dropLast(6)
+    }.replace("/", ".").replace("$", ".")
+
+
+internal
+fun classFilePathCandidatesFor(sourceName: String): Iterable<String> =
+    sourceName.replace(".", "/").let { path ->
+        sequenceOf("$path$classFilePathSuffix", "${path}Kt$classFilePathSuffix") +
+            if (path.contains("/")) {
+                val generator = { p: String ->
+                    if (p.contains("/")) p.substringBeforeLast("/") + '$' + p.substring(p.lastIndexOf("/") + 1)
+                    else null
+                }
+                generateSequence({ generator(path) }, generator)
+                    .flatMap { sequenceOf("$it$classFilePathSuffix", "${it}Kt$classFilePathSuffix") }
+            } else emptySequence()
+    }.asIterable()

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
@@ -126,7 +126,7 @@ class ClassBytesRepository(classPath: ClassPath) : Closeable {
 
     private
     fun directoryClassBytesIndexFor(dir: File): ClassBytesIndex = { classFilePath ->
-        File(dir, classFilePath).takeIf { it.isFile }?.let { classFile -> { classFile.readBytes() } }
+        dir.resolve(classFilePath).takeIf { it.isFile }?.let { classFile -> { classFile.readBytes() } }
     }
 
     private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
@@ -148,12 +148,16 @@ private
 const val classFilePathSuffix = ".class"
 
 
+private
+val slashOrDollar = Regex("[/$]")
+
+
 internal
 fun kotlinSourceNameOf(classFilePath: String): String =
-    classFilePath.let {
-        if (it.endsWith("Kt$classFilePathSuffix")) it.dropLast(8)
-        else it.dropLast(6)
-    }.replace("/", ".").replace("$", ".")
+    classFilePath.run {
+        if (endsWith("Kt$classFilePathSuffix")) dropLast(8)
+        else dropLast(6)
+    }.replace(slashOrDollar, ".")
 
 
 internal

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
@@ -27,7 +27,7 @@ import java.util.jar.JarFile
 
 
 internal
-fun classPathBytecodeRepositoryFor(jarsOrDirs: List<File>) =
+fun classPathBytesRepositoryFor(jarsOrDirs: List<File>) =
     ClassBytesRepository(DefaultClassPath.of(jarsOrDirs))
 
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
@@ -76,6 +76,7 @@ fun unzipEntryTo(outputDirectory: File, zip: ZipFile, entry: ZipEntry) {
     if (entry.isDirectory) {
         output.mkdirs()
     } else {
+        output.parentFile.mkdirs()
         zip.getInputStream(entry).use { it.copyTo(output) }
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProviderTest.kt
@@ -1,6 +1,7 @@
 package org.gradle.kotlin.dsl.codegen
 
 import org.gradle.api.Plugin
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.PluginCollection
 
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
@@ -21,7 +22,8 @@ class ApiTypeProviderTest : AbstractIntegrationTest() {
 
         val jars = listOf(withClassJar("some.jar",
             Plugin::class.java,
-            PluginCollection::class.java))
+            PluginCollection::class.java,
+            ObjectFactory::class.java))
 
         ApiTypeProvider(classPathBytecodeRepositoryFor(jars)).use { api ->
 
@@ -32,33 +34,41 @@ class ApiTypeProviderTest : AbstractIntegrationTest() {
                 assertThat(sourceName, equalTo("org.gradle.api.plugins.PluginCollection"))
                 assertTrue(isPublic)
                 assertThat(formalTypeParameters.size, equalTo(1))
-                formalTypeParameters.first().apply {
+                formalTypeParameters.single().apply {
                     assertThat(sourceName, equalTo("T"))
                     assertThat(bounds.size, equalTo(1))
-                    assertThat(bounds.first().sourceName, equalTo("org.gradle.api.Plugin"))
+                    assertThat(bounds.single().sourceName, equalTo("org.gradle.api.Plugin"))
                 }
 
                 functions.single { it.name == "withType" }.apply {
                     assertThat(formalTypeParameters.size, equalTo(1))
-                    formalTypeParameters.first().apply {
+                    formalTypeParameters.single().apply {
                         assertThat(sourceName, equalTo("S"))
                         assertThat(bounds.size, equalTo(1))
-                        assertThat(bounds.first().sourceName, equalTo("T"))
+                        assertThat(bounds.single().sourceName, equalTo("T"))
                     }
                     assertThat(parameters.size, equalTo(1))
-                    parameters.values.first().apply {
+                    parameters.values.single().apply {
                         assertThat(sourceName, equalTo("java.lang.Class"))
                         assertThat(typeParameters.size, equalTo(1))
-                        typeParameters.first().apply {
+                        typeParameters.single().apply {
                             assertThat(sourceName, equalTo("S"))
                         }
                     }
                     returnType.apply {
                         assertThat(sourceName, equalTo("org.gradle.api.plugins.PluginCollection"))
                         assertThat(typeParameters.size, equalTo(1))
-                        typeParameters.first().apply {
+                        typeParameters.single().apply {
                             assertThat(sourceName, equalTo("S"))
                         }
+                    }
+                }
+            }
+            api.type(ObjectFactory::class.java.canonicalName)!!.apply {
+                functions.single { it.name == "newInstance" }.apply {
+                    parameters.values.drop(1).single().apply {
+                        assertThat(sourceName, equalTo("Array"))
+                        assertThat(typeParameters.single().sourceName, equalTo("Any"))
                     }
                 }
             }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProviderTest.kt
@@ -1,0 +1,67 @@
+package org.gradle.kotlin.dsl.codegen
+
+import org.gradle.api.Plugin
+import org.gradle.api.plugins.PluginCollection
+
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.kotlin.dsl.support.classPathBytecodeRepositoryFor
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
+
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+
+class ApiTypeProviderTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `provides a source code generation oriented model over a classpath`() {
+
+        val jars = listOf(withClassJar("some.jar",
+            Plugin::class.java,
+            PluginCollection::class.java))
+
+        ApiTypeProvider(classPathBytecodeRepositoryFor(jars)).use { api ->
+
+            assertThat(api.type(Test::class.java.canonicalName), nullValue())
+
+            api.type(PluginCollection::class.java.canonicalName)!!.apply {
+
+                assertThat(sourceName, equalTo("org.gradle.api.plugins.PluginCollection"))
+                assertTrue(isPublic)
+                assertThat(formalTypeParameters.size, equalTo(1))
+                formalTypeParameters.first().apply {
+                    assertThat(sourceName, equalTo("T"))
+                    assertThat(bounds.size, equalTo(1))
+                    assertThat(bounds.first().sourceName, equalTo("org.gradle.api.Plugin"))
+                }
+
+                functions.single { it.name == "withType" }.apply {
+                    assertThat(formalTypeParameters.size, equalTo(1))
+                    formalTypeParameters.first().apply {
+                        assertThat(sourceName, equalTo("S"))
+                        assertThat(bounds.size, equalTo(1))
+                        assertThat(bounds.first().sourceName, equalTo("T"))
+                    }
+                    assertThat(parameters.size, equalTo(1))
+                    parameters.values.first().apply {
+                        assertThat(sourceName, equalTo("java.lang.Class"))
+                        assertThat(typeParameters.size, equalTo(1))
+                        typeParameters.first().apply {
+                            assertThat(sourceName, equalTo("S"))
+                        }
+                    }
+                    returnType.apply {
+                        assertThat(sourceName, equalTo("org.gradle.api.plugins.PluginCollection"))
+                        assertThat(typeParameters.size, equalTo(1))
+                        typeParameters.first().apply {
+                            assertThat(sourceName, equalTo("S"))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProviderTest.kt
@@ -34,16 +34,16 @@ class ApiTypeProviderTest : AbstractIntegrationTest() {
 
                 assertThat(sourceName, equalTo("org.gradle.api.plugins.PluginCollection"))
                 assertTrue(isPublic)
-                assertThat(formalTypeParameters.size, equalTo(1))
-                formalTypeParameters.single().apply {
+                assertThat(typeParameters.size, equalTo(1))
+                typeParameters.single().apply {
                     assertThat(sourceName, equalTo("T"))
                     assertThat(bounds.size, equalTo(1))
                     assertThat(bounds.single().sourceName, equalTo("org.gradle.api.Plugin"))
                 }
 
                 functions.single { it.name == "withType" }.apply {
-                    assertThat(formalTypeParameters.size, equalTo(1))
-                    formalTypeParameters.single().apply {
+                    assertThat(typeParameters.size, equalTo(1))
+                    typeParameters.single().apply {
                         assertThat(sourceName, equalTo("S"))
                         assertThat(bounds.size, equalTo(1))
                         assertThat(bounds.single().sourceName, equalTo("T"))
@@ -51,15 +51,15 @@ class ApiTypeProviderTest : AbstractIntegrationTest() {
                     assertThat(parameters.size, equalTo(1))
                     parameters.single().type.apply {
                         assertThat(sourceName, equalTo("java.lang.Class"))
-                        assertThat(typeParameters.size, equalTo(1))
-                        typeParameters.single().apply {
+                        assertThat(typeArguments.size, equalTo(1))
+                        typeArguments.single().apply {
                             assertThat(sourceName, equalTo("S"))
                         }
                     }
                     returnType.apply {
                         assertThat(sourceName, equalTo("org.gradle.api.plugins.PluginCollection"))
-                        assertThat(typeParameters.size, equalTo(1))
-                        typeParameters.single().apply {
+                        assertThat(typeArguments.size, equalTo(1))
+                        typeArguments.single().apply {
                             assertThat(sourceName, equalTo("S"))
                         }
                     }
@@ -68,8 +68,8 @@ class ApiTypeProviderTest : AbstractIntegrationTest() {
             api.type(ObjectFactory::class.java.canonicalName)!!.apply {
                 functions.single { it.name == "newInstance" }.apply {
                     parameters.drop(1).single().type.apply {
-                        assertThat(sourceName, equalTo("Array"))
-                        assertThat(typeParameters.single().sourceName, equalTo("Any"))
+                        assertThat(sourceName, equalTo("kotlin.Array"))
+                        assertThat(typeArguments.single().sourceName, equalTo("Any"))
                     }
                 }
             }
@@ -85,13 +85,13 @@ class ApiTypeProviderTest : AbstractIntegrationTest() {
             val contentFilterable = api.type(ContentFilterable::class.java.canonicalName)!!
 
             contentFilterable.functions.single { it.name == "expand" }.apply {
-                assertTrue(formalTypeParameters.isEmpty())
+                assertTrue(typeParameters.isEmpty())
                 assertThat(parameters.size, equalTo(1))
                 parameters.single().type.apply {
                     assertThat(sourceName, equalTo("kotlin.collections.Map"))
-                    assertThat(typeParameters.size, equalTo(2))
-                    assertThat(typeParameters[0].sourceName, equalTo("String"))
-                    assertThat(typeParameters[1].sourceName, equalTo("*"))
+                    assertThat(typeArguments.size, equalTo(2))
+                    assertThat(typeArguments[0].sourceName, equalTo("String"))
+                    assertThat(typeArguments[1].sourceName, equalTo("*"))
                 }
             }
         }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -107,7 +107,7 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
                 startsWith(
                     "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.findByType(): T? =\n    findByType(typeOf<T>())"),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.create(p1: String, p2: java.lang.Class<T>, vararg p3: Any): T =\n    create(typeOf<T>(), p1, T::class.java, p3)"),
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.create(p1: String, p2: kotlin.reflect.KClass<T>, vararg p3: Any): T =\n    create(typeOf<T>(), p1, p2.java, p3)"),
                 startsWith(
                     "inline fun <reified T> org.gradle.api.plugins.ExtensionContainer.create(p0: String, vararg p2: Any): T =\n    create(p0, T::class.java, p2)"),
                 startsWith(

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -1,0 +1,92 @@
+package org.gradle.kotlin.dsl.codegen
+
+import org.gradle.api.Named
+import org.gradle.api.Plugin
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.plugins.PluginCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.customInstallation
+import org.gradle.kotlin.dsl.support.classPathBytecodeRepositoryFor
+
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.hasItem
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+
+class GradleApiExtensionsTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `Gradle API`() {
+
+        val gradleJars = customInstallation().let { listOf(it.resolve("lib"), it.resolve("lib/plugins")) }.flatMap { it.listFiles().toList() }
+
+        ApiTypeProvider(classPathBytecodeRepositoryFor(gradleJars)).use { api ->
+
+            var seenPrivateType = false
+            var seenInternalType = false
+            var seenPublicType = false
+
+            var seenPrivateFunction = false
+            var seenPublicFunction = false
+
+            api.allTypes().filter { it.isGradleApi }.forEach {
+                if (it.sourceName == "org.gradle.api.Project") seenPublicType = true
+                if (!it.isPublic) seenPrivateType = true
+                if (it.sourceName.startsWith("org.gradle.util") || it.sourceName.contains(".internal.")) seenInternalType = true
+
+                it.gradleApiFunctions.forEach {
+                    if (it.isPublic) seenPublicFunction = true
+                    else seenPrivateFunction = true
+                }
+            }
+
+            assertFalse(seenPrivateType)
+            assertFalse(seenInternalType)
+            assertTrue(seenPublicType)
+
+            assertFalse(seenPrivateFunction)
+            assertTrue(seenPublicFunction)
+        }
+    }
+
+    @Test
+    fun `reified type extensions`() {
+
+        val jar = withClassJar(
+            "unbounded.jar",
+            Named::class.java,
+            Property::class.java,
+            ListProperty::class.java,
+            SetProperty::class.java,
+            Plugin::class.java,
+            ObjectFactory::class.java,
+            PluginCollection::class.java)
+
+        ApiTypeProvider(classPathBytecodeRepositoryFor(listOf(jar))).use { api ->
+
+            assertThat(
+                gradleApiExtensionDeclarationsFor(api).toList(),
+                allOf(
+                    hasItem(containsString(
+                        "inline fun <reified T : org.gradle.api.Named> org.gradle.api.model.ObjectFactory.named(p1: String): T =")),
+                    hasItem(containsString(
+                        "inline fun <reified T> org.gradle.api.model.ObjectFactory.property(): org.gradle.api.provider.Property<T> =")),
+                    hasItem(containsString(
+                        "inline fun <reified T> org.gradle.api.model.ObjectFactory.listProperty(): org.gradle.api.provider.ListProperty<T> =")),
+                    hasItem(containsString(
+                        "inline fun <reified T> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> =")),
+                    hasItem(containsString(
+                        "inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> ="))
+                ))
+        }
+    }
+}

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -71,13 +71,14 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
             SetProperty::class.java,
             Plugin::class.java,
             ObjectFactory::class.java,
-            PluginCollection::class.java))
+            PluginCollection::class.java,
+            Project::class.java))
 
         val generatedExtensions = ApiTypeProvider(classPathBytecodeRepositoryFor(jars)).use { api ->
             gradleApiExtensionDeclarationsFor(api).toList()
         }
 
-        assertThat(generatedExtensions.size, equalTo(6))
+        assertThat(generatedExtensions.size, equalTo(9))
 
         assertThat(
             generatedExtensions,
@@ -93,6 +94,12 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
                 startsWith(
                     "inline fun <reified T> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> ="),
                 startsWith(
-                    "inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> =")))
+                    "inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> ="),
+                startsWith(
+                    "@Deprecated(\"Deprecated Gradle API\")\ninline fun <reified T> org.gradle.api.Project.property(): org.gradle.api.provider.PropertyState<T> ="),
+                startsWith(
+                    "inline fun <reified T> org.gradle.api.Project.container(): org.gradle.api.NamedDomainObjectContainer<T> ="),
+                startsWith(
+                    "inline fun <reified T> org.gradle.api.Project.container(p1: org.gradle.api.NamedDomainObjectFactory<T>): org.gradle.api.NamedDomainObjectContainer<T> =")))
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -16,6 +16,7 @@ import org.gradle.util.TextUtil
 
 import org.gradle.kotlin.dsl.GradleDsl
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.kotlin.dsl.fixtures.customInstallation
 
 import org.hamcrest.CoreMatchers.containsString
@@ -120,62 +121,82 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
 
         assertThat(generatedExtensions.filter { it.contains("<reified ") }.size, equalTo(13))
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : org.gradle.api.Named> org.gradle.api.model.ObjectFactory.named(p1: String): T =")))
+        generatedExtensions.apply {
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : org.gradle.api.Named> org.gradle.api.model.ObjectFactory.named(p1: String): T =
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.newInstance(vararg p1: Any): T =")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.newInstance(vararg p1: Any): T =
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.property(): org.gradle.api.provider.Property<T> =")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.property(): org.gradle.api.provider.Property<T> =
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.listProperty(): org.gradle.api.provider.ListProperty<T> =")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.listProperty(): org.gradle.api.provider.ListProperty<T> =
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> =")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> =
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> =")))
+            assertContainsExtension("""
+            inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> =
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@Deprecated(\"Deprecated Gradle API\")\n" +
-                "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.provider.ProviderFactory.property(): org.gradle.api.provider.PropertyState<T> =")))
+            assertContainsExtension("""
+            @Deprecated("Deprecated Gradle API")
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.provider.ProviderFactory.property(): org.gradle.api.provider.PropertyState<T> =
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.add(p1: String, p2: T): Unit =\n" +
-                "    add(typeOf<T>(), p1, p2)")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.add(p1: String, p2: T): Unit =
+                add(typeOf<T>(), p1, p2)
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.getByType(): T =\n" +
-                "    getByType(typeOf<T>())")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.getByType(): T =
+                getByType(typeOf<T>())
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.findByType(): T? =\n" +
-                "    findByType(typeOf<T>())")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.findByType(): T? =
+                findByType(typeOf<T>())
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.create(p1: String, p2: kotlin.reflect.KClass<T>, vararg p3: Any): T =\n" +
-                "    create(typeOf<T>(), p1, p2.java, p3)")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.create(p1: String, p2: kotlin.reflect.KClass<T>, vararg p3: Any): T =
+                create(typeOf<T>(), p1, p2.java, p3)
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.create(p0: String, vararg p2: Any): T =\n" +
-                "    create(p0, T::class.java, p2)")))
+            assertContainsExtension("""
+            inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.create(p0: String, vararg p2: Any): T =
+                create(p0, T::class.java, p2)
+            """)
 
-        assertThat(generatedExtensions, hasItem(containsString(
-            "@org.gradle.api.Incubating\n" +
-                "inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.configure(noinline p1: T.() -> Unit): Unit =\n" +
-                "    configure(typeOf<T>(), p1)")))
+            assertContainsExtension("""
+            @org.gradle.api.Incubating
+            inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.configure(noinline p1: T.() -> Unit): Unit =
+                configure(typeOf<T>(), p1)
+            """)
+        }
+    }
+
+    private
+    fun List<String>.assertContainsExtension(string: String) {
+        assertThat(this, hasItem(containsMultiLineString(string)))
     }
 
     @Test
@@ -187,7 +208,6 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
         }
 
         val varargExtension = generatedExtensions.single { it.contains(".withArtifacts(") && it.contains("vararg ") }
-        println(varargExtension)
 
         assertThat(varargExtension,
             containsString("vararg p1: kotlin.reflect.KClass<org.gradle.api.component.Artifact>"))

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -8,6 +8,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.PluginCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.util.TextUtil
 
@@ -72,34 +73,30 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
             Plugin::class.java,
             ObjectFactory::class.java,
             PluginCollection::class.java,
-            Project::class.java))
+            ProviderFactory::class.java))
 
         val generatedExtensions = ApiTypeProvider(classPathBytecodeRepositoryFor(jars)).use { api ->
             gradleApiExtensionDeclarationsFor(api).toList()
         }
 
-        assertThat(generatedExtensions.size, equalTo(9))
+        assertThat(generatedExtensions.size, equalTo(7))
 
         assertThat(
             generatedExtensions,
             hasItems(
                 startsWith(
-                    "inline fun <reified T : org.gradle.api.Named> org.gradle.api.model.ObjectFactory.named(p1: String): T ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : org.gradle.api.Named> org.gradle.api.model.ObjectFactory.named(p1: String): T ="),
                 startsWith(
-                    "inline fun <reified T> org.gradle.api.model.ObjectFactory.newInstance(vararg p1: Any): T ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.newInstance(vararg p1: Any): T ="),
                 startsWith(
-                    "inline fun <reified T> org.gradle.api.model.ObjectFactory.property(): org.gradle.api.provider.Property<T> ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.property(): org.gradle.api.provider.Property<T> ="),
                 startsWith(
-                    "inline fun <reified T> org.gradle.api.model.ObjectFactory.listProperty(): org.gradle.api.provider.ListProperty<T> ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.listProperty(): org.gradle.api.provider.ListProperty<T> ="),
                 startsWith(
-                    "inline fun <reified T> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> ="),
                 startsWith(
                     "inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> ="),
                 startsWith(
-                    "@Deprecated(\"Deprecated Gradle API\")\ninline fun <reified T> org.gradle.api.Project.property(): org.gradle.api.provider.PropertyState<T> ="),
-                startsWith(
-                    "inline fun <reified T> org.gradle.api.Project.container(): org.gradle.api.NamedDomainObjectContainer<T> ="),
-                startsWith(
-                    "inline fun <reified T> org.gradle.api.Project.container(p1: org.gradle.api.NamedDomainObjectFactory<T>): org.gradle.api.NamedDomainObjectContainer<T> =")))
+                    "@Deprecated(\"Deprecated Gradle API\")\n@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.provider.ProviderFactory.property(): org.gradle.api.provider.PropertyState<T> =")))
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.PluginCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -73,13 +74,14 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
             Plugin::class.java,
             ObjectFactory::class.java,
             PluginCollection::class.java,
-            ProviderFactory::class.java))
+            ProviderFactory::class.java,
+            ExtensionContainer::class.java))
 
         val generatedExtensions = ApiTypeProvider(classPathBytecodeRepositoryFor(jars)).use { api ->
             gradleApiExtensionDeclarationsFor(api).toList()
         }
 
-        assertThat(generatedExtensions.size, equalTo(7))
+        assertThat(generatedExtensions.size, equalTo(13))
 
         assertThat(
             generatedExtensions,
@@ -97,6 +99,19 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
                 startsWith(
                     "inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> ="),
                 startsWith(
-                    "@Deprecated(\"Deprecated Gradle API\")\n@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.provider.ProviderFactory.property(): org.gradle.api.provider.PropertyState<T> =")))
+                    "@Deprecated(\"Deprecated Gradle API\")\n@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.provider.ProviderFactory.property(): org.gradle.api.provider.PropertyState<T> ="),
+                startsWith(
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.add(p1: String, p2: T): Unit =\n    add(typeOf<T>(), p1, p2)"),
+                startsWith(
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.getByType(): T =\n    getByType(typeOf<T>())"),
+                startsWith(
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.findByType(): T? =\n    findByType(typeOf<T>())"),
+                startsWith(
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.create(p1: String, p2: java.lang.Class<T>, vararg p3: Any): T =\n    create(typeOf<T>(), p1, T::class.java, p3)"),
+                startsWith(
+                    "inline fun <reified T> org.gradle.api.plugins.ExtensionContainer.create(p0: String, vararg p2: Any): T =\n    create(p0, T::class.java, p2)"),
+                startsWith(
+                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.configure(noinline p1: T.() -> Unit): Unit =\n    configure(typeOf<T>(), p1)")
+            ))
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -37,7 +37,7 @@ import kotlin.system.measureTimeMillis
 class GradleApiExtensionsTest : AbstractIntegrationTest() {
 
     @Test
-    fun `whole Gradle API generation and compilation`() {
+    fun `whole Gradle API extensions generation and compilation`() {
         val jars = customInstallation().let { custom ->
             sequenceOf(custom.resolve("lib"), custom.resolve("lib/plugins")).flatMap {
                 it.listFiles(FileFilter { it.name.endsWith(".jar") }).asSequence()
@@ -49,17 +49,16 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
         measureTimeMillis {
             writeGradleApiExtensionsTo(sourceFile, jars)
         }.also {
-            println("Generation to file took ${it}ms")
+            println("Generation to file succeeded in ${it}ms")
         }
 
         measureTimeMillis {
             StandardKotlinFileCompiler.compileToDirectory(
                 existing("output").also { it.mkdirs() },
                 listOf(sourceFile),
-                jars
-            )
+                jars)
         }.also {
-            println("Compilation took ${it}ms")
+            println("Compilation succeeded in ${it}ms")
         }
     }
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -89,29 +89,29 @@ class GradleApiExtensionsTest : AbstractIntegrationTest() {
                 startsWith(
                     "@org.gradle.api.Incubating\ninline fun <reified T : org.gradle.api.Named> org.gradle.api.model.ObjectFactory.named(p1: String): T ="),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.newInstance(vararg p1: Any): T ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.model.ObjectFactory.newInstance(vararg p1: Any): T ="),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.property(): org.gradle.api.provider.Property<T> ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.model.ObjectFactory.property(): org.gradle.api.provider.Property<T> ="),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.listProperty(): org.gradle.api.provider.ListProperty<T> ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.model.ObjectFactory.listProperty(): org.gradle.api.provider.ListProperty<T> ="),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> ="),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.model.ObjectFactory.setProperty(): org.gradle.api.provider.SetProperty<T> ="),
                 startsWith(
                     "inline fun <reified S : T, T : org.gradle.api.Plugin<*>> org.gradle.api.plugins.PluginCollection<T>.withType(): org.gradle.api.plugins.PluginCollection<S> ="),
                 startsWith(
-                    "@Deprecated(\"Deprecated Gradle API\")\n@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.provider.ProviderFactory.property(): org.gradle.api.provider.PropertyState<T> ="),
+                    "@Deprecated(\"Deprecated Gradle API\")\n@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.provider.ProviderFactory.property(): org.gradle.api.provider.PropertyState<T> ="),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.add(p1: String, p2: T): Unit =\n    add(typeOf<T>(), p1, p2)"),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.add(p1: String, p2: T): Unit =\n    add(typeOf<T>(), p1, p2)"),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.getByType(): T =\n    getByType(typeOf<T>())"),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.getByType(): T =\n    getByType(typeOf<T>())"),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.findByType(): T? =\n    findByType(typeOf<T>())"),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.findByType(): T? =\n    findByType(typeOf<T>())"),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.create(p1: String, p2: kotlin.reflect.KClass<T>, vararg p3: Any): T =\n    create(typeOf<T>(), p1, p2.java, p3)"),
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.create(p1: String, p2: kotlin.reflect.KClass<T>, vararg p3: Any): T =\n    create(typeOf<T>(), p1, p2.java, p3)"),
                 startsWith(
-                    "inline fun <reified T> org.gradle.api.plugins.ExtensionContainer.create(p0: String, vararg p2: Any): T =\n    create(p0, T::class.java, p2)"),
+                    "inline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.create(p0: String, vararg p2: Any): T =\n    create(p0, T::class.java, p2)"),
                 startsWith(
-                    "@org.gradle.api.Incubating\ninline fun <reified T> org.gradle.api.plugins.ExtensionContainer.configure(noinline p1: T.() -> Unit): Unit =\n    configure(typeOf<T>(), p1)")
+                    "@org.gradle.api.Incubating\ninline fun <reified T : Any> org.gradle.api.plugins.ExtensionContainer.configure(noinline p1: T.() -> Unit): Unit =\n    configure(typeOf<T>(), p1)")
             ))
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -29,7 +29,7 @@ class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
 
         val kotlinExtensionsMonitor = mock<ProgressMonitor>(name = "kotlinExtensionsMonitor")
         val progressMonitorProvider = mock<JarGenerationProgressMonitorProvider> {
-            on { progressMonitorFor(generatedKotlinExtensions, 1) } doReturn kotlinExtensionsMonitor
+            on { progressMonitorFor(generatedKotlinExtensions, 2) } doReturn kotlinExtensionsMonitor
         }
 
         val subject = KotlinScriptClassPathProvider(
@@ -47,7 +47,7 @@ class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
 
     private
     fun verifyProgressMonitor(monitor: ProgressMonitor) {
-        verify(monitor, times(1)).onProgress()
+        verify(monitor, times(2)).onProgress()
         verify(monitor, times(1)).close()
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -29,7 +29,7 @@ class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
 
         val kotlinExtensionsMonitor = mock<ProgressMonitor>(name = "kotlinExtensionsMonitor")
         val progressMonitorProvider = mock<JarGenerationProgressMonitorProvider> {
-            on { progressMonitorFor(generatedKotlinExtensions, 2) } doReturn kotlinExtensionsMonitor
+            on { progressMonitorFor(generatedKotlinExtensions, 3) } doReturn kotlinExtensionsMonitor
         }
 
         val subject = KotlinScriptClassPathProvider(
@@ -47,7 +47,7 @@ class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
 
     private
     fun verifyProgressMonitor(monitor: ProgressMonitor) {
-        verify(monitor, times(2)).onProgress()
+        verify(monitor, times(3)).onProgress()
         verify(monitor, times(1)).close()
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
@@ -1,0 +1,97 @@
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.api.tasks.javadoc.Groovydoc
+import org.gradle.api.tasks.wrapper.Wrapper
+
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.DeepThought
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.notNullValue
+
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+
+class ClassBytesRepositoryTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `class file path candidates for source name`() {
+
+        assertThat(
+            classFilePathCandidatesFor("My").toList(),
+            equalTo(listOf("My.class", "MyKt.class")))
+
+        assertThat(
+            classFilePathCandidatesFor("foo.My").toList(),
+            equalTo(listOf(
+                "foo/My.class", "foo/MyKt.class",
+                "foo${'$'}My.class", "foo${'$'}MyKt.class")))
+
+        assertThat(
+            classFilePathCandidatesFor("foo.My.Nested").toList(),
+            equalTo(listOf(
+                "foo/My/Nested.class", "foo/My/NestedKt.class",
+                "foo/My${'$'}Nested.class", "foo/My${'$'}NestedKt.class",
+                "foo${'$'}My${'$'}Nested.class", "foo${'$'}My${'$'}NestedKt.class")))
+    }
+
+    @Test
+    fun `source name for class file path`() {
+
+        assertThat(kotlinSourceNameOf("My.class"), equalTo("My"))
+        assertThat(kotlinSourceNameOf("MyKt.class"), equalTo("My"))
+
+        assertThat(kotlinSourceNameOf("foo/My.class"), equalTo("foo.My"))
+        assertThat(kotlinSourceNameOf("foo/MyKt.class"), equalTo("foo.My"))
+
+        assertThat(kotlinSourceNameOf("foo/My${'$'}Nested.class"), equalTo("foo.My.Nested"))
+        assertThat(kotlinSourceNameOf("foo/My${'$'}NestedKt.class"), equalTo("foo.My.Nested"))
+    }
+
+    class SomeKotlin {
+        interface NestedType
+    }
+
+    @Test
+    fun `finds top-level, nested, java, kotlin types in JARs and directories`() {
+
+        val jar1 = withClassJar(
+            "first.jar",
+            Groovydoc::class.java,
+            Groovydoc.Link::class.java,
+            DeepThought::class.java)
+
+        val jar2 = withClassJar(
+            "second.jar",
+            Wrapper::class.java,
+            Wrapper.DistributionType::class.java,
+            SomeKotlin::class.java,
+            SomeKotlin.NestedType::class.java)
+
+        val cpDir = existing("cp-dir").also { it.mkdirs() }
+        unzipTo(cpDir, jar2)
+
+        classPathBytecodeRepositoryFor(listOf(jar1, cpDir)).use { repo ->
+            assertThat(
+                repo.classBytesFor(Groovydoc.Link::class.qualifiedName!!),
+                notNullValue())
+            assertThat(
+                repo.classBytesFor(Wrapper.DistributionType::class.qualifiedName!!),
+                notNullValue())
+        }
+
+        classPathBytecodeRepositoryFor(listOf(jar1, cpDir)).use { repo ->
+            assertThat(
+                repo.allClassesBytesBySourceName().map { it.first }.toList(),
+                equalTo(listOf(
+                    Groovydoc::class.qualifiedName!!,
+                    Groovydoc.Link::class.qualifiedName!!,
+                    DeepThought::class.qualifiedName!!,
+                    Wrapper.DistributionType::class.qualifiedName!!,
+                    Wrapper::class.qualifiedName!!,
+                    SomeKotlin.NestedType::class.qualifiedName!!,
+                    SomeKotlin::class.qualifiedName!!)))
+        }
+    }
+}

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
@@ -7,6 +7,7 @@ import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
 
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.CoreMatchers.notNullValue
 
 import org.junit.Assert.assertThat
@@ -74,24 +75,24 @@ class ClassBytesRepositoryTest : AbstractIntegrationTest() {
 
         classPathBytecodeRepositoryFor(listOf(jar1, cpDir)).use { repo ->
             assertThat(
-                repo.classBytesFor(Groovydoc.Link::class.qualifiedName!!),
+                repo.classBytesFor(Groovydoc.Link::class.java.canonicalName),
                 notNullValue())
             assertThat(
-                repo.classBytesFor(Wrapper.DistributionType::class.qualifiedName!!),
+                repo.classBytesFor(Wrapper.DistributionType::class.java.canonicalName),
                 notNullValue())
         }
 
         classPathBytecodeRepositoryFor(listOf(jar1, cpDir)).use { repo ->
             assertThat(
                 repo.allClassesBytesBySourceName().map { it.first }.toList(),
-                equalTo(listOf(
-                    Groovydoc::class.qualifiedName!!,
-                    Groovydoc.Link::class.qualifiedName!!,
-                    DeepThought::class.qualifiedName!!,
-                    Wrapper.DistributionType::class.qualifiedName!!,
-                    Wrapper::class.qualifiedName!!,
-                    SomeKotlin.NestedType::class.qualifiedName!!,
-                    SomeKotlin::class.qualifiedName!!)))
+                hasItems(
+                    Groovydoc::class.java.canonicalName,
+                    Groovydoc.Link::class.java.canonicalName,
+                    DeepThought::class.java.canonicalName,
+                    Wrapper.DistributionType::class.java.canonicalName,
+                    Wrapper::class.java.canonicalName,
+                    SomeKotlin.NestedType::class.java.canonicalName,
+                    SomeKotlin::class.java.canonicalName))
         }
     }
 }

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
@@ -73,7 +73,7 @@ class ClassBytesRepositoryTest : AbstractIntegrationTest() {
         val cpDir = existing("cp-dir").also { it.mkdirs() }
         unzipTo(cpDir, jar2)
 
-        classPathBytecodeRepositoryFor(listOf(jar1, cpDir)).use { repo ->
+        classPathBytesRepositoryFor(listOf(jar1, cpDir)).use { repo ->
             assertThat(
                 repo.classBytesFor(Groovydoc.Link::class.java.canonicalName),
                 notNullValue())
@@ -82,7 +82,7 @@ class ClassBytesRepositoryTest : AbstractIntegrationTest() {
                 notNullValue())
         }
 
-        classPathBytecodeRepositoryFor(listOf(jar1, cpDir)).use { repo ->
+        classPathBytesRepositoryFor(listOf(jar1, cpDir)).use { repo ->
             assertThat(
                 repo.allClassesBytesBySourceName().map { it.first }.toList(),
                 hasItems(


### PR DESCRIPTION

This PR is a spike on generating Kotlin extensions over the Gradle API that:
- replace `Class<T>` parameters with `KClass<T>`
- reify type argument of `TypeOf` or `Class` taking methods, favoring `TypeOf<T>` as it allows to capture type arguments fully

For:

```java
public interface ObjectFactory {
    <T extends Named> T named(Class<T> type, String name);
}
```

it generates the following (comments and annotations ommited):

```kotlin
fun <T : Named> ObjectFactory.named(p0: KClass<T>, p1: String): T =
    named(p0.java, p1)

inline fun <reified T : Named> ObjectFactory.named(p1: String): T =
    named(T::class.java, p1)
```

It also maps arrays of `Class` to Kotlin varargs, e.g.:

```kotlin
fun ArtifactResolutionQuery.withArtifacts(p0: KClass<Component>, vararg p1: KClass<Artifact>): ArtifactResolutionQuery =
    withArtifacts(p0.java, *p1.map { it.java }.toTypedArray())
```

And translates `Action<T>` to `T.() -> Unit`, e.g.:

```kotlin
inline fun <reified T : Any> ExtensionContainer.configure(noinline p1: T.() -> Unit): Unit =
    configure(typeOf<T>(), p1)
```

Unfortunately, parameter names aren't present in the bytecode so extensions use numbered parameter names. Once Gradle requires Java 8 and is compiled with the `-parameters` flag we'll be able to read parameter names from the bytecode. Client code using named parameters will break when parameter names change.

This process produces extensions that are already present in the Gradle Kotlin DSL api, the latter should be removed. This spike doesn't include the removals, hence using it as this repository's wrapper will fail with conflicting extensions errors. These removals also are a breaking change for client code that uses named parameters.

Just like for extensions for core plugin IDs, the generation happens when generating the `gradle-kotlin-dsl-extensions-XXX.jar`.

On a local cold vm, generation takes <2s, down to 700ms if run repeatedly. Compilation takes ~6/7s, down to ~1.5s if run repeatedly. But this is intended to be run on a cold vm, once per Gradle Kotlin DSL version. We're talking about a total of 8 to 9 seconds.

It goes over the whole Gradle API. This is relatively costly because we need to discover all available types from a ClassPath. Another approach could be to generate extensions only for types from the implicit imports list, thus removing the type discovery cost.

We could win, say, a second, by e.g. using the implicit imports as an input and parallelizing the generation. Some other optimizations are probably lurking here and there.  But, Kotlin compilation largely dominates.

