### PR TITLE
Replace deprecated ProgressLogger.setLoggingHeader by build operation

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -29,6 +29,7 @@ import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.internal.classloader.ClasspathHasher
 
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.operations.BuildOperationExecutor
 
 import org.gradle.kotlin.dsl.cache.ScriptCache
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
@@ -48,6 +49,7 @@ object BuildServices {
         classLoaderScopeRegistry: ClassLoaderScopeRegistry,
         dependencyFactory: DependencyFactory,
         jarCache: GeneratedGradleJarCache,
+        buildOperationExecutor: BuildOperationExecutor,
         progressLoggerFactory: ProgressLoggerFactory
     ) =
 
@@ -57,6 +59,7 @@ object BuildServices {
             classLoaderScopeRegistry.coreAndPluginsScope,
             gradleApiJarsProviderFor(dependencyFactory),
             versionedJarCacheFor(jarCache),
+            buildOperationExecutor,
             StandardJarGenerationProgressMonitorProvider(progressLoggerFactory))
 
     @Suppress("unused")

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/JarGenerationProgressMonitorProvider.kt
@@ -52,8 +52,7 @@ class StandardJarGenerationProgressMonitorProvider(
     private
     fun progressLoggerFor(outputJar: File): ProgressLogger =
         progressLoggerFactory.newOperation(JarGenerationProgressMonitorProvider::class.java).apply {
-            description = "Gradle Kotlin DSL JARs generation"
-            loggingHeader = "Generating JAR file '${outputJar.name}'"
+            description = "Generating ${outputJar.name}"
             started()
         }
 }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -12,6 +12,8 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.Clas
 import org.gradle.api.internal.classpath.Module
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.RunnableBuildOperation
 
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 
@@ -32,6 +34,12 @@ class KotlinScriptClassPathProviderTest : AbstractIntegrationTest() {
 
         val apiMetadataModule = mockGradleApiMetadataModule()
 
+        val buildOperationExecutor = mock<BuildOperationExecutor> {
+            on { run(any()) }.thenAnswer {
+                it.getArgument<RunnableBuildOperation>(0).run(mock())
+            }
+        }
+
         val kotlinExtensionsMonitor = mock<ProgressMonitor>(name = "kotlinExtensionsMonitor")
         val progressMonitorProvider = mock<JarGenerationProgressMonitorProvider> {
             on { progressMonitorFor(generatedKotlinExtensions, 3) } doReturn kotlinExtensionsMonitor
@@ -43,6 +51,7 @@ class KotlinScriptClassPathProviderTest : AbstractIntegrationTest() {
             coreAndPluginsScope = mock(),
             gradleApiJarsProvider = { listOf(gradleApiJar) },
             jarCache = { id, generator -> existing("$id.jar").apply(generator) },
+            buildOperationExecutor = buildOperationExecutor,
             progressMonitorProvider = progressMonitorProvider)
 
         assertThat(


### PR DESCRIPTION
See #991 

![generated-jar-progress](https://user-images.githubusercontent.com/132773/43456179-bd4c9b6e-94c2-11e8-9929-30af7ecfde2c.gif)

The line gets quite long.