### PR TITLE
Optimise compilation classpath computation

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinBuildScriptCompiler.kt
@@ -93,7 +93,7 @@ class KotlinBuildScriptCompiler(
 
     private
     val compilationClassPath: ClassPath by lazy {
-        buildscriptBlockCompilationClassPath + classPathProvider.compilationClassPathOf(targetScope)
+        classPathProvider.compilationClassPathOf(targetScope)
     }
 
     private

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -116,8 +116,8 @@ class KotlinScriptClassPathProvider(
         require(scope.isLocked) {
             "$scope must be locked before it can be used to compute a classpath!"
         }
-        val rootClassPath = cachedClassLoaderClassPath.of(scope.root.exportClassLoader)
         val fullClassPath = cachedClassLoaderClassPath.of(scope.exportClassLoader)
+        val rootClassPath = cachedClassLoaderClassPath.of(scope.root.exportClassLoader)
         return fullClassPath - rootClassPath
     }
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -198,10 +198,12 @@ class ClassLoaderClassPathCache {
     val cachedClassPaths = hashMapOf<ClassLoader, ClassPath>()
 
     fun of(classLoader: ClassLoader): ClassPath =
-        cachedClassPaths.computeIfAbsent(classLoader, ::computeClassPath)
+        cachedClassPaths.getOrPut(classLoader) {
+            classPathOf(classLoader)
+        }
 
     private
-    fun computeClassPath(classLoader: ClassLoader): ClassPath {
+    fun classPathOf(classLoader: ClassLoader): ClassPath {
         val classPathFiles = mutableListOf<File>()
 
         object : ClassLoaderVisitor() {

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -208,10 +208,11 @@ class ClassLoaderClassPathCache {
 
         object : ClassLoaderVisitor() {
             override fun visitClassPath(classPath: Array<URL>) {
-                classPath
-                    .filter { it.protocol == "file" }
-                    .map { File(toURI(it)) }
-                    .let(classPathFiles::addAll)
+                classPath.forEach { url ->
+                    if (url.protocol == "file") {
+                        classPathFiles.add(fileFrom(url))
+                    }
+                }
             }
 
             override fun visitParent(classLoader: ClassLoader) {
@@ -221,6 +222,9 @@ class ClassLoaderClassPathCache {
 
         return DefaultClassPath.of(classPathFiles)
     }
+
+    private
+    fun fileFrom(url: URL) = File(toURI(url))
 }
 
 


### PR DESCRIPTION
- By caching the complete compilation `ClassPath` per `ClassLoaderScope`
- And by caching each individual `ClassLoader` `ClassPath`

The caches are part of a build scoped service and so all `ClassLoaderScope` and `ClassLoader` instances will be held until the end of the build.