### PR TITLE
Generate compilable accessors for extensions with types in the default package

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -185,7 +185,8 @@ fun sourceFilesWithAccessorsFor(projectSchema: ProjectSchema<TypeAccessibility>,
     for ((index, schemaSubset) in schemaPerTarget.values.withIndex()) {
         writeAccessorsTo(
             sourceFile("Accessors$index.kt"),
-            schemaSubset.extensionAccessors()
+            schemaSubset.extensionAccessors(),
+            importsRequiredBy(schemaSubset)
         )
     }
 
@@ -196,6 +197,25 @@ fun sourceFilesWithAccessorsFor(projectSchema: ProjectSchema<TypeAccessibility>,
 
     return sourceFiles
 }
+
+
+private
+fun importsRequiredBy(schemaSubset: ProjectSchema<TypeAccessibility>): List<String> =
+    defaultPackageTypesIn(
+        schemaSubset
+            .extensions
+            .flatMap { listOf(it.target, it.type) }
+            .filterIsInstance<TypeAccessibility.Accessible>()
+            .map { it.type }
+    )
+
+
+internal
+fun defaultPackageTypesIn(typeStrings: List<String>): List<String> =
+    typeStrings
+        .flatMap { classNamesFromTypeString(it).all }
+        .filter { '.' !in it }
+        .distinct()
 
 
 internal
@@ -539,14 +559,14 @@ fun enabledJitAccessors(project: Project) =
 
 
 private
-fun writeAccessorsTo(outputFile: File, accessors: Sequence<String>): Unit =
+fun writeAccessorsTo(outputFile: File, accessors: Sequence<String>, imports: List<String> = emptyList()): Unit =
     outputFile.bufferedWriter().use { writer ->
-        writeAccessorsTo(writer, accessors)
+        writeAccessorsTo(writer, accessors, imports)
     }
 
 
 private
-fun writeAccessorsTo(writer: BufferedWriter, accessors: Sequence<String>) {
+fun writeAccessorsTo(writer: BufferedWriter, accessors: Sequence<String>, imports: List<String>) {
     writer.apply {
         write(fileHeader)
         newLine()
@@ -560,6 +580,12 @@ fun writeAccessorsTo(writer: BufferedWriter, accessors: Sequence<String>) {
         newLine()
         appendln("import org.gradle.kotlin.dsl.*")
         newLine()
+        if (imports.isNotEmpty()) {
+            imports.forEach {
+                appendln("import $it")
+            }
+            newLine()
+        }
         accessors.forEach {
             appendln(it)
         }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/DefaultPackageTypesTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/DefaultPackageTypesTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+
+class DefaultPackageTypesTest {
+
+    @Test
+    fun `#defaultPackageTypesIn generic type`() {
+
+        assertThat(
+            defaultPackageTypesIn(listOf("gradle.Container<Extension>")),
+            equalTo(listOf("Extension"))
+        )
+    }
+}

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
@@ -51,6 +51,11 @@ class TypeAccessibilityProviderTest : TestWithClassPath() {
             assertTrue(leafs.isEmpty())
         }
 
+        classNamesFromTypeString("org.gradle.api.NamedDomainObjectContainer<Extension>").apply {
+            assertThat(all, hasItems("org.gradle.api.NamedDomainObjectContainer", "Extension"))
+            assertThat(leafs, hasItems("Extension"))
+        }
+
         classNamesFromTypeString("java.lang.String").apply {
             assertThat(all, hasItems("java.lang.String"))
             assertThat(leafs, hasItems("java.lang.String"))


### PR DESCRIPTION
By adding the required import directives to the generated source files.

Resolves #807