### PR TITLE
Let script source dependencies order be stable

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourcePathProvider.kt
@@ -73,5 +73,5 @@ object SourcePathProvider {
 
 internal
 fun subDirsOf(dir: File): Collection<File> =
-    if (dir.isDirectory) dir.listFiles().filter { it.isDirectory }
+    if (dir.isDirectory) dir.listFiles().filter { it.isDirectory }.sortedBy { it.name }
     else emptyList()

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinLibSources.kt
@@ -109,7 +109,8 @@ fun resolveSourcesUsing(dependencyHandler: DependencyHandler, query: ArtifactRes
             .resolvedComponents
             .flatMap { it.getArtifacts(SourcesArtifact::class.java) }
             .filterIsInstance<ResolvedArtifactResult>()
-            .map { it.file })
+            .map { it.file }
+            .sorted()) // TODO remove sorting once https://github.com/gradle/gradle/issues/5507 is fixed
 
 
 private


### PR DESCRIPTION
See https://github.com/gradle/kotlin-dsl/issues/891