### PR TITLE
Generate versions manifest properties file

### DIFF
--- a/provider/build.gradle.kts
+++ b/provider/build.gradle.kts
@@ -52,6 +52,16 @@ val clean: Delete by tasks
 clean.delete(apiExtensionsOutputDir)
 
 
+// -- Version manifest properties --------------------------------------
+val versionsManifestOutputDir = file("$buildDir/versionsManifest")
+val writeVersionsManifest by tasks.creating(WriteProperties::class) {
+    outputFile = versionsManifestOutputDir.resolve("gradle-kotlin-dsl-versions.properties")
+    property("provider", version)
+    property("kotlin", kotlinVersion)
+}
+java.sourceSets["main"].output.dir(mapOf("builtBy" to writeVersionsManifest), versionsManifestOutputDir)
+
+
 // -- Testing ----------------------------------------------------------
 val prepareIntegrationTestFixtures by rootProject.tasks
 val customInstallation by rootProject.tasks


### PR DESCRIPTION
For the Gradle launcher to display the Gradle Kotlin DSL provider and Kotlin versions.
This PR is the first part of #481, the [second part](https://github.com/gradle/gradle/compare/eskatos/launcher/kotlin-dsl-version) will take place in `gradle/gradle` once this is merged.

```
user@host$ ./gradlew --version
------------------------------------------------------------
Gradle 4.9-20180515103222+0000
------------------------------------------------------------

Build time:   2018-05-15 10:32:22 UTC
Revision:     51a4c83e862480fb69625cc2100b487d7c2971d0

Kotlin DSL:   0.17.4
Kotlin:       1.2.41
Groovy:       2.4.12
Ant:          Apache Ant(TM) version 1.9.11 compiled on March 23 2018
JVM:          1.8.0_161 (Oracle Corporation 25.161-b12)
OS:           Mac OS X 10.13.4 x86_64
```
