### PR TITLE
 Let Gradle create the `build-scan` plugin dependency spec

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/ant/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/ant/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/build-cache/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/build-cache/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/build-scan/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/build-scan/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/buildSrc-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/buildSrc-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/code-quality/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/code-quality/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/composite-builds/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/composite-builds/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/copy/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/copy/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/domain-objects/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/domain-objects/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/extra-properties/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/extra-properties/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/gradle-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/groovy-interop/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/groovy-interop/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/hello-android/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/hello-coroutines/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-coroutines/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/hello-js/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-js/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/hello-kapt/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-kapt/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/hello-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/hello-world/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/hello-world/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/kotlin-friendly-groovy-plugin/consumer/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/kotlin-friendly-groovy-plugin/consumer/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/kotlin-friendly-groovy-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/kotlin-friendly-groovy-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/kotlin-friendly-groovy-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/kotlin-friendly-groovy-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/maven-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/maven-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/maven-publish/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/maven-publish/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/model-rules/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/model-rules/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/modularity/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/modularity/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/multi-kotlin-project-config-injection/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-kotlin-project-config-injection/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/multi-kotlin-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-kotlin-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/multi-kotlin-project/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-kotlin-project/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/multi-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/multi-project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/precompiled-script-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/precompiled-script-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/precompiled-script-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/precompiled-script-plugin/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/project-properties/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/project-properties/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/project-with-buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/provider-properties/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/provider-properties/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/source-control/external/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/source-control/external/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/source-control/sample/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/source-control/sample/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/task-dependencies/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/task-dependencies/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/samples/testkit/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/testkit/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180830211241+0000-all.zip
+distributionUrl=https\://repo.gradle.org/gradle/kotlin-dsl-snapshots-local/gradle-kotlin-dsl-5.0-20180831035038+0000-all.zip

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecExtensions.kt
@@ -30,4 +30,4 @@ import org.gradle.plugin.use.PluginDependencySpec
  * You can also use e.g. `` `build-scan` version "1.8" `` to request a different version.
  */
 val PluginDependenciesSpec.`build-scan`: PluginDependencySpec
-    get() = id(AutoAppliedBuildScanPlugin.ID.id) version AutoAppliedBuildScanPlugin.VERSION
+    get() = AutoAppliedBuildScanPlugin.addBuildScanPluginDependencySpecTo(this)


### PR DESCRIPTION
Blocked by gradle/gradle#6579