### PR TITLE
Return build cache metadata from script caching commands

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -72,7 +72,7 @@ fun buildAccessorsClassPathFor(project: Project, classPath: ClassPath) =
     configuredProjectSchemaOf(project)?.let { projectSchema ->
         val cacheDir =
             scriptCacheOf(project)
-                .cacheDirFor(cacheKeyFor(projectSchema)) { baseDir, _ ->
+                .cacheDirFor(cacheKeyFor(projectSchema)) { baseDir ->
                     buildAccessorsJarFor(projectSchema, classPath, outputDir = baseDir)
                 }
         AccessorsClassPath(

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -34,9 +34,13 @@ import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.id.UniqueId
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.scopeids.id.BuildInvocationScopeId
+import org.gradle.internal.time.Time.startTimer
 
 import org.gradle.kotlin.dsl.cache.LoadDirectory
+import org.gradle.kotlin.dsl.cache.PackMetadata
 import org.gradle.kotlin.dsl.cache.ScriptBuildCacheKey
 import org.gradle.kotlin.dsl.cache.ScriptCache
 import org.gradle.kotlin.dsl.cache.StoreDirectory
@@ -227,31 +231,51 @@ class StandardKotlinScriptEvaluator(
             initializer: (File) -> Unit
         ): File =
             scriptCache.cacheDirFor(cacheKeySpec, properties = cacheProperties) { baseDir, cacheKey ->
-
-                val cacheDir =
-                    File(baseDir, "cache").apply { require(mkdir()) }
-
-                // TODO: Move BuildCacheController integration to ScriptCache
-                val cacheController =
-                    if (scriptCache.hasBuildCacheIntegration) buildCacheControllerOf(scriptHost) else null
-
-                if (cacheController != null) {
-                    val buildCacheKey = ScriptBuildCacheKey(scriptHost.scriptSource.displayName, cacheKey)
-                    val existing = cacheController.load(LoadDirectory(cacheDir, buildCacheKey))
-                    if (existing == null) {
-                        initializer(cacheDir)
-                        cacheController.store(StoreDirectory(cacheDir, buildCacheKey))
-                    }
-                } else {
-                    initializer(cacheDir)
-                }
+                val cacheDir = File(baseDir, "cache").apply { require(mkdir()) }
+                initializeCacheDir(cacheDir, cacheKey, scriptHost, initializer)
             }.resolve("cache")
 
         private
-        fun buildCacheControllerOf(scriptHost: KotlinScriptHost<*>) =
+        fun initializeCacheDir(cacheDir: File, cacheKey: String, scriptHost: KotlinScriptHost<*>, initializer: (File) -> Unit) {
+
+            // TODO: Move BuildCacheController integration to ScriptCache
+            val cacheController =
+                if (scriptCache.hasBuildCacheIntegration) buildCacheControllerOf(scriptHost)
+                else null
+
+            if (cacheController != null) {
+                val buildCacheKey = ScriptBuildCacheKey(scriptHost.scriptSource.displayName, cacheKey)
+                val existing = cacheController.load(LoadDirectory(cacheDir, buildCacheKey))
+                if (existing === null) {
+
+                    val executionTime = executionTimeMillisOf {
+                        initializer(cacheDir)
+                    }
+
+                    cacheController.store(
+                        StoreDirectory(
+                            cacheDir,
+                            buildCacheKey,
+                            PackMetadata(buildInvocationIdOf(scriptHost), executionTime)
+                        )
+                    )
+                }
+            } else {
+                initializer(cacheDir)
+            }
+        }
+
+        private
+        fun buildCacheControllerOf(scriptHost: KotlinScriptHost<*>): BuildCacheController? =
             (scriptHost.target as? Project)
                 ?.serviceOf<BuildCacheController>()
                 ?.takeIf { it.isEnabled }
+
+        private
+        fun buildInvocationIdOf(scriptHost: KotlinScriptHost<*>): UniqueId =
+            (scriptHost.target as Project)
+                .gradle.serviceOf<BuildInvocationScopeId>()
+                .id
 
         private
         val cacheProperties = mapOf("version" to "12")
@@ -281,6 +305,13 @@ class StandardKotlinScriptEvaluator(
         override val implicitImports: List<String>
             get() = this@StandardKotlinScriptEvaluator.implicitImports.list
     }
+}
+
+
+private
+inline fun executionTimeMillisOf(action: () -> Unit) = startTimer().run {
+    action()
+    elapsedMillis
 }
 
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
@@ -24,6 +24,7 @@ import org.gradle.kotlin.dsl.integration.normalisedPath
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 
+import org.junit.Ignore
 import org.junit.Test
 
 import java.io.File
@@ -31,6 +32,7 @@ import java.io.File
 
 class BuildCacheIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
+    @Ignore("Waiting on a new patch release of the build-scan plugin")
     @Test
     fun `can publish build scan`() {
 


### PR DESCRIPTION
The cache commands will store and load `OriginTaskExecutionMetadata` as currently expected by the build-scan plugin.

Unfortunately this breaks the build-scan plugin assumption that a cache command is only ever triggered in the context of an executing task and will require a new plugin version before it can be used (and the corresponding integration test ignored).