### PR TITLE
Serialize TAPI model requests

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/EventLoop.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/EventLoop.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.concurrent
+
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+
+import kotlin.concurrent.thread
+
+
+internal
+class EventLoop<T>(val loop: (() -> T?) -> Unit) {
+
+    fun accept(event: T): Boolean {
+        if (q.offer(event, offerTimeoutMillis, TimeUnit.MILLISECONDS)) {
+            ensureAliveConsumer()
+            return true
+        }
+        return false
+    }
+
+    private
+    val q = ArrayBlockingQueue<T>(64)
+
+    private
+    var consumer: Thread? = null
+
+    private
+    fun ensureAliveConsumer() = synchronized(this) {
+        if (consumer?.isAlive != true) {
+            consumer = newConsumerThread()
+        }
+    }
+
+    private
+    fun newConsumerThread() = thread {
+        loop(::poll)
+    }
+
+    private
+    fun poll(): T? = q.poll(pollTimeoutMillis, TimeUnit.MILLISECONDS)
+}
+
+
+private
+const val offerTimeoutMillis = 50L
+
+
+private
+const val pollTimeoutMillis = 5_000L

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -309,20 +309,10 @@ object RequestQueue {
         while (true) {
             val (request, k) = poll() ?: break
             try {
-                k.resume(serve(request))
+                k.resume(fetchKotlinBuildScriptModelFor(request))
             } catch (e: Throwable) {
                 k.resumeWithException(e)
             }
-        }
-    }
-
-    private
-    fun serve(request: KotlinBuildScriptModelRequest): KotlinBuildScriptModel {
-        val connection = projectConnectionFor(request)
-        try {
-            return connection.modelBuilderFor(request).get()
-        } finally {
-            connection.close()
         }
     }
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -16,12 +16,12 @@
 
 package org.gradle.kotlin.dsl.resolver
 
-import org.gradle.kotlin.dsl.concurrent.tapi
 import org.gradle.kotlin.dsl.provider.KotlinDslProviderMode
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ModelBuilder
+import org.gradle.tooling.ProjectConnection
 
 import java.io.File
 
@@ -56,28 +56,27 @@ typealias ModelBuilderCustomization = ModelBuilder<KotlinBuildScriptModel>.() ->
 
 
 internal
-suspend fun fetchKotlinBuildScriptModelFor(
+fun fetchKotlinBuildScriptModelFor(
     request: KotlinBuildScriptModelRequest,
     modelBuilderCustomization: ModelBuilderCustomization = {}
 ): KotlinBuildScriptModel {
 
     val connection = projectConnectionFor(request)
     try {
-        return tapi { connection.modelBuilderFor(request).apply(modelBuilderCustomization).get(it) }
+        return connection.modelBuilderFor(request).apply(modelBuilderCustomization).get()
     } finally {
-        // Run close on a separate thread as TAPI doesn't allow closing the connection from an executor thread
-        kotlin.concurrent.thread { connection.close() }
+        connection.close()
     }
 }
 
 
-internal
-fun projectConnectionFor(request: KotlinBuildScriptModelRequest): org.gradle.tooling.ProjectConnection =
+private
+fun projectConnectionFor(request: KotlinBuildScriptModelRequest): ProjectConnection =
     connectorFor(request).connect()
 
 
-internal
-fun org.gradle.tooling.ProjectConnection.modelBuilderFor(request: KotlinBuildScriptModelRequest) =
+private
+fun ProjectConnection.modelBuilderFor(request: KotlinBuildScriptModelRequest) =
     model(KotlinBuildScriptModel::class.java).apply {
         setJavaHome(request.javaHome)
         setJvmArguments(request.jvmOptions + modelSpecificJvmOptions)
@@ -96,7 +95,7 @@ const val kotlinBuildScriptModelTarget = "org.gradle.kotlin.dsl.provider.script"
 
 
 internal
-fun connectorFor(request: KotlinBuildScriptModelRequest): org.gradle.tooling.GradleConnector =
+fun connectorFor(request: KotlinBuildScriptModelRequest): GradleConnector =
     connectorFor(request.projectDir, request.gradleInstallation)
         .useGradleUserHomeDir(request.gradleUserHome)
 
@@ -112,7 +111,7 @@ fun connectorFor(projectDir: File, gradleInstallation: GradleInstallation): Grad
 
 
 private
-fun applyGradleInstallationTo(connector: GradleConnector, gradleInstallation: GradleInstallation): org.gradle.tooling.GradleConnector =
+fun applyGradleInstallationTo(connector: GradleConnector, gradleInstallation: GradleInstallation): GradleConnector =
     gradleInstallation.run {
         when (this) {
             is GradleInstallation.Local -> connector.useInstallation(dir)

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -71,12 +71,12 @@ suspend fun fetchKotlinBuildScriptModelFor(
 }
 
 
-private
+internal
 fun projectConnectionFor(request: KotlinBuildScriptModelRequest): org.gradle.tooling.ProjectConnection =
     connectorFor(request).connect()
 
 
-private
+internal
 fun org.gradle.tooling.ProjectConnection.modelBuilderFor(request: KotlinBuildScriptModelRequest) =
     model(KotlinBuildScriptModel::class.java).apply {
         setJavaHome(request.javaHome)

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -38,11 +38,11 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 
 
-private
+internal
 const val offerTimeoutMillis = 50L
 
 
-private
+internal
 const val pollTimeoutMillis = 5_000L
 
 

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -17,6 +17,8 @@
 package org.gradle.kotlin.dsl.resolver
 
 import org.gradle.internal.os.OperatingSystem
+
+import org.gradle.kotlin.dsl.concurrent.EventLoop
 import org.gradle.kotlin.dsl.support.userHome
 
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
@@ -30,50 +32,20 @@ import java.io.StringWriter
 import java.text.SimpleDateFormat
 
 import java.util.*
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.TimeUnit
 
-import kotlin.concurrent.thread
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
-
-
-internal
-const val offerTimeoutMillis = 50L
-
-
-internal
-const val pollTimeoutMillis = 5_000L
 
 
 internal
 object ResolverEventLogger {
 
     fun log(event: ResolverEvent) {
-        q.offer(now() to event, offerTimeoutMillis, TimeUnit.MILLISECONDS)
-        ensureAliveConsumer()
+        eventLoop.accept(now() to event)
     }
 
     private
-    val q = ArrayBlockingQueue<Pair<Date, ResolverEvent>>(64)
-
-    private
-    val outputFile by lazy {
-        File(outputDir(), "resolver-${timestampForFileName()}.log")
-    }
-
-    private
-    var consumer: Thread? = null
-
-    private
-    fun ensureAliveConsumer() = synchronized(ResolverEventLogger) {
-        if (consumer?.isAlive != true) {
-            consumer = newConsumerThread()
-        }
-    }
-
-    private
-    fun newConsumerThread() = thread {
+    val eventLoop = EventLoop<Pair<Date, ResolverEvent>> { poll ->
 
         val format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
 
@@ -90,10 +62,15 @@ object ResolverEventLogger {
             }
 
             while (true) {
-                val (timestamp, event) = q.poll(pollTimeoutMillis, TimeUnit.MILLISECONDS) ?: break
+                val (timestamp, event) = poll() ?: break
                 write(timestamp, event)
             }
         }
+    }
+
+    private
+    val outputFile by lazy {
+        File(outputDir(), "resolver-${timestampForFileName()}.log")
     }
 
     private


### PR DESCRIPTION
In order to avoid spawning a Gradle daemon per open .gradle.kts script.