### PR TITLE
Let the `kotlin-dsl` plugin add gradleKotlinDSl() to testImplementation

### DIFF
--- a/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
@@ -26,7 +26,7 @@ import org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
  * The `kotlin-dsl` plugin.
  *
  * - Applies the `embedded-kotlin` plugin
- * - Adds the `gradleKotlinDsl()` dependency to the `compileOnly` and `testRuntimeOnly` configurations
+ * - Adds the `gradleKotlinDsl()` dependency to the `compileOnly` and `testImplementation` configurations
  * - Configures the Kotlin DSL compiler plugins
  *
  * @see org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
@@ -38,7 +38,7 @@ open class KotlinDslPlugin : Plugin<Project> {
 
             applyEmbeddedKotlinPlugin()
             applyKotlinDslCompilerPlugins()
-            addGradleKotlinDslDependencyTo("compileOnly", "testRuntimeOnly")
+            addGradleKotlinDslDependencyTo("compileOnly", "testImplementation")
         }
     }
 

--- a/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -44,7 +44,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
     }
 
     @Test
-    fun `gradle kotlin dsl api is available at test runtime`() {
+    fun `gradle kotlin dsl api is available for test implementation`() {
         withBuildScript("""
 
             plugins {
@@ -81,16 +81,17 @@ class KotlinDslPluginTest : AbstractPluginTest() {
 
             import org.gradle.testfixtures.ProjectBuilder
             import org.junit.Test
+            import org.gradle.kotlin.dsl.*
 
             class MyTest {
 
                 @Test
                 fun `my test`() {
-                    val project = ProjectBuilder.builder().build()
-                    project.plugins.apply(MyPlugin::class.java)
+                    ProjectBuilder.builder().build().run {
+                        apply<MyPlugin>()
+                    }
                 }
             }
-
         """)
 
         assertThat(


### PR DESCRIPTION
instead of `testRuntime` in order for the Kotlin DSL api to be available for tests implemented using `ProjectBuilder`, mocks etc...