### PR TITLE
Fix missing parameter names in Gradle Kotlin DSL jars

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     compile(kotlin("reflect"))
 
     compile("com.gradle.publish:plugin-publish-plugin:0.10.0")
-    compile("org.ow2.asm:asm-all:5.1")
+    compile("org.ow2.asm:asm:6.2")
 
     testCompile("junit:junit:4.12")
     testCompile(gradleTestKit())

--- a/buildSrc/src/main/kotlin/build/GradleApiParameterNamesTransform.kt
+++ b/buildSrc/src/main/kotlin/build/GradleApiParameterNamesTransform.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.transform.ArtifactTransform
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RelativePath
+import org.gradle.api.specs.Spec
+import org.gradle.api.specs.Specs
+
+import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDependency
+import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.file.pattern.PatternMatcherFactory
+import org.gradle.internal.installation.CurrentGradleInstallation
+import org.gradle.util.GradleVersion
+
+import org.gradle.kotlin.dsl.*
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.ClassWriter.COMPUTE_FRAMES
+import org.objectweb.asm.ClassWriter.COMPUTE_MAXS
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes.ASM6
+import org.objectweb.asm.Type
+
+import java.io.File
+import java.util.Properties
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+
+
+fun Project.gradleApiWithParameterNames(): Dependency =
+    DefaultSelfResolvingDependency(gradleApiWithParameterNamesFiles() as FileCollectionInternal)
+
+
+private
+fun Project.gradleApiWithParameterNamesFiles(): FileCollection =
+    files().from(provider {
+        resolvedGradleApiWithParameterNames()
+    })
+
+
+private
+val artifactType = Attribute.of("artifactType", String::class.java)
+
+
+private
+const val withParameterNames = "with-parameter-names"
+
+
+private
+fun Project.resolvedGradleApiWithParameterNames(): FileCollection =
+    gradleApiDetachedConfiguration().run {
+        dependencies {
+            registerTransform {
+                from.attribute(artifactType, "jar")
+                to.attribute(artifactType, withParameterNames)
+                artifactTransform(GradleApiParameterNamesTransform::class)
+            }
+        }
+        incoming.artifactView {
+            attributes {
+                attribute(artifactType, withParameterNames)
+            }
+        }.artifacts.artifactFiles
+    }
+
+
+private
+fun Project.gradleApiDetachedConfiguration() =
+    configurations.detachedConfiguration(dependencies.gradleApi())
+
+
+private
+val gradleApiJarFileName by lazy {
+    "gradle-api-${GradleVersion.current().version}.jar"
+}
+
+
+class GradleApiParameterNamesTransform : ArtifactTransform() {
+
+    override fun transform(input: File): MutableList<File> =
+        when (input.name) {
+            gradleApiJarFileName -> mutableListOf(outputDirectory).also {
+                JarFile(input).use { jar ->
+                    jar.entries().asSequence().filterNot { it.isDirectory }.forEach { entry ->
+                        if (entry.isGradleApi) jar.transformEntryIntoOutputDirectory(entry)
+                        else jar.writeEntryToOutputDirectory(entry)
+                    }
+                }
+            }
+            else -> mutableListOf(input)
+        }
+
+    private
+    val JarEntry.isGradleApi
+        get() = name.endsWith(".class")
+            && name != "package-info.class"
+            && gradleApiMetadata.spec.isSatisfiedBy(RelativePath.parse(true, name))
+
+    fun JarFile.transformEntryIntoOutputDirectory(entry: JarEntry) {
+        getInputStream(entry).use { input ->
+            val reader = ClassReader(input)
+            val writer = ClassWriter(COMPUTE_MAXS and COMPUTE_FRAMES)
+            val visitor = ParameterNamesClassVisitor(writer, gradleApiMetadata.parameterNamesSupplier)
+            reader.accept(visitor, 0)
+            outputDirectory.resolve(entry.name)
+                .also { it.parentFile.mkdirs() }
+                .writeBytes(writer.toByteArray())
+        }
+    }
+
+    private
+    fun JarFile.writeEntryToOutputDirectory(entry: JarEntry) =
+        getInputStream(entry).use { input ->
+            outputDirectory.resolve(entry.name)
+                .also { it.parentFile.mkdirs() }
+                .outputStream().use { output ->
+                    input.copyTo(output)
+                }
+        }
+}
+
+
+private
+class ParameterNamesClassVisitor(
+    delegate: ClassVisitor,
+    private val parameterNamesSupplier: ParameterNamesSupplier
+) : ClassVisitor(ASM6, delegate) {
+
+    private
+    lateinit var typeName: String
+
+    override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<out String>?) {
+        typeName = name
+        super.visit(version, access, name, signature, superName, interfaces)
+    }
+
+    override fun visitMethod(access: Int, name: String, desc: String, signature: String?, exceptions: Array<out String>?): MethodVisitor {
+        return super.visitMethod(access, name, desc, signature, exceptions).apply {
+            parameterNamesSupplier.parameterNamesForBinaryNames(typeName, name, desc)?.forEach { parameterName ->
+                // TODO figure out what to set for access
+                visitParameter(parameterName, 0)
+            }
+        }
+    }
+
+    private
+    fun ParameterNamesSupplier.parameterNamesForBinaryNames(typeName: String, methodName: String, methodDescriptor: String) =
+        parameterNamesFor(
+            typeBinaryNameFor(typeName),
+            methodName,
+            parameterTypesBinaryNamesFor(methodDescriptor)
+        )
+
+    private
+    fun typeBinaryNameFor(internalName: String): String =
+        Type.getObjectType(internalName).className
+
+    private
+    fun parameterTypesBinaryNamesFor(methodDescriptor: String) =
+        Type.getArgumentTypes(methodDescriptor).map { it.className }
+}
+
+
+private
+data class GradleApiMetadata(
+    val includes: List<String>,
+    val excludes: List<String>,
+    val parameterNamesSupplier: ParameterNamesSupplier
+) {
+    val spec = apiSpecFor(includes, excludes)
+}
+
+
+private
+typealias ParameterNamesSupplier = (String) -> List<String>?
+
+
+private
+val gradleApiMetadata by lazy {
+    gradleApiMetadataFrom(locateGradleApiMetadataJar())
+}
+
+
+private
+const val gradleApiMetadataModuleName = "gradle-api-metadata"
+
+
+private
+const val gradleApiDeclarationPropertiesName = "gradle-api-declaration.properties"
+
+
+private
+const val gradleApiParameterNamesPropertiesName = "gradle-api-parameter-names.properties"
+
+
+private
+fun locateGradleApiMetadataJar() =
+    CurrentGradleInstallation.get()!!.libDirs.flatMap {
+        it.listFiles().filter { it.name.startsWith(gradleApiMetadataModuleName) }
+    }.single()
+
+
+private
+fun gradleApiMetadataFrom(gradleApiMetadataJar: File): GradleApiMetadata =
+    JarFile(gradleApiMetadataJar).use { jar ->
+        val apiDeclaration = jar.loadProperties(gradleApiDeclarationPropertiesName)
+        val parameterNames = jar.loadProperties(gradleApiParameterNamesPropertiesName)
+        GradleApiMetadata(
+            apiDeclaration.getProperty("includes").split(":"),
+            apiDeclaration.getProperty("excludes").split(":"),
+            parameterNamesSupplierFrom(parameterNames))
+    }
+
+
+private
+fun ParameterNamesSupplier.parameterNamesFor(typeName: String, functionName: String, parameterTypeNames: List<String>): List<String>? =
+    this("$typeName.$functionName(${parameterTypeNames.joinToString(",")})")
+
+
+private
+fun parameterNamesSupplierFrom(parameterNames: Properties): ParameterNamesSupplier =
+    { key: String -> parameterNames.getProperty(key, null)?.split(",") }
+
+
+private
+fun apiSpecFor(includes: List<String>, excludes: List<String>): Spec<RelativePath> =
+    when {
+        includes.isEmpty() && excludes.isEmpty() -> Specs.satisfyAll()
+        includes.isEmpty() -> Specs.negate(patternSpecFor(excludes))
+        excludes.isEmpty() -> patternSpecFor(includes)
+        else -> Specs.intersect(patternSpecFor(includes), Specs.negate(patternSpecFor(excludes)))
+    }
+
+
+private
+fun patternSpecFor(patterns: List<String>) =
+    Specs.union(patterns.map {
+        PatternMatcherFactory.getPatternMatcher(true, true, it)
+    })
+
+
+private
+fun JarFile.loadProperties(name: String) =
+    getInputStream(getJarEntry(name)).use { input ->
+        Properties().also { it.load(input) }
+    }

