### PR TITLE
Rename dist-snapshots repo to kotlin-dsl-snapshots-local

### DIFF
--- a/doc/release-notes/0.11.1.md
+++ b/doc/release-notes/0.11.1.md
@@ -2,13 +2,13 @@ Gradle Kotlin DSL 0.11.1 Release Notes
 ============================
 
 Gradle Kotlin DSL v0.11.1 brings the latest and greatest Kotlin (**1.1.4-3**) and takes big steps toward general usability with utilities for Groovy-heavy DSLs such as Maven POM customization, Ant usage and those provided by Groovy-biased community plugins.
- 
+
 v0.11.1 is expected to be included in the upcoming Gradle 4.2 RC1.
 
 The features in this release are also available for immediate use within the latest Gradle Kotlin DSL distribution snapshot. To use it, upgrade your Gradle wrapper in the following fashion:
 
     $ cd $YOUR_PROJECT_ROOT
-    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/dist-snapshots/gradle-kotlin-dsl-4.2-20170901130305+0000-all.zip
+    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.2-20170901130305+0000-all.zip
 
 Once Gradle 4.2 RC1 is out, we encourage all users to upgrade in the following fashion:
 
@@ -41,14 +41,14 @@ Updates since v0.10.3
    }
    ```
 
-   Check out the [maven plugin configuration sample](https://github.com/gradle/kotlin-dsl/blob/75eff6bff118253852d5e040831caa7afd7136c3/samples/maven-plugin/build.gradle.kts#L16) and the [ant usage sample](https://github.com/gradle/kotlin-dsl/blob/fc5cd9d444c8917b1e7e9bf828cdd406068c9259/samples/ant/build.gradle.kts) to see these extensions in action. 
+   Check out the [maven plugin configuration sample](https://github.com/gradle/kotlin-dsl/blob/75eff6bff118253852d5e040831caa7afd7136c3/samples/maven-plugin/build.gradle.kts#L16) and the [ant usage sample](https://github.com/gradle/kotlin-dsl/blob/fc5cd9d444c8917b1e7e9bf828cdd406068c9259/samples/ant/build.gradle.kts) to see these extensions in action.
 
- * **Projects using the `kotlin-dsl` plugin can be edited correctly in IntelliJ** ([#373][issue-373]). Before this release, lambda expressions passed as `org.gradle.api.Action<T>` arguments were not being typed accurately and  so `T` member references were highlighted as errors and code completion provided wrong suggestions. These are now working properly except in `buildSrc` projects. 
+ * **Projects using the `kotlin-dsl` plugin can be edited correctly in IntelliJ** ([#373][issue-373]). Before this release, lambda expressions passed as `org.gradle.api.Action<T>` arguments were not being typed accurately and  so `T` member references were highlighted as errors and code completion provided wrong suggestions. These are now working properly except in `buildSrc` projects.
 
    ![Gradle plugin screenshot](https://user-images.githubusercontent.com/132773/29875212-83c1f456-8d99-11e7-84f7-987b3c34164c.png)
 
  * **Seamless testing for projects using the `kotlin-dsl` plugin** ([#450][issue-450]). As the `gradleKotlinDsl()` dependency is now added to the `testRuntimeOnly` configuration.
- 
+
  * **IntelliJ IDEA resolves Gradle script classpath asynchronously** ([#355][issue-355]). A long awaited feature, IntelliJ no longer blocks the editor while the classpath of the open script is being resolved.
 
  * **Maven repository shortcut** ([#256][issue-256]). Due to popular demand a shortcut has been added to the DSL that simplifies the configuration of `maven` repositories.
@@ -74,7 +74,7 @@ Updates since v0.10.3
  * **New samples** ([#456][issue-456], [#260][issue-260]). A new sample demonstrating how to write [a Kotlin DSL friendly Gradle plugin in Groovy](https://github.com/gradle/kotlin-dsl/blob/2ac84ffa73a0c786560e16c562d2b57d6900fbb9/samples/kotlin-friendly-groovy-plugin/plugin/src/main/groovy/my/DocumentationPlugin.groovy#L5) has been added as well as another one demonstrating [how to configure the (now deprecated) Software Model in Kotlin](https://github.com/gradle/kotlin-dsl/blob/68206dceb2d86a5e33fc4169d7dc15039c5289e2/samples/model-rules/buildSrc/src/main/kotlin/my/model_rules.kt#L16).
 
  * **`applyFrom(uri)` removed from the DSL** ([#444][issue-444]). For symmetry, scripts should use `apply { from(uri) }` instead.
- 
+
 [issue-47]: https://github.com/gradle/kotlin-dsl/issues/47
 [issue-142]: https://github.com/gradle/kotlin-dsl/issues/142
 [issue-256]: https://github.com/gradle/kotlin-dsl/issues/256

--- a/doc/release-notes/0.12.0.md
+++ b/doc/release-notes/0.12.0.md
@@ -8,7 +8,7 @@ v0.12.0 is expected to be included in the upcoming Gradle 4.3 RC1.
 The features in this release are also available for immediate use within the latest Gradle Kotlin DSL distribution snapshot. To use it, upgrade your Gradle wrapper in the following fashion:
 
     $ cd $YOUR_PROJECT_ROOT
-    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/dist-snapshots/gradle-kotlin-dsl-4.3-20171004164220+0000-all.zip
+    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.3-20171004164220+0000-all.zip
 
 Once Gradle 4.3 RC1 is out, we encourage all users to upgrade in the following fashion:
 
@@ -184,7 +184,7 @@ Updates since v0.11.1
             }
         }
     }
-    ```        
+    ```
 
  * **Nullable extra properties** ([#516](https://github.com/gradle/kotlin-dsl/issues/516), [#512](https://github.com/gradle/kotlin-dsl/issues/512)). Nullable extra properties can now be expressed via nullability of the property type:
 

--- a/doc/release-notes/0.12.1.md
+++ b/doc/release-notes/0.12.1.md
@@ -8,7 +8,7 @@ v0.12.1 is expected to be included in the upcoming Gradle 4.3 RC1.
 The features in this release are also available for immediate use within the latest Gradle Kotlin DSL distribution snapshot. To use it, upgrade your Gradle wrapper in the following fashion:
 
     $ cd $YOUR_PROJECT_ROOT
-    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/dist-snapshots/gradle-kotlin-dsl-4.3-20171010191714+0000-all.zip
+    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.3-20171010191714+0000-all.zip
 
 Once Gradle 4.3 RC1 is out, we encourage all users to upgrade in the following fashion:
 

--- a/doc/release-notes/0.13.1.md
+++ b/doc/release-notes/0.13.1.md
@@ -9,7 +9,7 @@ The features in this release are also available for immediate use within the lat
 
     $ cd $YOUR_PROJECT_ROOT
     $ gradle wrapper --gradle-distribution-url
-    https://repo.gradle.org/gradle/dist-snapshots/gradle-kotlin-dsl-4.4-20171117171149+0000-all.zip
+    https://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.4-20171117171149+0000-all.zip
 
 Once Gradle 4.4 RC1 is out, we encourage all users to upgrade in the following fashion:
 
@@ -21,14 +21,14 @@ Updates since v0.12.3
 ----------------------
 
  * **Support settings file written in Kotlin** (#56). Gradle will now look for a file named `settings.gradle.kts` whenever `settings.gradle` cannot be found during the [initialization phase](https://docs.gradle.org/current/userguide/build_lifecycle.html#sec:build_phases). `settings.gradle.kts` is evaluated against the [Gradle Settings object](https://docs.gradle.org/current/dsl/org.gradle.api.initialization.Settings.html) so all of its members can be referenced without qualification. In addition, all members of the [ScriptApi interface](https://github.com/gradle/kotlin-dsl/blob/37c28af671d0498c72c9e72d24227cddc7d3932e/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/ScriptApi.kt#L50) are supported and can also be referenced without qualification. Support for authoring `settings.gradle.kts` landed on IntelliJ IDEA starting with version `1.1.60-eap-43` of the Kotlin plugin (#531):
-   
+
    ![settings.gradle.kts](https://user-images.githubusercontent.com/51689/32514644-d11ab388-c3e4-11e7-91b0-d0f9bd8a6fde.gif)
 
     All [samples](https://github.com/gradle/kotlin-dsl/tree/95d1fcb02655f5abb1e47fa23f5c76b948dc4dba/samples) have been updated to take advantage of `settings.gradle.kts` support (#550) and new samples have been added demonstrating how to use `settings.gradle.kts` to configure:
     * the [build cache](https://guides.gradle.org/using-build-cache/) (#570, [sample](https://github.com/gradle/kotlin-dsl/tree/95d1fcb02655f5abb1e47fa23f5c76b948dc4dba/samples/build-cache))
     * dependency substitutions in [composite builds](https://docs.gradle.org/current/userguide/composite_builds.html) (#571, [sample](https://github.com/gradle/kotlin-dsl/tree/95d1fcb02655f5abb1e47fa23f5c76b948dc4dba/samples/composite-builds))
     * [source dependencies](https://github.com/gradle/gradle-native/issues/42) (#572, [sample](https://github.com/gradle/kotlin-dsl/tree/95d1fcb02655f5abb1e47fa23f5c76b948dc4dba/samples/source-control))
-   
+
  * **Default `build-scan` plugin version is the same as the one applied by Gradle when the `--scan` option is specified** (#490). Prior to this release, the default version of the `build-scan` plugin was hard-coded in the `kotlin-dsl` distribution. That information is now managed by Gradle Core.
 
  * **Expose Kotlin standard library extensions for Java 7 and Java 8 to build scripts** (#558). The build script classpath now includes `kotlin-stdlib-jre8` and `kotlin-stdlib-jre7` enabling the use of features such as [named regex groups](https://github.com/gradle/gradle/issues/3194), [kotlin.streams](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.streams/index.html) among other things.
@@ -37,4 +37,4 @@ Updates since v0.12.3
 
  * **kotlin2js plugin sample updated to leverage the `plugins` block** (#539).
 
- * **Account for `PropertyState` deprecation in favor of `Property`** (#540). [`org.gradle.api.provider.PropertyState`](https://docs.gradle.org/current/javadoc/index.html?org/gradle/api/provider/PropertyState.html) has been deprecated in favour of [`org.gradle.api.provider.Property`](https://docs.gradle.org/current/javadoc/index.html?org/gradle/api/provider/PropertyState.html). Samples and API extensions have been updated to take the change into account. 
+ * **Account for `PropertyState` deprecation in favor of `Property`** (#540). [`org.gradle.api.provider.PropertyState`](https://docs.gradle.org/current/javadoc/index.html?org/gradle/api/provider/PropertyState.html) has been deprecated in favour of [`org.gradle.api.provider.Property`](https://docs.gradle.org/current/javadoc/index.html?org/gradle/api/provider/PropertyState.html). Samples and API extensions have been updated to take the change into account.

--- a/doc/release-notes/0.14.0.md
+++ b/doc/release-notes/0.14.0.md
@@ -8,7 +8,7 @@ v0.14.0 will be included in Gradle 4.5.
 The features in this release are also available for immediate use within the latest Gradle Kotlin DSL distribution snapshot. To use it, upgrade your Gradle wrapper in the following fashion:
 
     $ cd $YOUR_PROJECT_ROOT
-    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/dist-snapshots/gradle-kotlin-dsl-4.5-20171202002741+0000-all.zip
+    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.5-20171202002741+0000-all.zip
 
 Once Gradle 4.5 RC1 is out, we encourage all users to upgrade in the following fashion:
 

--- a/doc/release-notes/0.8.0.md
+++ b/doc/release-notes/0.8.0.md
@@ -1,21 +1,21 @@
 Gradle Script Kotlin 0.8.0 Release Notes
 ========================================
 
-Gradle Script Kotlin v0.8.0 is a major step forward in usability, bringing a more consistent DSL, convenient and type-safe access to contributed project extensions and conventions, much better error reporting, bug fixes and, of course, the latest and greatest Kotlin release. 
- 
+Gradle Script Kotlin v0.8.0 is a major step forward in usability, bringing a more consistent DSL, convenient and type-safe access to contributed project extensions and conventions, much better error reporting, bug fixes and, of course, the latest and greatest Kotlin release.
+
 v0.8.0 is expected to be included in the upcoming Gradle 3.5 RC1.
 
 The features in this release are also available for immediate use within the latest Gradle Script Kotlin distribution snapshot. To use it, upgrade your Gradle wrapper in the following fashion:
 
     $ cd $YOUR_PROJECT_ROOT
-    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/dist-snapshots/gradle-script-kotlin-3.5-20170305000422+0000-all.zip
+    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-script-kotlin-3.5-20170305000422+0000-all.zip
 
 Updates since v0.7.0
 --------------------
 
  * **Kotlin 1.1.0** ([#289](https://github.com/gradle/gradle-script-kotlin/issues/289)). Build scripts are now compiled against [Kotlin 1.1.0](https://blog.jetbrains.com/kotlin/2017/03/kotlin-1-1/)! This enables, among other things, [the use of coroutines in build scripts](https://github.com/gradle/gradle-script-kotlin/issues/292#issuecomment-284367696).
-    
- * **Better error reporting** ([#177](https://github.com/gradle/gradle-script-kotlin/issues/177), [#170](https://github.com/gradle/gradle-script-kotlin/issues/170), [#254](https://github.com/gradle/gradle-script-kotlin/issues/254), [#290](https://github.com/gradle/gradle-script-kotlin/issues/290)). Gradle will now report the correct location for compilation errors occurring inside `buildscript` and `plugins` blocks, will do so in a format that's readily recognised by many tools - clicking a compilation error in a console window should open the configured text editor, for instance - and will only ever display stack traces when explicitly instructed via the `--stacktrace` argument. 
+
+ * **Better error reporting** ([#177](https://github.com/gradle/gradle-script-kotlin/issues/177), [#170](https://github.com/gradle/gradle-script-kotlin/issues/170), [#254](https://github.com/gradle/gradle-script-kotlin/issues/254), [#290](https://github.com/gradle/gradle-script-kotlin/issues/290)). Gradle will now report the correct location for compilation errors occurring inside `buildscript` and `plugins` blocks, will do so in a format that's readily recognised by many tools - clicking a compilation error in a console window should open the configured text editor, for instance - and will only ever display stack traces when explicitly instructed via the `--stacktrace` argument.
 
  * **Consistent DSL across core and community plugins** ([#156](https://github.com/gradle/gradle-script-kotlin/issues/156), [#155](https://github.com/gradle/gradle-script-kotlin/issues/155), [#157](https://github.com/gradle/gradle-script-kotlin/issues/157), [#224](https://github.com/gradle/gradle-script-kotlin/issues/224)). The build script compiler will now treat [Gradle's `Action<T>`](https://docs.gradle.org/current/javadoc/org/gradle/api/Action.html) type as an alias to the `T.() -> Unit` type (a [function literal with receiver](https://kotlinlang.org/docs/reference/lambdas.html#function-literals-with-receiver) in Kotlin parlance) finally solving the [_dreaded `it` problem_](https://www.youtube.com/watch?v=vv4zh_oPBTw&feature=youtu.be&t=1387) once and for all. _WARNING: This is a breaking change and some scripts will fail to compile due to `it` no longer being defined inside lambda expressions passed as `Action<T>` parameters. Simply replace `it` by `this` or remove it altogether._
 
@@ -38,7 +38,7 @@ Updates since v0.7.0
    Given the inherent flexibility in Gradle's plugin system, it's not possible to cover all the different plugin application scenarios with a single, one-size-fits-all solution so type-safe accessors can be used in three different modes: _just-in-time_, _ahead-of-time_ and _ad hoc_.
 
    *TL;DR*: Opt-in to type-safe accessors by setting the `org.gradle.script.lang.kotlin.accessors.auto` project property to `"true"` and hack on, if you get _Unresolved reference_ compilation errors, read on.
-   
+
     * **just-in-time** In just-in-time mode, accessors are generated immediatelly after the evaluation of the `plugins` block, just before the evaluation of the build script body and, because of that, accessors for extensions and conventions registered later in the process are not available. In summary, the following example works in just-in-time mode:
 
         ```kotlin
