### PR TITLE
Prove init script plugins can be applied from init scripts

### DIFF
--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptModelIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptModelIntegrationTest.kt
@@ -1,6 +1,5 @@
 package org.gradle.kotlin.dsl.integration
 
-import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 
@@ -22,7 +21,7 @@ class KotlinInitScriptModelIntegrationTest : ScriptModelIntegrationTest() {
         assertContainsGradleKotlinDslJars(classPath)
         assertThat(
             classPath.map { it.name },
-            not(hasItem("buildSrc.jar")))
+            not(hasBuildSrc()))
     }
 
     @Test

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptModelIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/ScriptModelIntegrationTest.kt
@@ -177,7 +177,11 @@ abstract class ScriptModelIntegrationTest : AbstractIntegrationTest() {
     fun assertContainsBuildSrc(classPath: List<File>) =
         assertThat(
             classPath.map { it.name },
-            hasItem("buildSrc.jar"))
+            hasBuildSrc())
+
+    protected
+    fun hasBuildSrc() =
+        hasItem("buildSrc.jar")
 
     protected
     fun assertIncludes(classPath: List<File>, vararg files: File) =


### PR DESCRIPTION
With a classpath computed from its `initscript` block.