--- a/buildSrc/src/main/kotlin/build/GradleApiParameterNamesTransform.kt
+++ b/buildSrc/src/main/kotlin/build/GradleApiParameterNamesTransform.kt
@@ -187,7 +187,6 @@ class ParameterNamesClassVisitor(
     override fun visitMethod(access: Int, name: String, desc: String, signature: String?, exceptions: Array<out String>?): MethodVisitor {
         return super.visitMethod(access, name, desc, signature, exceptions).apply {
             parameterNamesSupplier.parameterNamesForBinaryNames(typeName, name, desc)?.forEach { parameterName ->
-                // TODO figure out what to set for access
                 visitParameter(parameterName, 0)
             }
         }

--- a/buildSrc/src/main/kotlin/plugins/kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/plugins/kotlin-library.gradle.kts
@@ -37,6 +37,7 @@ tasks {
         kotlinOptions {
             freeCompilerArgs += listOf(
                 "-java-parameters",
+                "-Xuse-old-class-files-reading",
                 "-Xjsr305=strict",
                 "-Xskip-runtime-version-check")
         }

--- a/buildSrc/src/main/kotlin/plugins/kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/plugins/kotlin-library.gradle.kts
@@ -36,6 +36,7 @@ tasks {
     withType<KotlinCompile> {
         kotlinOptions {
             freeCompilerArgs += listOf(
+                "-java-parameters",
                 "-Xjsr305=strict",
                 "-Xskip-runtime-version-check")
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-Xms256m -Xmx256m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms256m -Xmx320m -Dfile.encoding=UTF-8
 systemProp.gradle.publish.skip.namespace.check=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/ant/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/ant/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/build-cache/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/build-cache/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/build-scan/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/build-scan/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/buildSrc-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/buildSrc-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/code-quality/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/code-quality/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/composite-builds/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/composite-builds/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/copy/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/copy/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/domain-objects/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/domain-objects/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/extra-properties/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/extra-properties/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/gradle-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/groovy-interop/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/groovy-interop/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/hello-android/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/hello-coroutines/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-coroutines/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/hello-js/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-js/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/hello-kapt/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-kapt/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/hello-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/hello-world/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-world/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/kotlin-friendly-groovy-plugin/consumer/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/kotlin-friendly-groovy-plugin/consumer/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/kotlin-friendly-groovy-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/kotlin-friendly-groovy-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/kotlin-friendly-groovy-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/kotlin-friendly-groovy-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/maven-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/maven-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/maven-publish/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/maven-publish/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/model-rules/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/model-rules/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/modularity/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/modularity/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/multi-kotlin-project-config-injection/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-kotlin-project-config-injection/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/multi-kotlin-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-kotlin-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/multi-kotlin-project/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-kotlin-project/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/multi-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/precompiled-script-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/precompiled-script-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/precompiled-script-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/precompiled-script-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/project-properties/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/project-properties/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/provider-properties/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/provider-properties/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/source-control/external/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/source-control/external/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/source-control/sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/source-control/sample/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/task-dependencies/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/task-dependencies/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/samples/testkit/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/testkit/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804101723+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-4.10-20180804120920+0000-all.zip

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -49,7 +49,7 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
                 tasks.withType<KotlinCompile>().configureEach {
                     it.kotlinOptions {
                         jvmTarget = this@kotlinDslPluginOptions.jvmTarget.get()
-                        freeCompilerArgs += listOf("-java-parameters", "-Xuse-old-class-files-reading")
+                        freeCompilerArgs += "-java-parameters"
                     }
                     it.applyKotlinDslPluginProgressiveMode(progressive.get())
                 }

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -47,7 +47,10 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
         afterEvaluate {
             kotlinDslPluginOptions {
                 tasks.withType<KotlinCompile>().configureEach {
-                    it.kotlinOptions.jvmTarget = jvmTarget.get()
+                    it.kotlinOptions {
+                        jvmTarget = this@kotlinDslPluginOptions.jvmTarget.get()
+                        freeCompilerArgs += "-java-parameters"
+                    }
                     it.applyKotlinDslPluginProgressiveMode(progressive.get())
                 }
             }

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -49,7 +49,7 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
                 tasks.withType<KotlinCompile>().configureEach {
                     it.kotlinOptions {
                         jvmTarget = this@kotlinDslPluginOptions.jvmTarget.get()
-                        freeCompilerArgs += "-java-parameters"
+                        freeCompilerArgs += listOf("-java-parameters", "-Xuse-old-class-files-reading")
                     }
                     it.applyKotlinDslPluginProgressiveMode(progressive.get())
                 }

--- a/subprojects/provider-plugins/provider-plugins.gradle.kts
+++ b/subprojects/provider-plugins/provider-plugins.gradle.kts
@@ -9,7 +9,7 @@ base {
 }
 
 dependencies {
-    compileOnly(gradleApi())
+    compileOnly(gradleApiWithParameterNames())
 
     compile(project(":provider"))
 }

--- a/subprojects/provider/provider.gradle.kts
+++ b/subprojects/provider/provider.gradle.kts
@@ -11,7 +11,7 @@ base {
 }
 
 dependencies {
-    compileOnly(gradleApi())
+    compileOnly(gradleApiWithParameterNames())
 
     compile(project(":tooling-models"))
     compile(futureKotlin("stdlib-jdk8"))

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -46,7 +46,6 @@ annotation class KotlinScriptTemplate
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = ".*\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
-    "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -46,6 +46,7 @@ annotation class KotlinScriptTemplate
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = ".*\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
+    "-java-parameters",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -47,6 +47,7 @@ annotation class KotlinScriptTemplate
     scriptFilePattern = ".*\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
     "-java-parameters",
+    "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -46,7 +46,6 @@ annotation class KotlinScriptTemplate
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = ".*\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
-    "-java-parameters",
     "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -61,6 +61,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
     scriptFilePattern = ".+\\.init\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
     "-java-parameters",
+    "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -60,7 +60,6 @@ import kotlin.script.templates.ScriptTemplateDefinition
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = ".+\\.init\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
-    "-java-parameters",
     "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -60,6 +60,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = ".+\\.init\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
+    "-java-parameters",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -60,7 +60,6 @@ import kotlin.script.templates.ScriptTemplateDefinition
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = ".+\\.init\\.gradle\\.kts")
 @ScriptTemplateAdditionalCompilerArguments([
-    "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -70,7 +70,6 @@ import kotlin.script.templates.ScriptTemplateDefinition
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = "^(settings|.+\\.settings)\\.gradle\\.kts$")
 @ScriptTemplateAdditionalCompilerArguments([
-    "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -71,6 +71,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
     scriptFilePattern = "^(settings|.+\\.settings)\\.gradle\\.kts$")
 @ScriptTemplateAdditionalCompilerArguments([
     "-java-parameters",
+    "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -70,7 +70,6 @@ import kotlin.script.templates.ScriptTemplateDefinition
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = "^(settings|.+\\.settings)\\.gradle\\.kts$")
 @ScriptTemplateAdditionalCompilerArguments([
-    "-java-parameters",
     "-Xuse-old-class-files-reading",
     "-Xjsr305=strict",
     "-Xprogressive",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -70,6 +70,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
     resolver = KotlinBuildScriptDependenciesResolver::class,
     scriptFilePattern = "^(settings|.+\\.settings)\\.gradle\\.kts$")
 @ScriptTemplateAdditionalCompilerArguments([
+    "-java-parameters",
     "-Xjsr305=strict",
     "-Xprogressive",
     "-XXLanguage:+NewInference",

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -66,8 +66,11 @@ private
 typealias ApiTypeSupplier = () -> ApiType
 
 
-internal
 typealias ParameterNamesSupplier = (String) -> List<String>?
+
+
+fun ParameterNamesSupplier.parameterNamesFor(typeName: String, functionName: String, parameterTypeNames: List<String>): List<String>? =
+    this("$typeName.$functionName(${parameterTypeNames.joinToString(",")})")
 
 
 /**
@@ -144,7 +147,7 @@ class ApiTypeProvider(
             typeProvider.type(sourceName)
 
         fun parameterNamesFor(typeName: String, functionName: String, parameterTypeNames: List<String>): List<String>? =
-            parameterNamesSupplier("$typeName.$functionName(${parameterTypeNames.joinToString(",")})")
+            parameterNamesSupplier.parameterNamesFor(typeName, functionName, parameterTypeNames)
     }
 }
 

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -33,6 +33,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 
 import org.gradle.kotlin.dsl.codegen.generateApiExtensionsJar
+import org.gradle.kotlin.dsl.support.gradleApiMetadataModuleName
 import org.gradle.kotlin.dsl.support.ProgressMonitor
 import org.gradle.kotlin.dsl.support.serviceOf
 
@@ -219,10 +220,6 @@ fun DependencyFactory.gradleApi(): Dependency =
 
 private
 val gradleApiNotation = DependencyFactory.ClassPathNotation.GRADLE_API
-
-
-internal
-const val gradleApiMetadataModuleName = "gradle-api-metadata"
 
 
 private

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleApiMetadata.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleApiMetadata.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.api.file.RelativePath
+import org.gradle.api.specs.Spec
+import org.gradle.api.specs.Specs
+
+import org.gradle.api.internal.file.pattern.PatternMatcherFactory
+
+import org.gradle.kotlin.dsl.codegen.ParameterNamesSupplier
+
+import java.io.File
+import java.util.Properties
+import java.util.jar.JarFile
+
+
+const val gradleApiMetadataModuleName = "gradle-api-metadata"
+
+
+data class GradleApiMetadata(
+    val includes: List<String>,
+    val excludes: List<String>,
+    val parameterNamesSupplier: ParameterNamesSupplier
+) {
+    val spec = apiSpecFor(includes, excludes)
+}
+
+
+fun gradleApiMetadataFrom(gradleApiMetadataJar: File): GradleApiMetadata =
+    JarFile(gradleApiMetadataJar).use { jar ->
+        val apiDeclaration = jar.loadProperties(gradleApiDeclarationPropertiesName)
+        val parameterNames = jar.loadProperties(gradleApiParameterNamesPropertiesName)
+        GradleApiMetadata(
+            apiDeclaration.getProperty("includes").split(":"),
+            apiDeclaration.getProperty("excludes").split(":"),
+            parameterNamesSupplierFrom(parameterNames))
+    }
+
+
+private
+fun JarFile.loadProperties(name: String) =
+    getInputStream(getJarEntry(name)).use { input ->
+        Properties().also { it.load(input) }
+    }
+
+
+private
+const val gradleApiDeclarationPropertiesName = "gradle-api-declaration.properties"
+
+
+private
+const val gradleApiParameterNamesPropertiesName = "gradle-api-parameter-names.properties"
+
+
+private
+fun parameterNamesSupplierFrom(parameterNames: Properties): ParameterNamesSupplier =
+    { key: String -> parameterNames.getProperty(key, null)?.split(",") }
+
+
+private
+fun apiSpecFor(includes: List<String>, excludes: List<String>): Spec<RelativePath> =
+    when {
+        includes.isEmpty() && excludes.isEmpty() -> Specs.satisfyAll()
+        includes.isEmpty() -> Specs.negate(patternSpecFor(excludes))
+        excludes.isEmpty() -> patternSpecFor(includes)
+        else -> Specs.intersect(patternSpecFor(includes), Specs.negate(patternSpecFor(excludes)))
+    }
+
+
+private
+fun patternSpecFor(patterns: List<String>) =
+    Specs.union(patterns.map {
+        PatternMatcherFactory.getPatternMatcher(true, true, it)
+    })

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -40,7 +40,6 @@ import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import org.jetbrains.kotlin.config.JVMConfigurationKeys.PARAMETERS_METADATA
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.JVM_TARGET
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_JAR
@@ -208,7 +207,6 @@ fun compilerConfigurationFor(messageCollector: MessageCollector): CompilerConfig
         put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
         put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettings)
         put(JVM_TARGET, JvmTarget.JVM_1_8)
-        put(PARAMETERS_METADATA, true)
         put(USE_FAST_CLASS_FILES_READING, false)
     }
 

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -40,6 +40,7 @@ import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.PARAMETERS_METADATA
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.JVM_TARGET
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_JAR
@@ -206,6 +207,7 @@ fun compilerConfigurationFor(messageCollector: MessageCollector): CompilerConfig
         put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
         put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettings)
         put(JVM_TARGET, JvmTarget.JVM_1_8)
+        put(PARAMETERS_METADATA, true)
     }
 
 

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -44,7 +44,6 @@ import org.jetbrains.kotlin.config.JVMConfigurationKeys.JVM_TARGET
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_JAR
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY
-import org.jetbrains.kotlin.config.JVMConfigurationKeys.USE_FAST_CLASS_FILES_READING
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersion
@@ -207,7 +206,6 @@ fun compilerConfigurationFor(messageCollector: MessageCollector): CompilerConfig
         put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
         put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettings)
         put(JVM_TARGET, JvmTarget.JVM_1_8)
-        put(USE_FAST_CLASS_FILES_READING, false)
     }
 
 

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -45,6 +45,7 @@ import org.jetbrains.kotlin.config.JVMConfigurationKeys.JVM_TARGET
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_JAR
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY
+import org.jetbrains.kotlin.config.JVMConfigurationKeys.USE_FAST_CLASS_FILES_READING
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersion
@@ -208,6 +209,7 @@ fun compilerConfigurationFor(messageCollector: MessageCollector): CompilerConfig
         put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettings)
         put(JVM_TARGET, JvmTarget.JVM_1_8)
         put(PARAMETERS_METADATA, true)
+        put(USE_FAST_CLASS_FILES_READING, false)
     }
 
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.kotlin.dsl.codegen
 
+import org.gradle.api.specs.Specs
+
 import org.gradle.kotlin.dsl.accessors.TestWithClassPath
 
 import org.gradle.kotlin.dsl.fixtures.codegen.ClassAndGroovyNamedArguments
@@ -285,8 +287,7 @@ class GradleApiExtensionsTest : TestWithClassPath() {
             "SourceBaseName",
             apiJars,
             emptyList(),
-            emptyList(),
-            emptyList(),
+            Specs.satisfyAll(),
             fixtureParameterNamesSupplier
         )
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiParameterNamesTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiParameterNamesTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.PluginDependenciesSpecScope
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.plugin.use.PluginDependenciesSpec
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+import kotlin.reflect.KClass
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.full.valueParameters
+
+
+class GradleApiParameterNamesTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `Gradle API has parameter names`() {
+
+        assertHasParameterNames(
+            PluginDependenciesSpec::class, "id", listOf(String::class), listOf("id")
+        )
+    }
+
+    @Test
+    fun `Kotlin delegation generated member has parameter names`() {
+
+        assertHasParameterNames(
+            PluginDependenciesSpecScope::class, "id", listOf(String::class), listOf("id")
+        )
+    }
+
+    private
+    fun assertHasParameterNames(type: KClass<*>, methodName: String, parameterTypes: List<KClass<*>>, parameterNames: List<String>) {
+
+        // java.lang.reflect
+        val javaMethod = type.java.getDeclaredMethod(
+            methodName,
+            *parameterTypes.map { it.java }.toTypedArray()
+        )
+        assertThat(
+            javaMethod.parameters.map { it.name },
+            equalTo(parameterNames)
+        )
+
+        // kotlin.reflect
+        parameterTypes.map { it }
+        val kotlinFunction = type.declaredFunctions.single {
+            it.name == methodName && it.valueParameters.map { it.type.classifier } == parameterTypes
+        }
+        assertThat(
+            kotlinFunction.valueParameters.map { it.name!! },
+            equalTo(parameterNames as List<String?>)
+        )
+    }
+}

--- a/subprojects/test-fixtures/test-fixtures.gradle.kts
+++ b/subprojects/test-fixtures/test-fixtures.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
     compile("junit:junit:4.12")
     compile("com.nhaarman:mockito-kotlin:1.6.0")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2")
-    compile("org.ow2.asm:asm-all:5.2")
+    compile("org.ow2.asm:asm:6.2")
 }

--- a/subprojects/test-fixtures/test-fixtures.gradle.kts
+++ b/subprojects/test-fixtures/test-fixtures.gradle.kts
@@ -1,9 +1,11 @@
+import build.*
+
 plugins {
     id("kotlin-library")
 }
 
 dependencies {
-    compile(gradleApi())
+    compile(gradleApiWithParameterNames())
 
     compile(project(":provider"))
     compile(project(":tooling-builders"))

--- a/subprojects/tooling-builders/tooling-builders.gradle.kts
+++ b/subprojects/tooling-builders/tooling-builders.gradle.kts
@@ -9,7 +9,7 @@ base {
 }
 
 dependencies {
-    compileOnly(gradleApi())
+    compileOnly(gradleApiWithParameterNames())
 
     compile(project(":provider"))
 


### PR DESCRIPTION
Functions on types using kotlin [implementation by delegation](https://kotlinlang.org/docs/reference/delegation.html#implementation-by-delegation) for a Java interface miss parameter names metadata.

See #464 

Reusing the `gradle-api-metadata`, an `ArtifactTransform` hydrates the Gradle API bytecode provided by `gradleApi()` with Java 8 parameter names. The Gradle Kotlin DSL is compiled against the transformed Gradle API disabling the kotlin compiler fast class reader. This combination lets the parameter names show up properly in the IDE instead of `p0`, `p1` ...

![image](https://user-images.githubusercontent.com/132773/43677668-203814d8-9806-11e8-94f6-0ddd9da33307.png)




