### PR TITLE
Remove usages of TestKit internals

### DIFF
--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -146,7 +146,6 @@ class KotlinDslPluginTest : AbstractPluginTest() {
             import java.io.File
 
             import org.gradle.testkit.runner.GradleRunner
-            import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
             import org.hamcrest.CoreMatchers.containsString
             import org.junit.Assert.assertThat
@@ -172,6 +171,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
                     // and:
                     System.setProperty("org.gradle.daemon.idletimeout", "1000")
                     System.setProperty("org.gradle.daemon.registry.base", "${escapedPathOf(customDaemonRegistry())}")
+                    File(projectRoot, "gradle.properties").writeText("org.gradle.jvmargs=-Xmx128m")
 
                     // and:
                     val runner = GradleRunner.create()
@@ -179,7 +179,6 @@ class KotlinDslPluginTest : AbstractPluginTest() {
                         .withProjectDir(projectRoot)
                         .withPluginClasspath()
                         .forwardOutput()
-                    (runner as DefaultGradleRunner).withJvmArguments("-Xmx128m")
 
                     // when:
                     val result = runner.withArguments("help").build()

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptCachingIntegrationTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptCachingIntegrationTest.kt
@@ -15,7 +15,6 @@ import org.gradle.kotlin.dsl.support.KotlinPluginsBlock
 import org.gradle.kotlin.dsl.support.KotlinSettingsBuildscriptBlock
 
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
 import org.junit.ClassRule
 import org.junit.Test
@@ -241,9 +240,9 @@ class ScriptCachingIntegrationTest : AbstractIntegrationTest() {
 
     private
     fun buildWithDaemonHeapSize(heapMb: Int, vararg arguments: String): BuildResult =
-        gradleRunnerForCacheInspection(*arguments).run {
-            (this as DefaultGradleRunner).withJvmArguments("-Xms${heapMb}m", "-Xmx${heapMb}m", "-Dfile.encoding=UTF-8")
-        }.build()
+        withGradleJvmArguments("-Xms${heapMb}m", "-Xmx${heapMb}m", "-Dfile.encoding=UTF-8").run {
+            gradleRunnerForCacheInspection(*arguments).build()
+        }
 
     private
     fun gradleRunnerForCacheInspection(vararg arguments: String) =

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
@@ -23,11 +23,15 @@ fun copySampleProject(from: File, to: File) {
 
 private
 fun withMergedGradleProperties(gradlePropertiesFile: File, action: () -> Unit) =
-    loadPropertiesFrom(gradlePropertiesFile).also { baseProperties ->
-        gradlePropertiesFile.delete()
+    loadThenDeletePropertiesFrom(gradlePropertiesFile).also { baseProperties ->
         action()
-        loadPropertiesFrom(gradlePropertiesFile).also { sampleProperties ->
+        loadThenDeletePropertiesFrom(gradlePropertiesFile).also { sampleProperties ->
             baseProperties.putAll(sampleProperties)
             gradlePropertiesFile.outputStream().use { baseProperties.store(it, null) }
         }
     }
+
+
+private
+fun loadThenDeletePropertiesFrom(file: File) =
+    loadPropertiesFrom(file).also { file.delete() }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
@@ -1,9 +1,9 @@
 package org.gradle.kotlin.dsl.samples
 
+import org.gradle.kotlin.dsl.fixtures.loadPropertiesFrom
 import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 
 import java.io.File
-import java.util.Properties
 
 
 internal
@@ -31,8 +31,3 @@ fun withMergedGradleProperties(gradlePropertiesFile: File, action: () -> Unit) =
             gradlePropertiesFile.outputStream().use { baseProperties.store(it, null) }
         }
     }
-
-
-private
-fun loadPropertiesFrom(file: File) =
-    file.takeIf { it.isFile }?.inputStream()?.use { Properties().apply { load(it) } } ?: Properties()

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
@@ -25,7 +25,7 @@ private
 fun withMergedGradleProperties(gradlePropertiesFile: File, action: () -> Unit) =
     loadThenDeletePropertiesFrom(gradlePropertiesFile).also { baseProperties ->
         action()
-        loadThenDeletePropertiesFrom(gradlePropertiesFile).also { sampleProperties ->
+        loadPropertiesFrom(gradlePropertiesFile).also { sampleProperties ->
             baseProperties.putAll(sampleProperties)
             gradlePropertiesFile.outputStream().use { baseProperties.store(it, null) }
         }

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
@@ -1,6 +1,7 @@
 package org.gradle.kotlin.dsl.samples
 
 import org.gradle.kotlin.dsl.fixtures.loadPropertiesFrom
+import org.gradle.kotlin.dsl.fixtures.mergePropertiesInto
 import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 
 import java.io.File
@@ -22,14 +23,12 @@ fun copySampleProject(from: File, to: File) {
 
 
 private
-fun withMergedGradleProperties(gradlePropertiesFile: File, action: () -> Unit) =
-    loadThenDeletePropertiesFrom(gradlePropertiesFile).also { baseProperties ->
+fun withMergedGradleProperties(gradlePropertiesFile: File, action: () -> Unit) {
+    loadThenDeletePropertiesFrom(gradlePropertiesFile).let { baseProperties ->
         action()
-        loadPropertiesFrom(gradlePropertiesFile).also { sampleProperties ->
-            baseProperties.putAll(sampleProperties)
-            gradlePropertiesFile.outputStream().use { baseProperties.store(it, null) }
-        }
+        mergePropertiesInto(gradlePropertiesFile, baseProperties.map { it.toPair() })
     }
+}
 
 
 private

--- a/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/samples.kt
@@ -3,6 +3,7 @@ package org.gradle.kotlin.dsl.samples
 import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 
 import java.io.File
+import java.util.Properties
 
 
 internal
@@ -11,8 +12,27 @@ val samplesRootDir = File(rootProjectDir, "samples")
 
 internal
 fun copySampleProject(from: File, to: File) {
-    from.copyRecursively(to)
-    listOf(".gradle", "build").map { File(to, it) }.filter { it.exists() }.forEach {
-        it.deleteRecursively()
+    withMergedGradleProperties(to.resolve("gradle.properties")) {
+        from.copyRecursively(to)
+        listOf(".gradle", "build").map { File(to, it) }.filter { it.exists() }.forEach {
+            it.deleteRecursively()
+        }
     }
 }
+
+
+private
+fun withMergedGradleProperties(gradlePropertiesFile: File, action: () -> Unit) =
+    loadPropertiesFrom(gradlePropertiesFile).also { baseProperties ->
+        gradlePropertiesFile.delete()
+        action()
+        loadPropertiesFrom(gradlePropertiesFile).also { sampleProperties ->
+            baseProperties.putAll(sampleProperties)
+            gradlePropertiesFile.outputStream().use { baseProperties.store(it, null) }
+        }
+    }
+
+
+private
+fun loadPropertiesFrom(file: File) =
+    file.takeIf { it.isFile }?.inputStream()?.use { Properties().apply { load(it) } } ?: Properties()

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
@@ -161,8 +161,7 @@ open class AbstractIntegrationTest {
 
     private
     fun loadGradleProperties() =
-        gradlePropertiesFile.takeIf { it.isFile }?.inputStream()?.use { Properties().apply { load(it) } }
-            ?: Properties()
+        loadPropertiesFrom(gradlePropertiesFile)
 
     private
     val gradlePropertiesFile by lazy { existing("gradle.properties") }
@@ -232,3 +231,7 @@ fun setOrClearProperty(key: String, value: String?) {
         else -> System.setProperty(key, value)
     }
 }
+
+
+fun loadPropertiesFrom(file: File) =
+    file.takeIf { it.isFile }?.inputStream()?.use { Properties().apply { load(it) } } ?: Properties()

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
@@ -150,10 +150,7 @@ open class AbstractIntegrationTest {
 
     private
     fun withGradleProperties(vararg gradleProperties: Pair<String, String>) =
-        loadGradleProperties().let { properties ->
-            properties.putAll(gradleProperties)
-            storeGradleProperties(properties)
-        }
+        mergePropertiesInto(gradlePropertiesFile, gradleProperties.asIterable())
 
     private
     fun storeGradleProperties(properties: Properties) =
@@ -235,3 +232,11 @@ fun setOrClearProperty(key: String, value: String?) {
 
 fun loadPropertiesFrom(file: File) =
     file.takeIf { it.isFile }?.inputStream()?.use { Properties().apply { load(it) } } ?: Properties()
+
+
+fun mergePropertiesInto(propertiesFile: File, additionalProperties: Iterable<Pair<Any, Any>>) {
+    loadPropertiesFrom(propertiesFile).let { originalProperties ->
+        originalProperties.putAll(additionalProperties)
+        propertiesFile.outputStream().use { originalProperties.store(it, null) }
+    }
+}

--- a/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
+++ b/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractIntegrationTest.kt
@@ -6,17 +6,18 @@ import org.gradle.kotlin.dsl.support.zipTo
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.internal.DefaultGradleRunner
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.CoreMatchers.containsString
 
 import org.junit.Assert.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TestName
 
 import java.io.File
+import java.util.Properties
 
 
 internal
@@ -30,6 +31,10 @@ open class AbstractIntegrationTest {
 
     @JvmField
     @Rule val temporaryFolder = ForcefullyDeletedTemporaryFolder()
+
+    @Before
+    fun withDefaultGradleJvmArguments() =
+        withGradleJvmArguments("-Xms128m", "-Xmx512m", "-Dfile.encoding=UTF-8")
 
     protected
     val projectRoot: File
@@ -138,6 +143,29 @@ open class AbstractIntegrationTest {
     protected
     fun gradleRunnerForArguments(vararg arguments: String) =
         gradleRunnerFor(projectRoot, *arguments)
+
+    protected
+    fun withGradleJvmArguments(vararg jvmArguments: String) =
+        withGradleProperties("org.gradle.jvmargs" to jvmArguments.joinToString(" "))
+
+    private
+    fun withGradleProperties(vararg gradleProperties: Pair<String, String>) =
+        loadGradleProperties().let { properties ->
+            properties.putAll(gradleProperties)
+            storeGradleProperties(properties)
+        }
+
+    private
+    fun storeGradleProperties(properties: Properties) =
+        gradlePropertiesFile.outputStream().use { properties.store(it, null) }
+
+    private
+    fun loadGradleProperties() =
+        gradlePropertiesFile.takeIf { it.isFile }?.inputStream()?.use { Properties().apply { load(it) } }
+            ?: Properties()
+
+    private
+    val gradlePropertiesFile by lazy { existing("gradle.properties") }
 }
 
 
@@ -157,7 +185,6 @@ fun gradleRunnerFor(projectDir: File, vararg arguments: String): GradleRunner = 
     withDebug(false)
     if (isCI) withArguments(*arguments, "--stacktrace", "-Dkotlin-daemon.verbose=true")
     else withArguments(*arguments, "--stacktrace")
-    (this as DefaultGradleRunner).withJvmArguments("-Xms128m", "-Xmx512m", "-Dfile.encoding=UTF-8")
     return this
 }
 


### PR DESCRIPTION
We use the internal `DefaultGradleRunner` in order to set Gradle JVM arguments but they can be set using a gradle.properties file instead.

Triggered by https://github.com/gradle/gradle/issues/5075