### PR TITLE
Refine [Named|Polymorphic]DomainObject[Collection|Container] extensions

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
@@ -21,7 +21,9 @@ import org.gradle.api.UnknownDomainObjectException
 
 import org.gradle.kotlin.dsl.support.illegalElementType
 
+import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlin.reflect.full.safeCast
 
 
 /**
@@ -40,6 +42,25 @@ inline fun <reified T : Any> NamedDomainObjectCollection<out Any>.getByName(name
     getByName(name).let {
         it as? T
             ?: throw illegalElementType(this, name, T::class, it::class)
+    }
+
+
+/**
+ * Locates an object by name and casts it to the expected [type].
+ *
+ * If an object with the given [name] is not found, [UnknownDomainObjectException] is thrown.
+ * If the object is found but cannot be cast to the expected [type], [IllegalArgumentException] is thrown.
+ *
+ * @param name object name
+ * @param type expected type
+ * @return the object, never null
+ * @throws [UnknownDomainObjectException] When the given object is not found.
+ * @throws [IllegalArgumentException] When the given object cannot be cast to the expected type.
+ */
+fun <T : Any> NamedDomainObjectCollection<out Any>.getByName(name: String, type: KClass<T>): T =
+    getByName(name).let {
+        type.safeCast(it)
+            ?: throw illegalElementType(this, name, type, it::class)
     }
 
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
@@ -39,8 +39,7 @@ import kotlin.reflect.KProperty
 inline fun <reified T : Any> NamedDomainObjectCollection<out Any>.getByName(name: String) =
     getByName(name).let {
         it as? T
-            ?: throw IllegalArgumentException(
-                "Element '$name' of type '${it::class.java.name}' cannot be cast to '${T::class.qualifiedName}'.")
+            ?: throw illegalElementType(this, name, T::class, it::class)
     }
 
 

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensions.kt
@@ -25,6 +25,42 @@ import kotlin.reflect.KProperty
 
 
 /**
+ * Locates an object by name and casts it to the expected type [T].
+ *
+ * If an object with the given [name] is not found, [UnknownDomainObjectException] is thrown.
+ * If the object is found but cannot be cast to the expected type [T], [IllegalArgumentException] is thrown.
+ *
+ * @param name object name
+ * @return the object, never null
+ * @throws [UnknownDomainObjectException] When the given object is not found.
+ * @throws [IllegalArgumentException] When the given object cannot be cast to the expected type.
+ */
+@Suppress("extension_shadowed_by_member")
+inline fun <reified T : Any> NamedDomainObjectCollection<out Any>.getByName(name: String) =
+    getByName(name).let {
+        it as? T
+            ?: throw IllegalArgumentException(
+                "Element '$name' of type '${it::class.java.name}' cannot be cast to '${T::class.qualifiedName}'.")
+    }
+
+
+/**
+ * Locates an object by name and casts it to the expected type [T] then configures it.
+ *
+ * If an object with the given [name] is not found, [UnknownDomainObjectException] is thrown.
+ * If the object is found but cannot be cast to the expected type [T], [IllegalArgumentException] is thrown.
+ *
+ * @param name object name
+ * @param configure configuration action to apply to the object before returning it
+ * @return the object, never null
+ * @throws [UnknownDomainObjectException] When the given object is not found.
+ * @throws [IllegalArgumentException] When the given object cannot be cast to the expected type.
+ */
+inline fun <reified T : Any> NamedDomainObjectCollection<out Any>.getByName(name: String, configure: T.() -> Unit) =
+    getByName<T>(name).also(configure)
+
+
+/**
  * Idiomatic way of referring to an existing element in a collection
  * via a delegate property.
  *

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -175,14 +175,14 @@ class PolymorphicDomainObjectContainerDelegateProvider<T : Any, U : T>(
 /**
  * Provides a property delegate that gets elements of the given [type] and applies the given [configuration].
  */
-fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getting(type: KClass<U>, configuration: U.() -> Unit) =
+fun <T : Any, U : T> NamedDomainObjectContainer<T>.getting(type: KClass<U>, configuration: U.() -> Unit) =
     PolymorphicDomainObjectContainerGettingDelegateProvider(this, type, configuration)
 
 
 /**
  * Provides a property delegate that gets elements of the given [type].
  */
-fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getting(type: KClass<U>) =
+fun <T : Any, U : T> NamedDomainObjectContainer<T>.getting(type: KClass<U>) =
     PolymorphicDomainObjectContainerGettingDelegate(this, type)
 
 
