### PR TITLE
Let ClassBytesRepository ignore invalid classpath entries

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
@@ -143,7 +143,7 @@ class ClassBytesRepository(classPath: ClassPath, classPathDependencies: ClassPat
  */
 private
 val File.isClassPathArchive
-    get() = extension.equals("jar", ignoreCase = true) || extension.equals("zip", ignoreCase = true)
+    get() = extension.run { equals("jar", ignoreCase = true) || equals("zip", ignoreCase = true) }
 
 
 private

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
@@ -85,10 +85,10 @@ class ClassBytesRepository(classPath: ClassPath, classPathDependencies: ClassPat
         classBytesIndex.firstNotNullResult { it(classFilePath) }
 
     private
-    fun sourceNamesFrom(jarOrDir: File): Sequence<String> =
+    fun sourceNamesFrom(entry: File): Sequence<String> =
         when {
-            jarOrDir.isFile -> sourceNamesFromJar(jarOrDir)
-            jarOrDir.isDirectory -> sourceNamesFromDir(jarOrDir)
+            entry.isClassPathArchive -> sourceNamesFromJar(entry)
+            entry.isDirectory -> sourceNamesFromDir(entry)
             else -> emptySequence()
         }
 
@@ -107,10 +107,10 @@ class ClassBytesRepository(classPath: ClassPath, classPathDependencies: ClassPat
             .map { kotlinSourceNameOf(normaliseFileSeparators(it.relativeTo(dir).path)) }
 
     private
-    fun classBytesIndexFor(jarOrDir: File): ClassBytesIndex =
+    fun classBytesIndexFor(entry: File): ClassBytesIndex =
         when {
-            jarOrDir.isFile -> jarClassBytesIndexFor(jarOrDir)
-            jarOrDir.isDirectory -> directoryClassBytesIndexFor(jarOrDir)
+            entry.isClassPathArchive -> jarClassBytesIndexFor(entry)
+            entry.isDirectory -> directoryClassBytesIndexFor(entry)
             else -> { _ -> null }
         }
 
@@ -136,6 +136,14 @@ class ClassBytesRepository(classPath: ClassPath, classPathDependencies: ClassPat
         openJars.values.forEach(JarFile::close)
     }
 }
+
+
+/**
+ * See https://docs.oracle.com/javase/8/docs/technotes/tools/findingclasses.html#userclass
+ */
+private
+val File.isClassPathArchive
+    get() = extension.equals("jar", ignoreCase = true) || extension.equals("zip", ignoreCase = true)
 
 
 private

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepositoryTest.kt
@@ -21,6 +21,8 @@ import org.gradle.api.tasks.wrapper.Wrapper
 
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
+import org.gradle.kotlin.dsl.fixtures.LightThought
+import org.gradle.kotlin.dsl.fixtures.ZeroThought
 import org.gradle.kotlin.dsl.fixtures.customInstallation
 
 import org.hamcrest.CoreMatchers.equalTo
@@ -139,6 +141,24 @@ class ClassBytesRepositoryTest : AbstractIntegrationTest() {
                 assertTrue(none { it == "package-info" })
                 assertTrue(none { it.matches(Regex("\\$[0-9]\\.class")) })
             }
+        }
+    }
+
+    @Test
+    fun `ignores invalid classpath entries`() {
+
+        val entries = listOf(
+            withClassJar("some.JAR", DeepThought::class.java),
+            withClassJar("some.zip", LightThought::class.java),
+            withClassJar("some.tar.gz", ZeroThought::class.java),
+            withFile("some.xml")
+        )
+
+        classPathBytesRepositoryFor(entries).use { repository ->
+            assertThat(
+                repository.allSourceNames,
+                equalTo(listOf(canonicalNameOf<DeepThought>(), canonicalNameOf<LightThought>()))
+            )
         }
     }
 


### PR DESCRIPTION
In order to prevent unexpected failures when the classpath contains invalid entries that [should be ignored](https://docs.oracle.com/javase/8/docs/technotes/tools/findingclasses.html#userclass).

See #1021 