### PR TITLE
Detect internal Kotlin types and mark them inaccessible

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -382,7 +382,7 @@ class ClassDataFromKotlinMetadataAnnotationVisitor(
     var d1 = mutableListOf<String>()
 
     /**
-     * @see kotlin.Metadata.d1
+     * @see kotlin.Metadata.d2
      */
     private
     var d2 = mutableListOf<String>()

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -387,25 +387,26 @@ class ClassDataFromKotlinMetadataAnnotationVisitor(
     private
     var d2 = mutableListOf<String>()
 
-    override fun visitArray(name: String?): AnnotationVisitor =
+    override fun visitArray(name: String?): AnnotationVisitor? =
         when (name) {
-            "d1" -> object : AnnotationVisitor(ASM6) {
-                override fun visit(name: String?, value: Any?) {
-                    (value as? String)?.let(d1::add)
-                }
-            }
-            "d2" -> object : AnnotationVisitor(ASM6) {
-                override fun visit(name: String?, value: Any?) {
-                    (value as? String)?.let(d2::add)
-                }
-            }
-            else -> super.visitArray(name)
+            "d1" -> AnnotationValueCollector(d1)
+            "d2" -> AnnotationValueCollector(d2)
+            else -> null
         }
 
     override fun visitEnd() {
         val (_, classData) = JvmProtoBufUtil.readClassDataFrom(d1.toTypedArray(), d2.toTypedArray())
         onClassData(classData)
         super.visitEnd()
+    }
+}
+
+
+private
+class AnnotationValueCollector<T>(val output: MutableList<T>) : AnnotationVisitor(ASM6) {
+    override fun visit(name: String?, value: Any?) {
+        @Suppress("unchecked_cast")
+        output.add(value as T)
     }
 }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -33,8 +33,14 @@ import org.gradle.kotlin.dsl.support.compileToJar
 import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.serviceOf
 
+import org.jetbrains.kotlin.metadata.ProtoBuf
+import org.jetbrains.kotlin.metadata.ProtoBuf.Visibility
+import org.jetbrains.kotlin.metadata.deserialization.Flags
+import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
+
 import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
 
+import org.jetbrains.org.objectweb.asm.AnnotationVisitor
 import org.jetbrains.org.objectweb.asm.ClassReader
 import org.jetbrains.org.objectweb.asm.ClassVisitor
 import org.jetbrains.org.objectweb.asm.Opcodes.ACC_PUBLIC
@@ -212,19 +218,37 @@ class TypeAccessibilityProvider(classPath: ClassPath) : Closeable {
     private
     fun loadAccessibilityInfoFor(className: String): TypeAccessibilityInfo {
         val classBytes = classBytesFor(className) ?: return TypeAccessibilityInfo(listOf(nonAvailable(className)))
-        val visitor = HasTypeParameterClassVisitor()
         val classReader = ClassReader(classBytes)
         val access = classReader.access
-        classReader.accept(visitor, 0)
         return TypeAccessibilityInfo(
-            listOfNotNull(when {
-                ACC_PUBLIC !in access -> nonPublic(className)
-                ACC_SYNTHETIC in access -> synthetic(className)
-                else -> null
-            }),
-            visitor.hasTypeParameters
+            listOfNotNull(
+                when {
+                    ACC_PUBLIC !in access -> nonPublic(className)
+                    ACC_SYNTHETIC in access -> synthetic(className)
+                    isNonPublicKotlinType(classReader) -> nonPublic(className)
+                    else -> null
+                }),
+            hasTypeParameters(classReader)
         )
     }
+
+    private
+    fun isNonPublicKotlinType(classReader: ClassReader) =
+        kotlinVisibilityFor(classReader)?.let { it != Visibility.PUBLIC } ?: false
+
+    private
+    fun kotlinVisibilityFor(classReader: ClassReader) =
+        classReader(KotlinVisibilityClassVisitor()).visibility
+
+    private
+    fun hasTypeParameters(classReader: ClassReader): Boolean =
+        classReader(HasTypeParameterClassVisitor()).hasTypeParameters
+
+    private
+    operator fun <T : ClassVisitor> ClassReader.invoke(visitor: T): T =
+        visitor.also {
+            accept(it, ClassReader.SKIP_CODE + ClassReader.SKIP_DEBUG + ClassReader.SKIP_FRAMES)
+        }
 
     private
     fun classBytesFor(className: String): ByteArray? {
@@ -313,7 +337,9 @@ fun classNamesFromTypeString(typeString: String): ClassNamesFromTypeString {
 
 private
 class HasTypeParameterClassVisitor : ClassVisitor(ASM6) {
+
     var hasTypeParameters = false
+
     override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<out String>?) {
         if (signature != null) {
             SignatureReader(signature).accept(object : SignatureVisitor(ASM6) {
@@ -322,6 +348,64 @@ class HasTypeParameterClassVisitor : ClassVisitor(ASM6) {
                 }
             })
         }
+    }
+}
+
+
+private
+class KotlinVisibilityClassVisitor : ClassVisitor(ASM6) {
+
+    var visibility: Visibility? = null
+
+    override fun visitAnnotation(desc: String?, visible: Boolean): AnnotationVisitor? =
+        when (desc) {
+            "Lkotlin/Metadata;" -> ClassDataFromKotlinMetadataAnnotationVisitor { classData ->
+                visibility = Flags.VISIBILITY[classData.flags]
+            }
+            else -> null
+        }
+}
+
+
+/**
+ * Reads the serialized [ProtoBuf.Class] information stored in the visited [kotlin.Metadata] annotation.
+ */
+private
+class ClassDataFromKotlinMetadataAnnotationVisitor(
+    private val onClassData: (ProtoBuf.Class) -> Unit
+) : AnnotationVisitor(ASM6) {
+
+    /**
+     * @see kotlin.Metadata.d1
+     */
+    private
+    var d1 = mutableListOf<String>()
+
+    /**
+     * @see kotlin.Metadata.d1
+     */
+    private
+    var d2 = mutableListOf<String>()
+
+    override fun visitArray(name: String?): AnnotationVisitor =
+        when (name) {
+            "d1" -> object : AnnotationVisitor(ASM6) {
+                override fun visit(name: String?, value: Any?) {
+                    (value as? String)?.let(d1::add)
+                }
+            }
+            "d2" -> object : AnnotationVisitor(ASM6) {
+                override fun visit(name: String?, value: Any?) {
+                    (value as? String)?.let(d2::add)
+                }
+            }
+            else -> super.visitArray(name)
+        }
+
+    override fun visitEnd() {
+        val (_, classData) = JvmProtoBufUtil.readClassDataFrom(d1.toTypedArray(), d2.toTypedArray())
+        onClassData(classData)
+        super.visitEnd()
     }
 }
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
@@ -11,6 +11,10 @@ import org.junit.Assert.*
 import org.junit.Test
 
 
+internal
+interface InternalType
+
+
 class TypeAccessibilityProviderTest : TestWithClassPath() {
 
     @Test
@@ -20,8 +24,19 @@ class TypeAccessibilityProviderTest : TestWithClassPath() {
         assertThat(
             accessibilityFor(
                 genericTypeWithPrimitiveComponent,
-                jarClassPathWith(PublicGenericType::class)),
+                classPath = jarClassPathWith(PublicGenericType::class)),
             equalTo(accessible(genericTypeWithPrimitiveComponent)))
+    }
+
+    @Test
+    fun `internal Kotlin type is inaccessible because NonPublic`() {
+
+        val internalType = kotlinTypeStringFor(typeOf<InternalType>())
+        assertThat(
+            accessibilityFor(
+                internalType,
+                classPath = jarClassPathWith(InternalType::class)),
+            equalTo(inaccessible(internalType, InaccessibilityReason.NonPublic(internalType))))
     }
 
     @Test


### PR DESCRIPTION
By deserializing the Kotlin `ProtoBuf.Class` information stored in the `kotlin.Metadata` annotation. This is done only for public classes for performance reasons.

Fixes #856