@@ -190,7 +190,7 @@ fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getting(type: KClass<U>
  * A property delegate that gets elements of the given [type] in the given [container].
  */
 class PolymorphicDomainObjectContainerGettingDelegate<T : Any, U : T>(
-    val container: PolymorphicDomainObjectContainer<T>,
+    val container: NamedDomainObjectContainer<T>,
     val type: KClass<U>
 ) {
 
@@ -204,7 +204,7 @@ class PolymorphicDomainObjectContainerGettingDelegate<T : Any, U : T>(
  * and applies the given [configuration].
  */
 class PolymorphicDomainObjectContainerGettingDelegateProvider<T : Any, U : T>(
-    val container: PolymorphicDomainObjectContainer<T>,
+    val container: NamedDomainObjectContainer<T>,
     val type: KClass<U>,
     val configuration: U.() -> Unit
 ) {
@@ -213,12 +213,12 @@ class PolymorphicDomainObjectContainerGettingDelegateProvider<T : Any, U : T>(
     operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) =
         container.apply {
             getByName(property.name, type).configuration()
-        } as PolymorphicDomainObjectContainer<U>
+        } as NamedDomainObjectContainer<U>
 }
 
 
 private
-fun <T : Any, U : T> PolymorphicDomainObjectContainer<T>.getByName(name: String, type: KClass<U>): U =
+fun <T : Any, U : T> NamedDomainObjectContainer<T>.getByName(name: String, type: KClass<U>): U =
     getByName(name).let {
         type.safeCast(it)
             ?: throw illegalElementType(this, name, type, it::class)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -20,11 +20,8 @@ import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.PolymorphicDomainObjectContainer
 
-import org.gradle.kotlin.dsl.support.illegalElementType
-
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
-import kotlin.reflect.full.safeCast
 
 
 /**
@@ -215,11 +212,3 @@ class PolymorphicDomainObjectContainerGettingDelegateProvider<T : Any, U : T>(
             getByName(property.name, type).configuration()
         } as NamedDomainObjectContainer<U>
 }
-
-
-private
-fun <T : Any, U : T> NamedDomainObjectContainer<T>.getByName(name: String, type: KClass<U>): U =
-    getByName(name).let {
-        type.safeCast(it)
-            ?: throw illegalElementType(this, name, type, it::class)
-    }

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/PolymorphicDomainObjectContainerExtensions.kt
@@ -53,3 +53,19 @@ inline fun <reified U : Any> PolymorphicDomainObjectContainer<in U>.create(
 @Suppress("extension_shadowed_by_member")
 inline fun <reified U : Any> PolymorphicDomainObjectContainer<in U>.create(name: String) =
     create(name, U::class.java)
+
+
+/**
+ * Creates a domain object with the specified name and type if it does not exists, and adds it to the container.
+ *
+ * @param name the name of the domain object to be created
+ * @param <U> the type of the domain object to be created
+ * @return the created domain object
+ * @throws [InvalidUserDataException] if a domain object with the specified name already
+ * exists or the container does not support creating a domain object with the specified
+ * type
+ * @throws [ClassCastException] if a domain object with the specified name exists with a different type
+ */
+@Suppress("extension_shadowed_by_member")
+inline fun <reified U : Any> PolymorphicDomainObjectContainer<in U>.maybeCreate(name: String) =
+    maybeCreate(name, U::class.java)

--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Exceptions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/Exceptions.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.KClass
 
 
 fun illegalElementType(container: NamedDomainObjectCollection<*>, name: String, expectedType: KClass<*>, actualType: KClass<*>) =
-    IllegalStateException(
+    IllegalArgumentException(
         "Element '$name' of type '${actualType.java.name}' from container '$container' cannot be cast to '${expectedType.qualifiedName}'.")
 
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -253,7 +253,7 @@ class NamedDomainObjectCollectionExtensionsTest {
         }
         val domainObject: DomainObject by container
 
-        val error = assertFailsWith(IllegalStateException::class) {
+        val error = assertFailsWith(IllegalArgumentException::class) {
             println(domainObject)
         }
         assertThat(

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -163,7 +163,7 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can access existing element by getting with type`() {
 
         val element = DomainObject()
-        val container = mock<PolymorphicDomainObjectContainer<Any>> {
+        val container = mock<NamedDomainObjectContainer<Any>> {
             on { getByName("domainObject") } doReturn element
         }
 
@@ -182,7 +182,7 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can configure existing typed element by getting`() {
 
         val element = DomainObject()
-        val container = mock<PolymorphicDomainObjectContainer<Any>> {
+        val container = mock<NamedDomainObjectContainer<Any>> {
             on { getByName("domainObject") } doReturn element
         }
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -144,7 +144,7 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can access existing typed element by getting`() {
 
         val element = DomainObject()
-        val container = mock<PolymorphicDomainObjectContainer<Any>> {
+        val container = mock<NamedDomainObjectContainer<Any>> {
             on { getByName("domainObject") } doReturn element
         }
 

--- a/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -74,6 +74,73 @@ class NamedDomainObjectCollectionExtensionsTest {
     }
 
     @Test
+    fun `can configure existing element by getting`() {
+
+        val element = DomainObject()
+        val container = mock<NamedDomainObjectContainer<DomainObject>> {
+            on { getByName("domainObject") } doReturn element
+        }
+
+        container { // invoke syntax
+            @Suppress("unused_variable")
+            val domainObject by getting { foo = "foo" }
+            assertThat(element.foo, equalTo("foo"))
+        }
+
+        container.apply { // regular syntax
+            @Suppress("unused_variable")
+            val domainObject by getting { foo = "bar" }
+            assertThat(element.foo, equalTo("bar"))
+        }
+    }
+
+    @Test
+    fun `can add element by creating`() {
+
+        val fooObject = DomainObject()
+        val barObject = DomainObject()
+        val container = mock<NamedDomainObjectContainer<DomainObject>> {
+            on { create("foo") } doReturn fooObject
+            on { getByName("foo") } doReturn fooObject
+            on { create("bar") } doReturn barObject
+            on { getByName("bar") } doReturn barObject
+        }
+
+        container { // invoke syntax
+            val foo by creating
+            assertThat(foo.foo, nullValue())
+        }
+
+        container.apply { // regular syntax
+            val bar by creating
+            assertThat(bar.foo, nullValue())
+        }
+    }
+
+    @Test
+    fun `can add and configure element by creating`() {
+
+        val fooObject = DomainObject()
+        val barObject = DomainObject()
+        val container = mock<NamedDomainObjectContainer<DomainObject>> {
+            on { create("foo") } doReturn fooObject
+            on { getByName("foo") } doReturn fooObject
+            on { create("bar") } doReturn barObject
+            on { getByName("bar") } doReturn barObject
+        }
+
+        container { // invoke syntax
+            val foo by creating { foo = "foo" }
+            assertThat(foo.foo, equalTo("foo"))
+        }
+
+        container.apply { // regular syntax
+            val bar by creating { foo = "bar" }
+            assertThat(bar.foo, equalTo("bar"))
+        }
+    }
+
+    @Test
     fun `can access existing typed element by getting`() {
 
         val element = DomainObject()
@@ -112,27 +179,6 @@ class NamedDomainObjectCollectionExtensionsTest {
     }
 
     @Test
-    fun `can configure existing element by getting`() {
-
-        val element = DomainObject()
-        val container = mock<NamedDomainObjectContainer<DomainObject>> {
-            on { getByName("domainObject") } doReturn element
-        }
-
-        container { // invoke syntax
-            @Suppress("unused_variable")
-            val domainObject by getting { foo = "foo" }
-            assertThat(element.foo, equalTo("foo"))
-        }
-
-        container.apply { // regular syntax
-            @Suppress("unused_variable")
-            val domainObject by getting { foo = "bar" }
-            assertThat(element.foo, equalTo("bar"))
-        }
-    }
-
-    @Test
     fun `can configure existing typed element by getting`() {
 
         val element = DomainObject()
@@ -150,6 +196,52 @@ class NamedDomainObjectCollectionExtensionsTest {
             @Suppress("unused_variable")
             val domainObject by getting(DomainObject::class) { foo = "bar" }
             assertThat(element.foo, equalTo("bar"))
+        }
+    }
+
+    @Test
+    fun `can add typed element by creating`() {
+
+        val fooObject = DomainObject()
+        val barObject = DomainObject()
+        val container = mock<PolymorphicDomainObjectContainer<Any>> {
+            on { create("foo", DomainObject::class.java) } doReturn fooObject
+            on { getByName("foo") } doReturn fooObject
+            on { create("bar", DomainObject::class.java) } doReturn barObject
+            on { getByName("bar") } doReturn barObject
+        }
+
+        container { // invoke syntax
+            val foo by creating(DomainObject::class)
+            assertThat(foo.foo, nullValue())
+        }
+
+        container.apply { // regular syntax
+            val bar by creating(DomainObject::class)
+            assertThat(bar.foo, nullValue())
+        }
+    }
+
+    @Test
+    fun `can add and configure typed element by creating`() {
+
+        val fooObject = DomainObject()
+        val barObject = DomainObject()
+        val container = mock<PolymorphicDomainObjectContainer<Any>> {
+            on { create("foo", DomainObject::class.java) } doReturn fooObject
+            on { getByName("foo") } doReturn fooObject
+            on { create("bar", DomainObject::class.java) } doReturn barObject
+            on { getByName("bar") } doReturn barObject
+        }
+
+        container { // invoke syntax
+            val foo by creating(DomainObject::class) { foo = "foo" }
+            assertThat(foo.foo, equalTo("foo"))
+        }
+
+        container.apply { // regular syntax
+            val bar by creating(DomainObject::class) { foo = "bar" }
+            assertThat(bar.foo, equalTo("bar"))
         }
     }
 


### PR DESCRIPTION
by making their whole API available with the invoke syntax
and adding reified getByName<T>(name) {} to NamedDomainObjectCollection
and adding reified maybeCreate<T>(name) to PolymorphicDomainObjectContainer
adding more coverage along the way

See #804 and #867
