### PR TITLE
Upgrade ktlint-gradle to 4.0.0 and ktlint to 0.23.1 in :plugins-experiments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,8 @@ project(":plugins") {
     version = futurePluginsVersion
 }
 
-val publishedPluginsExperimentsVersion by extra { "0.1.7" }
-val futurePluginsExperimentsVersion = "0.1.8"
+val publishedPluginsExperimentsVersion by extra { "0.1.8" }
+val futurePluginsExperimentsVersion = "0.1.9"
 project(":plugins-experiments") {
     group = "org.gradle.kotlin"
     version = futurePluginsExperimentsVersion

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
 
     val kotlinVersion = file("../kotlin-version.txt").readText().trim()
 
-    val pluginsExperiments = "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins-experiments:0.1.7"
+    val pluginsExperiments = "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins-experiments:0.1.8"
 
     dependencies {
         classpath(kotlin("gradle-plugin", version = kotlinVersion))

--- a/buildSrc/src/main/kotlin/plugins/public-kotlin-dsl-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/plugins/public-kotlin-dsl-module.gradle.kts
@@ -75,4 +75,3 @@ fun buildTagFor(version: String): String =
         "SNAPSHOT" -> "snapshot"
         else -> "release"
     }
-

--- a/subprojects/plugins-experiments/plugins-experiments.gradle.kts
+++ b/subprojects/plugins-experiments/plugins-experiments.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     compileOnly(gradleKotlinDsl())
 
-    implementation("gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.3.0")
+    implementation("gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:4.0.0")
     implementation(futureKotlin("stdlib-jdk8"))
 
     testImplementation(project(":test-fixtures"))

--- a/subprojects/plugins-experiments/plugins-experiments.gradle.kts
+++ b/subprojects/plugins-experiments/plugins-experiments.gradle.kts
@@ -37,7 +37,7 @@ bundledGradlePlugin(
 
 // default versions ---------------------------------------------------
 
-val ktlintVersion = "0.22.0"
+val ktlintVersion = "0.23.1"
 
 val basePackagePath = "org/gradle/kotlin/dsl/experiments/plugins"
 val processResources: ProcessResources by tasks

--- a/subprojects/plugins-experiments/plugins-experiments.gradle.kts
+++ b/subprojects/plugins-experiments/plugins-experiments.gradle.kts
@@ -5,7 +5,7 @@ import org.gradle.internal.hash.Hashing
 
 plugins {
     id("kotlin-dsl-plugin-bundle")
-    id("com.github.johnrengelman.shadow") version "2.0.2" apply false
+    id("com.github.johnrengelman.shadow") version "2.0.3" apply false
 }
 
 base {

--- a/subprojects/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/subprojects/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -2,15 +2,8 @@ package org.gradle.kotlin.dsl.experiments.plugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.execution.TaskExecutionListener
-import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.tasks.JavaExec
-import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.TaskState
 
 import org.gradle.cache.internal.GeneratedGradleJarCache
-import org.gradle.internal.logging.ConsoleRenderer
 
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
@@ -35,7 +28,7 @@ open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
 
-        plugins.apply("org.jlleitschuh.gradle.ktlint")
+        apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
         configure<KtlintExtension> {
             version = DefaultVersions.ktlint
@@ -50,14 +43,7 @@ open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
             ktlint(files(gradleKotlinDslKtlintRulesetJar()))
             ktlint(kotlin("reflect"))
         }
-
-        plugins.withId("kotlin") {
-            afterEvaluate {
-                fixKtlintTasks()
-            }
-        }
     }
-
 
     private
     fun Project.gradleKotlinDslKtlintRulesetJar() = provider {
@@ -65,73 +51,4 @@ open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
             jar.outputStream().use { it.write(rulesetJar.readBytes()) }
         }
     }
-
-
-    // Note that below are workarounds, not how things should be fixed upstream
-    // https://github.com/JLLeitschuh/ktlint-gradle/issues/67
-    // https://github.com/JLLeitschuh/ktlint-gradle/issues/51
-    private
-    fun Project.fixKtlintTasks() {
-        val reporters = the<KtlintExtension>().reporters
-        val ktLintCheckTasks = collectKtLintCheckTasks()
-        fixKtlintCheckTaskCacheability(ktLintCheckTasks, reporters)
-        displayLinkToReportsOnFailure(ktLintCheckTasks, reporters)
-    }
-
-
-    private
-    fun Project.collectKtLintCheckTasks() =
-        the<JavaPluginConvention>().sourceSets.mapNotNull { sourceSet ->
-            (tasks.findByName("ktlint${sourceSet.name.capitalize()}Check") as? JavaExec)?.let { task ->
-                Pair(sourceSet, task)
-            }
-        }
-
-
-    private
-    fun Project.fixKtlintCheckTaskCacheability(
-        tasksBySourceSets: List<Pair<SourceSet, JavaExec>>,
-        reporters: Array<ReporterType>
-    ) =
-
-        tasksBySourceSets.forEach { (sourceSet, task) ->
-
-            sourceSet.allSource.sourceDirectories.forEach { _ ->
-                reporters.forEach {
-                    task.outputs.file("$buildDir/${it.reportPathFor(sourceSet)}")
-                }
-                task.outputs.cacheIf { true }
-            }
-        }
-
-
-    private
-    fun Project.displayLinkToReportsOnFailure(
-        tasksBySourceSets: List<Pair<SourceSet, JavaExec>>,
-        reporters: Array<ReporterType>
-    ) =
-
-        gradle.taskGraph.addTaskExecutionListener(object : TaskExecutionListener {
-
-            val consoleRenderer = ConsoleRenderer()
-
-            override fun beforeExecute(aTask: Task) = Unit
-
-            override fun afterExecute(aTask: Task, state: TaskState) {
-                if (state.failure != null) {
-                    tasksBySourceSets.find { it.second == aTask }?.let { (sourceSet, _) ->
-                        val message = "ktlint check failed\n\n" + reporters.map {
-                            file("$buildDir/${it.reportPathFor(sourceSet)}")
-                        }.joinToString(separator = "\n") {
-                            consoleRenderer.asClickableFileUrl(it).prependIndent()
-                        } + '\n'
-                        logger.error(message)
-                    }
-                }
-            }
-        })
-
-    private
-    fun ReporterType.reportPathFor(sourceSet: SourceSet) =
-        "reports/ktlint/ktlint-${sourceSet.name}.$fileExtension"
 }


### PR DESCRIPTION
Brings:
- relocatable cacheable `ktlint` check tasks
- `.kts` linting