### PR TITLE
Resume continuation only once after handling model request

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -215,10 +215,22 @@ object RequestQueue {
         while (true) {
             val (request, k) = poll() ?: break
             try {
-                k.resume(fetchKotlinBuildScriptModelFor(request))
+                handle(request, k)
             } catch (e: Throwable) {
-                k.resumeWithException(e)
+                e.printStackTrace()
             }
         }
+    }
+
+    private
+    fun handle(request: KotlinBuildScriptModelRequest, k: Continuation<KotlinBuildScriptModel>) {
+        val response =
+            try {
+                fetchKotlinBuildScriptModelFor(request)
+            } catch (e: Throwable) {
+                k.resumeWithException(e)
+                return
+            }
+        k.resume(response)
     }
 }


### PR DESCRIPTION
Resume continuation outside the try block to avoid double resuming (first via `resume` then later with `resumeWithException`).

Exceptions thrown by the continuation are simply logged.