### PR TITLE
Let build cache integration be enabled via system property instead of project property

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
@@ -33,7 +33,7 @@ object BuildServices {
     ): ScriptCache {
 
         val hasBuildCacheIntegration =
-            startParameters.isBuildCacheEnabled && startParameters.isKotlinDslBuildCacheEnabled
+            startParameters.isBuildCacheEnabled && isKotlinDslBuildCacheEnabled
 
         return ScriptCache(
             cacheRepository,
@@ -46,5 +46,5 @@ object BuildServices {
 
 
 private
-val StartParameter.isKotlinDslBuildCacheEnabled: Boolean
-    get() = projectProperties.getOrDefault("org.gradle.kotlin.dsl.caching.buildcache", null) == "true"
+val isKotlinDslBuildCacheEnabled: Boolean
+    get() = System.getProperty("org.gradle.kotlin.dsl.caching.buildcache", null) == "true"

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/caching/AbstractScriptCachingIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/caching/AbstractScriptCachingIntegrationTest.kt
@@ -45,7 +45,15 @@ abstract class AbstractScriptCachingIntegrationTest : AbstractIntegrationTest() 
 
     protected
     fun buildWithUniqueGradleHome(vararg arguments: String): BuildResult =
-        buildForCacheInspection("-g", uniqueGradleHome(), *arguments)
+        buildWithGradleHome(uniqueGradleHome(), *arguments)
+
+    protected
+    fun buildWithGradleHome(gradleHomePath: String, vararg arguments: String) =
+        buildForCacheInspection("-g", gradleHomePath, *arguments)
+
+    protected
+    fun <T> withUniqueGradleHome(f: (String) -> T): T =
+        f(uniqueGradleHome())
 
     private
     fun uniqueGradleHome() =


### PR DESCRIPTION
And prove it can be enabled via `$GRADLE_HOME/gradle.properties`.

See #1032