### PR TITLE
Allow plugins which support only subtypes of project

### DIFF
--- a/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/provider/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -75,7 +75,7 @@ inline fun Project.defaultTasks(vararg tasks: Task) {
  * @param T the plugin type.
  * @see [PluginAware.apply]
  */
-inline fun <reified T : Plugin<Project>> Project.apply() =
+inline fun <reified T : Plugin<out Project>> Project.apply() =
     (this as PluginAware).apply<T>()
 
 


### PR DESCRIPTION
The most notable one is Gradle's built-in `JavaPlugin` which implements `Plugin<ProjectInternal>`.