### PR TITLE
Add build cache configuration to the build

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,2 @@
+apply(from = "../gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
+

--- a/gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts
@@ -20,8 +20,8 @@ import java.net.URI
  * need this to be a script unless we can model dual usage better with composite/included builds or another solution.
  */
 
-val remoteCacheUrl = System.getProperty("gradle.cache.remote.url")?.let { URI(it) }
-val isCiServer = System.getenv().containsKey("CI")
+val remoteCacheUrl = System.getProperty("gradle.cache.remote.url")?.let(::URI)
+val isCiServer = "CI" in System.getenv()
 val remotePush = System.getProperty("gradle.cache.remote.push") != "false"
 val remoteCacheUsername = System.getProperty("gradle.cache.remote.username", "")
 val remoteCachePassword = System.getProperty("gradle.cache.remote.password", "")
@@ -32,7 +32,9 @@ buildCache {
     }
 }
 
-val isRemoteBuildCacheEnabled = remoteCacheUrl != null && gradle.startParameter.isBuildCacheEnabled && !gradle.startParameter.isOffline
+val isRemoteBuildCacheEnabled = remoteCacheUrl != null
+    && gradle.startParameter.run { isBuildCacheEnabled && !isOffline }
+
 if (isRemoteBuildCacheEnabled) {
     buildCache {
         remote<HttpBuildCache> {

--- a/gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.net.URI
+
+/*
+ * This script is applied to the settings in buildSrc and the main build. That is why we
+ * need this to be a script unless we can model dual usage better with composite/included builds or another solution.
+ */
+
+val remoteCacheUrl = System.getProperty("gradle.cache.remote.url")?.let { URI(it) }
+val isCiServer = System.getenv().containsKey("CI")
+val remotePush = System.getProperty("gradle.cache.remote.push") != "false"
+val remoteCacheUsername = System.getProperty("gradle.cache.remote.username", "")
+val remoteCachePassword = System.getProperty("gradle.cache.remote.password", "")
+
+buildCache {
+    local {
+        isEnabled = !isCiServer
+    }
+}
+
+val isRemoteBuildCacheEnabled = remoteCacheUrl != null && gradle.startParameter.isBuildCacheEnabled && !gradle.startParameter.isOffline
+if (isRemoteBuildCacheEnabled) {
+    buildCache {
+        remote<HttpBuildCache> {
+            url = remoteCacheUrl
+            isPush = isCiServer && remotePush
+            if (remoteCacheUsername.isNotEmpty() && remoteCachePassword.isNotEmpty()) {
+                credentials {
+                    username = remoteCacheUsername
+                    password = remoteCachePassword
+                }
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+apply(from = "gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
+
 enableFeaturePreview("STABLE_PUBLISHING")
 
 rootProject.name = "gradle-kotlin-dsl"


### PR DESCRIPTION
CI configuration has been updated to enable the build cache.

The effect can be seen here:
https://builds.gradle.org/viewType.html?buildTypeId=GradleKotlinDSL_DevelopJava9&branch_GradleKotlinDSL=build%2Fcache&tab=buildTypeStatusDiv
and in produced build scans.