### PR TITLE
Simplify kotlin-dsl-plugin-bundle plugin

### DIFF
--- a/buildSrc/src/main/kotlin/accessors/conventions.kt
+++ b/buildSrc/src/main/kotlin/accessors/conventions.kt
@@ -21,9 +21,12 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.BasePluginConvention
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.kotlin.dsl.configure
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 
+import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.the
+
+import com.gradle.publish.PluginBundleExtension
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
@@ -45,4 +48,14 @@ fun Project.publishing(action: PublishingExtension.() -> Unit) =
 
 internal
 fun Project.kotlin(action: KotlinProjectExtension.() -> Unit) =
+    configure(action)
+
+
+internal
+fun Project.gradlePlugin(action: GradlePluginDevelopmentExtension.() -> Unit) =
+    configure(action)
+
+
+internal
+fun Project.pluginBundle(action: PluginBundleExtension.() -> Unit) =
     configure(action)

--- a/buildSrc/src/main/kotlin/plugins/kotlin-dsl-plugin-bundle.gradle.kts
+++ b/buildSrc/src/main/kotlin/plugins/kotlin-dsl-plugin-bundle.gradle.kts
@@ -1,11 +1,9 @@
 import accessors.base
+import accessors.gradlePlugin
+import accessors.pluginBundle
 import accessors.publishing
 
 import plugins.futurePluginVersionsFile
-import plugins.KotlinDslPlugin
-
-import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
-import com.gradle.publish.PluginBundleExtension
 
 
 plugins {
@@ -23,38 +21,10 @@ pluginBundle {
 }
 
 
-val kotlinDslPlugins = container(KotlinDslPlugin::class.java)
-extensions.add("kotlinDslPlugins", kotlinDslPlugins)
-
-
 afterEvaluate {
 
     pluginBundle {
         mavenCoordinates.artifactId = base.archivesBaseName
-    }
-
-    kotlinDslPlugins.all {
-
-        val plugin = this
-
-        gradlePlugin {
-            plugins {
-                create(plugin.name) {
-                    id = plugin.id
-                    implementationClass = plugin.implementationClass
-                }
-            }
-        }
-
-        pluginBundle {
-            plugins {
-                create(plugin.name) {
-                    id = plugin.id
-                    displayName = plugin.displayName
-                    description = plugin.displayName
-                }
-            }
-        }
     }
 }
 
@@ -93,15 +63,17 @@ fun Project.workAroundTestKitWithPluginClassPathIssues() {
 
     afterEvaluate {
 
-        kotlinDslPlugins.all {
+        gradlePlugin {
+            plugins.all {
 
-            val plugin = this
+                val plugin = this
 
-            publishPluginsToTestRepository
-                .dependsOn("publish${plugin.name.capitalize()}PluginMarkerMavenPublicationToTestRepository")
+                publishPluginsToTestRepository
+                    .dependsOn("publish${plugin.name.capitalize()}PluginMarkerMavenPublicationToTestRepository")
 
-            writeFuturePluginVersions
-                .property(plugin.id, version)
+                writeFuturePluginVersions
+                    .property(plugin.id, version)
+            }
         }
     }
 }
@@ -114,11 +86,3 @@ fun Project.createWriteFuturePluginVersionsTask(): WriteProperties {
         processTestResources.dependsOn(this)
     }
 }
-
-
-fun Project.gradlePlugin(action: GradlePluginDevelopmentExtension.() -> Unit) =
-    configure(action)
-
-
-fun Project.pluginBundle(action: PluginBundleExtension.() -> Unit) =
-    configure(action)

--- a/buildSrc/src/main/kotlin/plugins/kotlin-dsl-plugin-bundle.kt
+++ b/buildSrc/src/main/kotlin/plugins/kotlin-dsl-plugin-bundle.kt
@@ -16,17 +16,33 @@
 
 package plugins
 
-import org.gradle.api.Named
+import accessors.gradlePlugin
+import accessors.pluginBundle
+
+import org.gradle.api.Project
 import org.gradle.language.jvm.tasks.ProcessResources
-
-
-class KotlinDslPlugin(private val name: String) : Named {
-    override fun getName() = name
-    lateinit var displayName: String
-    lateinit var id: String
-    lateinit var implementationClass: String
-}
 
 
 val ProcessResources.futurePluginVersionsFile
     get() = destinationDir.resolve("future-plugin-versions.properties")
+
+
+fun Project.bundledGradlePlugin(name: String, shortDescription: String, pluginId: String, pluginClass: String) {
+    gradlePlugin {
+        plugins {
+            create(name) {
+                id = pluginId
+                implementationClass = pluginClass
+            }
+        }
+    }
+    pluginBundle {
+        plugins {
+            create(name) {
+                id = pluginId
+                displayName = shortDescription
+                description = shortDescription
+            }
+        }
+    }
+}

--- a/plugins-experiments/build.gradle.kts
+++ b/plugins-experiments/build.gradle.kts
@@ -1,4 +1,5 @@
 import build.futureKotlin
+import plugins.bundledGradlePlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.internal.hash.Hashing
 
@@ -27,13 +28,11 @@ dependencies {
 
 // plugins ------------------------------------------------------------
 
-kotlinDslPlugins {
-    create("ktlintConvention") {
-        displayName = "Gradle Kotlin DSL ktlint convention plugin (experimental)"
-        id = "org.gradle.kotlin.ktlint-convention"
-        implementationClass = "org.gradle.kotlin.dsl.experiments.plugins.GradleKotlinDslKtlintConventionPlugin"
-    }
-}
+bundledGradlePlugin(
+    name = "ktlintConvention",
+    shortDescription = "Gradle Kotlin DSL ktlint convention plugin (experimental)",
+    pluginId = "org.gradle.kotlin.ktlint-convention",
+    pluginClass = "org.gradle.kotlin.dsl.experiments.plugins.GradleKotlinDslKtlintConventionPlugin")
 
 
 // default versions ---------------------------------------------------

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -1,4 +1,5 @@
 import build.futureKotlin
+import plugins.bundledGradlePlugin
 
 plugins {
     id("kotlin-dsl-plugin-bundle")
@@ -21,15 +22,14 @@ dependencies {
 
 // plugins ------------------------------------------------------------
 
-kotlinDslPlugins {
-    create("embeddedKotlin") {
-        displayName = "Embedded Kotlin Gradle Plugin"
-        id = "org.gradle.kotlin.embedded-kotlin"
-        implementationClass = "org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin"
-    }
-    create("kotlinDsl") {
-        displayName = "Gradle Kotlin DSL Plugin"
-        id = "org.gradle.kotlin.kotlin-dsl"
-        implementationClass = "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPlugin"
-    }
-}
+bundledGradlePlugin(
+    name = "embeddedKotlin",
+    shortDescription = "Embedded Kotlin Gradle Plugin",
+    pluginId = "org.gradle.kotlin.embedded-kotlin",
+    pluginClass = "org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin")
+
+bundledGradlePlugin(
+    name = "kotlinDsl",
+    shortDescription = "Gradle Kotlin DSL Plugin",
+    pluginId = "org.gradle.kotlin.kotlin-dsl",
+    pluginClass = "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPlugin")


### PR DESCRIPTION
by using a simple function to configure gradlePlugin and pluginBundle
extensions, alleviating ordering problems caused by upstream publishing
configuration changes in java-gradle-plugin plugin after making
publishing {} not a @DeferredConfigurable anymore.
