### PR TITLE
Decouple the versions of the Kotlin libraries used by the build and by the runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,19 +9,12 @@ buildscript {
 
     build.loadExtraPropertiesOf(project)
 
-    val kotlinVersion: String by extra
-    dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    }
-
-    repositories {
-        gradlePluginPortal()
-    }
 }
 
 plugins {
     base
     id("org.jetbrains.gradle.plugin.idea-ext") version "0.1"
+    kotlin("jvm") apply false
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,8 @@ buildscript {
 
 plugins {
     base
-    id("org.jetbrains.gradle.plugin.idea-ext") version "0.1"
     kotlin("jvm") apply false
+    id("org.jetbrains.gradle.plugin.idea-ext") version "0.1"
 }
 
 allprojects {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,15 +1,11 @@
-import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslCompilerPlugins
 import org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
 
-    val kotlinVersion = file("../kotlin-version.txt").readText().trim()
-
     val pluginsExperiments = "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins-experiments:0.1.8"
 
     dependencies {
-        classpath(kotlin("gradle-plugin", version = kotlinVersion))
         classpath(pluginsExperiments)
     }
 
@@ -24,12 +20,10 @@ buildscript {
 
 plugins {
     `java-gradle-plugin`
-    `kotlin-dsl` apply false
+    `kotlin-dsl`
 }
 
 apply(plugin = "org.gradle.kotlin.ktlint-convention")
-apply(plugin = "kotlin")
-apply<KotlinDslCompilerPlugins>()
 apply<PrecompiledScriptPlugins>()
 
 tasks.withType<KotlinCompile> {

--- a/subprojects/plugins-experiments/plugins-experiments.gradle.kts
+++ b/subprojects/plugins-experiments/plugins-experiments.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(gradleKotlinDsl())
+    compileOnly(project(":provider"))
 
     implementation("gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:4.0.0")
     implementation(futureKotlin("stdlib-jdk8"))

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -40,7 +40,6 @@ import org.gradle.plugin.management.internal.DefaultPluginRequests
 
 import org.gradle.plugin.use.internal.PluginRequestCollector
 
-import org.jetbrains.kotlin.preprocessor.mkdirsOrFail
 import org.jetbrains.kotlin.script.KotlinScriptDefinition
 
 import org.jetbrains.org.objectweb.asm.ClassVisitor
@@ -531,7 +530,7 @@ class ResidualProgramCompiler(
     fun uniqueScriptFileFor(sourcePath: String, stage: String) =
         outputDir
             .resolve(stage)
-            .apply { mkdirsOrFail() }
+            .apply { mkdirs() }
             .resolve(scriptFileNameFor(sourcePath))
 
     private

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -11,13 +11,12 @@ import org.gradle.kotlin.dsl.fixtures.LightThought
 import org.gradle.kotlin.dsl.fixtures.ZeroThought
 import org.gradle.kotlin.dsl.fixtures.canPublishBuildScan
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.kotlin.dsl.fixtures.convertLineSeparators
 import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
-
-import org.jetbrains.kotlin.preprocessor.convertLineSeparators
 
 import org.junit.Assert.assertNotEquals
 import org.junit.Test

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/string.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/string.kt
@@ -9,3 +9,7 @@ fun String.toPlatformLineSeparators() =
 
 fun <T> Iterable<T>.joinLines(transform: (T) -> String) =
     joinToString(separator = "\n", transform = transform)
+
+
+fun String.convertLineSeparators() =
+    TextUtil.normaliseLineSeparators(this)


### PR DESCRIPTION
So that we can compile against a newer version of the Kotlin
libraries without incurring the risk of loading incompatible library
versions (like older plugins running against newer compilers, etc).

This makes upgrading to Kotlin 1.2.50 smoother.