### PR TITLE
Add known public types mapping to accessors generation

### DIFF
--- a/provider-spi/src/main/kotlin/org/gradle/kotlin/dsl/provider/spi/KotlinTypeStrings.kt
+++ b/provider-spi/src/main/kotlin/org/gradle/kotlin/dsl/provider/spi/KotlinTypeStrings.kt
@@ -28,7 +28,7 @@ fun kotlinTypeStringFor(type: TypeOf<*>): String = type.run {
         isWildcard ->
             upperBound?.let(::kotlinTypeStringFor) ?: "Any"
         else ->
-            toString().let { primitiveTypeStrings[it] ?: it }
+            toString().let { knownPublicTypes[it] ?: primitiveTypeStrings[it] ?: it }
     }
 }
 
@@ -57,3 +57,8 @@ val primitiveTypeStrings =
 
 
 val primitiveKotlinTypeNames = primitiveTypeStrings.values.toHashSet()
+
+
+private
+val knownPublicTypes = mapOf(
+    "org.jetbrains.kotlin.gradle.internal.KotlinSourceSetImpl" to "org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet")

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/GenerateProjectSchemaTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/GenerateProjectSchemaTest.kt
@@ -180,5 +180,5 @@ val kotlinDslProjectSchema: ProjectSchema<String> =
         conventions = javaProjectSchema.conventions + listOf(
             ProjectSchemaEntry(
                 "org.gradle.api.tasks.SourceSet",
-                "kotlin", "org.jetbrains.kotlin.gradle.internal.KotlinSourceSetImpl")),
+                "kotlin", "org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet")),
         configurations = (javaProjectSchema.configurations + listOf("embeddedKotlin", "kapt", "kaptTest")).sorted())


### PR DESCRIPTION
until HasPublicType is implemented upstream,
with only KotlinSourceSet for now.

This is a follow up to #343 
