### PR TITLE
Upgrade ktlint-gradle to 3.3.0 with relocatable check tasks

### DIFF
--- a/plugins-experiments/build.gradle.kts
+++ b/plugins-experiments/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 dependencies {
     compileOnly(gradleKotlinDsl())
 
-    implementation("gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.2.0")
+    implementation("gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.3.0")
     implementation(futureKotlin("stdlib-jdk8"))
 
     testImplementation(project(":test-fixtures"))

--- a/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -97,12 +97,6 @@ open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
         tasksBySourceSets.forEach { (sourceSet, task) ->
 
             sourceSet.allSource.sourceDirectories.forEach { srcDir ->
-                task.inputs.property(
-                    "kt files from $srcDir",
-                    files(srcDir).asFileTree.matching {
-                        it.include("**/*.kt")
-                    }
-                )
                 reporters.forEach {
                     task.outputs.file("$buildDir/${it.reportPathFor(sourceSet)}")
                 }


### PR DESCRIPTION
See #822 