### PR TITLE
Revisit `kotlin-dsl` experimental kotlin compiler settings warning

### DIFF
--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginOptions.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginOptions.kt
@@ -41,56 +41,11 @@ class KotlinDslPluginOptions internal constructor(objects: ObjectFactory) {
     }
 
     /**
-     * Switch for the `kotlin-dsl` plugin `progressive` mode.
-     *
-     * The `kotlin-dsl` plugin relies on Kotlin compiler's progressive mode and experimental features
-     * to enable among other things SAM conversion for Kotlin functions.
-     *
-     * Once built and published, artifacts produced by this project will continue to work on future Gradle versions.
-     * However, you may have to fix the sources of this project after upgrading the Gradle wrapper of this build.
-     *
-     * Defaults to [ProgressiveModeState.WARN] which enables SAM conversion for Kotlin functions and issue a warning.
-     * Set to [ProgressiveModeState.ENABLED] to silence the warning.
-     * Set to [ProgressiveModeState.DISABLED] to disable and give up SAM conversion for Kotlin functions.
-     *
-     * @see ProgressiveModeState
-     * @see KotlinDslPlugin
+     * Set to `false` to silence the warning about the `kotlin-dsl` plugin enabling Kotlin compiler experimental features.
      */
-    val progressive = objects.property<ProgressiveModeState>().apply {
-        set(ProgressiveModeState.WARN)
+    val experimentalWarning = objects.property<Boolean>().apply {
+        set(true)
     }
-}
-
-
-/**
- * State of the `kotlin-dsl` plugin `progressive` mode.
- *
- * @see KotlinDslPluginOptions.progressive
- * @see KotlinDslPlugin
- */
-enum class ProgressiveModeState {
-
-    /**
-     * SAM conversion for Kotlin functions is enabled and a warning is issued.
-     * This is the default.
-     *
-     * @see KotlinDslPluginOptions.progressive
-     */
-    WARN,
-
-    /**
-     * SAM conversion for Kotlin functions is enabled.
-     *
-     * @see KotlinDslPluginOptions.progressive
-     */
-    ENABLED,
-
-    /**
-     * SAM conversion for Kotlin functions is disabled.
-     *
-     * @see KotlinDslPluginOptions.progressive
-     */
-    DISABLED
 }
 
 

--- a/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -1,5 +1,7 @@
 package org.gradle.kotlin.dsl.plugins.dsl
 
+import org.gradle.api.internal.DocumentationRegistry
+
 import org.gradle.kotlin.dsl.fixtures.customDaemonRegistry
 import org.gradle.kotlin.dsl.fixtures.customInstallation
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
@@ -218,7 +220,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
     }
 
     @Test
-    fun `by default SAM conversion for Kotlin functions is enabled and a warning is issued`() {
+    fun `by default experimental Kotlin compiler features are enabled and a warning is issued`() {
 
         withBuildExercisingSamConversionForKotlinFunctions()
 
@@ -240,36 +242,16 @@ class KotlinDslPluginTest : AbstractPluginTest() {
 
             assertThat(
                 output,
-                containsString(kotlinDslPluginProgressiveWarning)
+                containsString(experimentalWarningFor(":buildSrc"))
             )
         }
     }
 
     @Test
-    fun `can explicitly disable SAM conversion for Kotlin functions and get no warning`() {
+    fun `can explicitly disable experimental Kotlin compiler features warning`() {
 
         withBuildExercisingSamConversionForKotlinFunctions(
-            "kotlinDslPluginOptions.progressive.set(ProgressiveModeState.DISABLED)"
-        )
-
-        buildAndFail("test").apply {
-
-            assertThat(
-                output,
-                not(containsString(KotlinCompilerArguments.samConversionForKotlinFunctions))
-            )
-            assertThat(
-                output,
-                not(containsString(kotlinDslPluginProgressiveWarning))
-            )
-        }
-    }
-
-    @Test
-    fun `can explicitly enable SAM conversion for Kotlin functions and get no warning`() {
-
-        withBuildExercisingSamConversionForKotlinFunctions(
-            "kotlinDslPluginOptions.progressive.set(ProgressiveModeState.ENABLED)"
+            "kotlinDslPluginOptions.experimentalWarning.set(false)"
         )
 
         build("test").apply {
@@ -290,10 +272,14 @@ class KotlinDslPluginTest : AbstractPluginTest() {
 
             assertThat(
                 output,
-                not(containsString(kotlinDslPluginProgressiveWarning))
+                not(containsString(experimentalWarningFor(":buildSrc")))
             )
         }
     }
+
+    private
+    fun experimentalWarningFor(projectPath: String) =
+        kotlinDslPluginExperimentalWarning("project '$projectPath'", DocumentationRegistry().getDocumentationFor("kotlin-dsl", "sec:kotlin-dsl-plugin"))
 
     private
     fun withBuildExercisingSamConversionForKotlinFunctions(buildSrcScript: String = "") {


### PR DESCRIPTION
- remove option to turn off sam-conversion-for-kotlin-functions
- simplify warning message, linking to the user manual

See #1003, another PR against `gradle/gradle` will introduce the related documentation