### PR TITLE
Regenerate accessors jar upon classpath changes

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -72,7 +72,7 @@ fun buildAccessorsClassPathFor(project: Project, classPath: ClassPath) =
     configuredProjectSchemaOf(project)?.let { projectSchema ->
         val cacheDir =
             scriptCacheOf(project)
-                .cacheDirFor(cacheKeyFor(projectSchema)) { baseDir ->
+                .cacheDirFor(cacheKeyFor(projectSchema, classPath)) { baseDir ->
                     buildAccessorsJarFor(projectSchema, classPath, outputDir = baseDir)
                 }
         AccessorsClassPath(
@@ -532,8 +532,10 @@ fun classLoaderScopeOf(project: Project) =
 
 
 private
-fun cacheKeyFor(projectSchema: ProjectSchema<String>): CacheKeySpec =
-    CacheKeySpec.withPrefix("gradle-kotlin-dsl-accessors") + projectSchema.toCacheKeyString()
+fun cacheKeyFor(projectSchema: ProjectSchema<String>, classPath: ClassPath): CacheKeySpec =
+    (CacheKeySpec.withPrefix("gradle-kotlin-dsl-accessors")
+        + projectSchema.toCacheKeyString()
+        + classPath)
 
 
 private

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
@@ -47,7 +47,10 @@ class FoldersDsl(val root: File) {
         asCanonicalFile().apply { mkdirs() }
 
     fun withFile(fileName: String, content: String = "") =
-        fileName.asCanonicalFile().apply { parentFile.mkdirs() }.writeText(content)
+        fileName.asCanonicalFile().apply {
+            parentFile.mkdirs()
+            writeText(content)
+        }
 
     private
     fun String.asCanonicalFile(): File =


### PR DESCRIPTION
To ensure changes in the accessibility of extension types are properly taken into account.
