### PR TITLE
Don't build kotlin-dsl with -Xuse-old-class-files-reading

### DIFF
--- a/buildSrc/src/main/kotlin/plugins/kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/plugins/kotlin-library.gradle.kts
@@ -37,7 +37,6 @@ tasks {
         kotlinOptions {
             freeCompilerArgs += listOf(
                 "-java-parameters",
-                "-Xuse-old-class-files-reading",
                 "-Xjsr305=strict",
                 "-Xprogressive",
                 "-Xskip-runtime-version-check")


### PR DESCRIPTION
Not needed anymore with Kotlin 1.2.70, see #1005, #1004, #464 and [KT-25193](https://youtrack.jetbrains.com/issue/KT-25193).

Still working:
![image](https://user-images.githubusercontent.com/132773/45542319-d3abb300-b811-11e8-8e9b-8f1f240e3073.png)