@@ -83,9 +83,9 @@ Updates since v0.7.0
 
             $ ./gradlew gskGenerateAccessors
             :gskGenerateAccessors
- 
+
             BUILD SUCCESSFUL
- 
+
             Total time: 1.867 secs
 
 
@@ -95,7 +95,7 @@ Updates since v0.7.0
         apply {
             plugin("application")
         }
- 
+
         // type-safe accessor for `application` convention
         application {
             mainClassName = "my.App"
@@ -104,11 +104,11 @@ Updates since v0.7.0
 
     * **ad-hoc** In this usage mode, the `gskProjectAccessors` task is executed whenever a new type-safe accessor is needed. `gskProjectAccessors` will then write the Kotlin code for all available type-safe accessors to stdout from where it can be copied into the build script or to a Kotlin file under `buildSrc`.
 
- * **Improved Gradle API**([#239](https://github.com/gradle/gradle-script-kotlin/issues/239), [#122](https://github.com/gradle/gradle-script-kotlin/issues/122), [#219](https://github.com/gradle/gradle-script-kotlin/issues/219), [#246](https://github.com/gradle/gradle-script-kotlin/issues/246), [#245](https://github.com/gradle/gradle-script-kotlin/issues/245), [#247](https://github.com/gradle/gradle-script-kotlin/issues/247), [#244](https://github.com/gradle/gradle-script-kotlin/issues/244), [#243](https://github.com/gradle/gradle-script-kotlin/issues/243), [#242](https://github.com/gradle/gradle-script-kotlin/issues/242), [#241](https://github.com/gradle/gradle-script-kotlin/issues/241), [#240](https://github.com/gradle/gradle-script-kotlin/issues/240), [#238](https://github.com/gradle/gradle-script-kotlin/issues/238), [#206](https://github.com/gradle/gradle-script-kotlin/issues/206), [#226](https://github.com/gradle/gradle-script-kotlin/issues/226)). Many methods in the Gradle API previously only available to Groovy have been overloaded with versions better suited to Kotlin. 
+ * **Improved Gradle API**([#239](https://github.com/gradle/gradle-script-kotlin/issues/239), [#122](https://github.com/gradle/gradle-script-kotlin/issues/122), [#219](https://github.com/gradle/gradle-script-kotlin/issues/219), [#246](https://github.com/gradle/gradle-script-kotlin/issues/246), [#245](https://github.com/gradle/gradle-script-kotlin/issues/245), [#247](https://github.com/gradle/gradle-script-kotlin/issues/247), [#244](https://github.com/gradle/gradle-script-kotlin/issues/244), [#243](https://github.com/gradle/gradle-script-kotlin/issues/243), [#242](https://github.com/gradle/gradle-script-kotlin/issues/242), [#241](https://github.com/gradle/gradle-script-kotlin/issues/241), [#240](https://github.com/gradle/gradle-script-kotlin/issues/240), [#238](https://github.com/gradle/gradle-script-kotlin/issues/238), [#206](https://github.com/gradle/gradle-script-kotlin/issues/206), [#226](https://github.com/gradle/gradle-script-kotlin/issues/226)). Many methods in the Gradle API previously only available to Groovy have been overloaded with versions better suited to Kotlin.
 
  * **Improved Groovy interoperability**([#286](https://github.com/gradle/gradle-script-kotlin/issues/286)). Groovy closures can now be invoked using regular function invocation syntax.
 
- * **Sub-project build scripts inherit parent project compilation classpath** ([#190](https://github.com/gradle/gradle-script-kotlin/issues/190)). 
+ * **Sub-project build scripts inherit parent project compilation classpath** ([#190](https://github.com/gradle/gradle-script-kotlin/issues/190)).
 
  * **Projects can use `kotlin-gradle-plugin` 1.0.x again** ([#189](https://github.com/gradle/gradle-script-kotlin/issues/189)). Thanks to the upgrade to Kotlin 1.1.0, compatibility with Kotlin 1.0.x has been restored.
 

--- a/doc/release-notes/0.9.0.md
+++ b/doc/release-notes/0.9.0.md
@@ -2,13 +2,13 @@ Gradle Script Kotlin 0.9.0 Release Notes
 ========================================
 
 Gradle Script Kotlin v0.9.0 is another major step forward in usability, bringing improvements to the DSL, IntelliJ experience, performance, and finally automatic detection of Kotlin based builds.
- 
+
 v0.9.0 is expected to be included in the upcoming Gradle 4.0 RC1.
 
 The features in this release are also available for immediate use within the latest Gradle Script Kotlin distribution snapshot. To use it, upgrade your Gradle wrapper in the following fashion:
 
     $ cd $YOUR_PROJECT_ROOT
-    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/dist-snapshots/gradle-script-kotlin-4.0-20170518042627+0000-all.zip
+    $ gradle wrapper --gradle-distribution-url https://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-script-kotlin-4.0-20170518042627+0000-all.zip
 
 Updates since v0.8.0
 --------------------
@@ -16,17 +16,17 @@ Updates since v0.8.0
  * **Automatic detection of Kotlin based builds** ([#37][10037], [#80][10080]). After a little more than an year since the issue was first added to our board this huge usability improvement has finally landed!
 
     No more `rootProject.buildFileName = 'build.gradle.kts'` boilerplate or `settings.gradle` file required in order to enable Kotlin build script! :tada:
- 
+
  * **Default imports for the whole Gradle API** ([#215][100215], [#347][100347]). To make build scripts more concise, the set of default imports now includes the whole Gradle API as documented in the [Default imports section of the Gradle User Guide](https://docs.gradle.org/current/userguide/writing_build_scripts.html#script-default-imports).
 
- * **Improved Gradle API with type safe setters** ([#341][100341]). Kotlin recognizes mutable JavaBean properties only when both the getter and at least one setter agree on the property type. 
+ * **Improved Gradle API with type safe setters** ([#341][100341]). Kotlin recognizes mutable JavaBean properties only when both the getter and at least one setter agree on the property type.
 
      More than 50 strongly typed setters have been recently added to the Gradle API enabling build scripts to migrate from invocation heavy configuration syntax such as:
 
     ```kotlin
     val someBuild by tasks.creating(GradleBuild::class) {
         setDir(file("some/path"))      // NOT RECOGNIZED AS PROPERTY BECAUSE OF UNTYPED SETTER
-        setTasks(listOf("foo", "bar")) // NOT RECOGNIZED AS PROPERTY BECAUSE OF UNTYPED SETTER 
+        setTasks(listOf("foo", "bar")) // NOT RECOGNIZED AS PROPERTY BECAUSE OF UNTYPED SETTER
     }
     ```
 
@@ -38,16 +38,16 @@ Updates since v0.8.0
         tasks = listOf("foo", "bar")
     }
     ```
- 
+
  * **Improved project extension accessors with properties** ([#330][100330]). So one can now write `java.sourceSets` instead of `java().sourceSets` as in `0.8.0`.
 
- * **API documentation** ([#209][100209]). A first cut of this important piece of documentation, generated using [Dokka](https://kotlinlang.org/docs/reference/kotlin-doc.html), is now available at https://gradle.github.io/gradle-script-kotlin-docs/api/. 
+ * **API documentation** ([#209][100209]). A first cut of this important piece of documentation, generated using [Dokka](https://kotlinlang.org/docs/reference/kotlin-doc.html), is now available at https://gradle.github.io/gradle-script-kotlin-docs/api/.
 
  * **IntelliJ improvements**
- 
+
    * **Classpath computation is now asynchronous** ([#249][100249]). And should no longer block the UI (pending a fix to [this IntelliJ issue](https://youtrack.jetbrains.com/issue/KT-17771))
 
-   * **Type-safe accessors are correctly included in the classpath given to IntelliJ** ([#340][100340]). Upon changes to the `plugins` block (pending a fix to [this IntelliJ issue](https://youtrack.jetbrains.com/issue/KT-17770)) 
+   * **Type-safe accessors are correctly included in the classpath given to IntelliJ** ([#340][100340]). Upon changes to the `plugins` block (pending a fix to [this IntelliJ issue](https://youtrack.jetbrains.com/issue/KT-17770))
 
    * **Source code navigation now works for everything Gradle** ([#281][100281]).
 
@@ -69,25 +69,25 @@ Updates since v0.8.0
                 jcenter()
             }
         }
-        
+
         apply {
             plugin("com.android.application")
             plugin("kotlin-android")
         }
-        
+
         android {
             buildToolsVersion("25.0.0")
             compileSdkVersion(23)
-        
+
             defaultConfig {
                 minSdkVersion(15)
                 targetSdkVersion(23)
-        
+
                 applicationId = "com.example.kotlingradle"
                 versionCode = 1
                 versionName = "1.0"
             }
-        
+
             buildTypes {
                 getByName("release") {
                     isMinifyEnabled = false
@@ -95,13 +95,13 @@ Updates since v0.8.0
                 }
             }
         }
-        
+
         dependencies {
             compile("com.android.support:appcompat-v7:23.4.0")
             compile("com.android.support.constraint:constraint-layout:1.0.0-alpha8")
             compile(kotlinModule("stdlib"))
         }
-        
+
         repositories {
             jcenter()
         }
@@ -115,17 +115,17 @@ Updates since v0.8.0
 
         ```kotlin
         open class GreetingPluginExtension(project: Project) {
-        
+
             // Declare a `PropertyState<String>` backing field
             private
             val messageState = project.property<String>()
-        
+
             // Expose `messageState` as the `message` property whose type is inferred as String
             var message by messageState
-        
+
             // Can also be exposed as `Provider<String>` for additional functionality
             val messageProvider: Provider<String> get() = messageState
-        
+
             // `outputFiles` property type is inferred as `ConfigurableFileCollection`
             // with the following behaviour:
             //  - getting will always return the original instance
@@ -133,9 +133,9 @@ Updates since v0.8.0
             var outputFiles by project.files()
         }
         ```
-        
+
         Check out the [provider-properties sample](/gradle/gradle-script-kotlin/tree/master/samples/provider-properties) for more information.
-  
+
    * **Better caching behaviour for type-safe accessors** ([#338][338]).
 
  * **Bug fixes**
@@ -144,8 +144,8 @@ Updates since v0.8.0
 
     * **Generated extension accessor for the `publishing` extension will work as expected** ([#327][100327], [#328][100328]). And defer configuration until necessary.
 
-    * **Projects with Kotlin build scripts in `buildSrc` can be edited with the correct classpath in IntelliJ** ([#339][100339]). As build scripts will now be executed in a best-effort manner when computing the classpath. 
-    
+    * **Projects with Kotlin build scripts in `buildSrc` can be edited with the correct classpath in IntelliJ** ([#339][100339]). As build scripts will now be executed in a best-effort manner when computing the classpath.
+
 
 [10037]: https://github.com/gradle/gradle-script-kotlin/issues/37
 [10080]: https://github.com/gradle/gradle-script-kotlin/issues/80

--- a/update-wrapper.sh
+++ b/update-wrapper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-repo='dist-snapshots'
+repo='kotlin-dsl-snapshots-local'
 
 # .children[-2] selects the one before the last which is the all distro
 latestSnapshotPath=`


### PR DESCRIPTION
As discussed in #828 this is a new pull request to the `develop` branch instead of the `master` branch. See details at #828.