### PR TITLE
Prevent path traversal on Gradle src dist unzip after on-demand download

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
@@ -23,6 +23,7 @@ import java.io.InputStream
 import java.io.OutputStream
 
 import java.util.zip.ZipEntry
+import java.util.zip.ZipException
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 
@@ -63,16 +64,20 @@ fun zipTo(outputStream: OutputStream, entries: Sequence<Pair<String, ByteArray>>
 internal
 fun unzipTo(outputDirectory: File, zipFile: File) {
     ZipFile(zipFile).use { zip ->
+        val outputDirectoryCanonicalPath = outputDirectory.canonicalPath
         for (entry in zip.entries()) {
-            unzipEntryTo(outputDirectory, zip, entry)
+            unzipEntryTo(outputDirectory, outputDirectoryCanonicalPath, zip, entry)
         }
     }
 }
 
 
 private
-fun unzipEntryTo(outputDirectory: File, zip: ZipFile, entry: ZipEntry) {
-    val output = File(outputDirectory, entry.name)
+fun unzipEntryTo(outputDirectory: File, outputDirectoryCanonicalPath: String, zip: ZipFile, entry: ZipEntry) {
+    val output = outputDirectory.resolve(entry.name)
+    if (!output.canonicalPath.startsWith(outputDirectoryCanonicalPath)) {
+        throw ZipException("Zip entry '${entry.name}' is outside of the output directory")
+    }
     if (entry.isDirectory) {
         output.mkdirs()
     } else {

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ZipTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ZipTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThat
+import org.junit.Assert.fail
+import org.junit.Test
+
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipException
+import java.util.zip.ZipOutputStream
+
+
+class ZipTest : TestWithTempFiles() {
+
+    @Test
+    fun `unzip fails on path traversal attempts`() {
+
+        val maliciousZip = file("malicious.zip").apply {
+            ZipOutputStream(outputStream()).use { zip ->
+                val content = "suspicious".toByteArray()
+                zip.putNextEntry(ZipEntry("path/../../traversal.txt".replace('/', File.separatorChar)).apply { size = content.size.toLong() })
+                zip.write(content)
+                zip.closeEntry()
+            }
+        }
+
+        try {
+            unzipTo(file("output/directory"), maliciousZip)
+            fail()
+        } catch (ex: ZipException) {
+            assertThat(ex.message, equalTo("Zip entry 'path/../../traversal.txt' is outside of the output directory".replace('/', File.separatorChar)))
+        }
+        assertFalse(file("output").exists())
+    }
+}


### PR DESCRIPTION
which is very unlikely, but better put belt and braces on.