### PR TITLE
Add init script to be used on CI to enable build scans

### DIFF
--- a/gradle/init-scripts/build-scan.init.gradle.kts
+++ b/gradle/init-scripts/build-scan.init.gradle.kts
@@ -1,0 +1,13 @@
+/*
+ * This is an init script for internal usage at Gradle Inc.
+ */
+if (!gradle.startParameter.systemPropertiesArgs.containsKey("disableScanPlugin")) {
+    rootProject {
+        pluginManager.withPlugin("com.gradle.build-scan") {
+            extensions["buildScan"].withGroovyBuilder {
+                "publishAlways"()
+                setProperty("server", "https://e.grdev.net")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Once merged, add `-I gradle/init-scripts/build-scan.init.gradle.kts --scan` to CI jobs