### PR TITLE
Let script compiler target be 1.8

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -40,9 +40,11 @@ import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.JVM_TARGET
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_JAR
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY
+import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
@@ -80,6 +82,7 @@ fun compileKotlinScriptToDirectory(
 
             val configuration = compilerConfigurationFor(messageCollector).apply {
                 addKotlinSourceRoot(scriptFile.canonicalPath)
+                put(JVM_TARGET, JvmTarget.JVM_1_8)
                 put(RETAIN_OUTPUT_IN_MEMORY, false)
                 put(OUTPUT_DIRECTORY, outputDirectory)
                 setModuleName("buildscript")

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -16,6 +16,7 @@ import org.gradle.kotlin.dsl.fixtures.rootProjectDir
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 
 import org.junit.Assert.assertNotEquals
@@ -871,6 +872,23 @@ class GradleKotlinDslIntegrationTest : AbstractIntegrationTest() {
         """)
 
         build("help")
+    }
+
+    @Test
+    fun `can use kotlin java8 inline-only methods`() {
+
+        withBuildScript("""
+            task("test") {
+                doLast {
+                    println(project.properties.getOrDefault("non-existent-property", "default-value"))
+                }
+            }
+        """)
+
+        assertThat(
+            build("-q", "test").output.trim(),
+            equalTo("default-value")
+        )
     }
 
     private


### PR DESCRIPTION
So inline functions from Kotlin libraries compiled against 1.8 can be used.

Fixes #955
