### PR TITLE
Remove unnecessary `apply` method from `SettingsScriptApi`

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -89,14 +89,6 @@ abstract class KotlinSettingsScript(
     override val fileOperations: DefaultFileOperations
         get() = host.operations
 
-    /**
-     * Applies zero or more plugins or scripts.
-     *
-     * @param configuration the block to configure an {@link ObjectConfigurationAction} with before “executing” it
-     */
-    override fun apply(configuration: ObjectConfigurationAction.() -> Unit) =
-        host.applyObjectConfigurationAction(Action { it.configuration() })
-
     override fun apply(action: Action<in ObjectConfigurationAction>) =
         host.applyObjectConfigurationAction(action)
 }
@@ -420,14 +412,6 @@ abstract class SettingsScriptApi(settings: Settings) : Settings by settings {
     @Suppress("unused")
     open fun buildscript(@Suppress("unused_parameter") block: ScriptHandlerScope.() -> Unit): Unit =
         internalError()
-
-    /**
-     * Applies zero or more plugins or scripts.
-     *
-     * @param configuration the block to configure an {@link ObjectConfigurationAction} with before “executing” it
-     */
-    open fun apply(configuration: ObjectConfigurationAction.() -> Unit) =
-        settings.apply(configuration)
 }
 
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinSettingsScriptIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinSettingsScriptIntegrationTest.kt
@@ -1,5 +1,8 @@
 package org.gradle.kotlin.dsl.integration
 
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
 import org.gradle.kotlin.dsl.fixtures.LeaksFileHandles
@@ -11,6 +14,29 @@ import org.junit.Test
 
 
 class KotlinSettingsScriptIntegrationTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `can apply plugin using ObjectConfigurationAction syntax`() {
+
+        withFile("buildSrc/src/main/java/MySettingsPlugin.java", """
+            import ${Plugin::class.qualifiedName};
+            import ${Settings::class.qualifiedName};
+
+            public class MySettingsPlugin implements Plugin<Settings> {
+                public void apply(Settings settings) {}
+            }
+        """)
+
+        withSettings("""
+            apply {
+                plugin<MySettingsPlugin>()
+            }
+        """)
+
+        withBuildScript("")
+
+        build("help", "-q")
+    }
 
     @Test
     fun `Settings script path is resolved relative to parent script dir`() {


### PR DESCRIPTION
The method is no longer needed and actually ambiguous since the introduction of `SamConversionForKotlinFunctions`.

Resolves #1066