### PR TITLE
Fix usabililty of Configuration accessors in the `configurations {}` block

### DIFF
--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -801,6 +801,30 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
             containsString("Type of `myConvention` receiver is MyConvention"))
     }
 
+    @Test
+    fun `accessors to existing configurations`() {
+
+        withBuildScript("""
+            plugins {
+                java
+            }
+
+            configurations {
+                runtimeOnly {
+                    extendsFrom(implementation.get())
+                }
+            }
+
+            configurations.implementation {
+                resolutionStrategy {
+                    failOnVersionConflict()
+                }
+            }
+        """)
+
+        build("help")
+    }
+
     private
     fun withFolders(folders: FoldersDslExpression) =
         projectRoot.withFolders(folders)

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationPublications
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.ExcludeRule
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.TaskDependency
+
+import java.io.File
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().buildDependencies"))
+val <T : Configuration> NamedDomainObjectProvider<T>.buildDependencies: TaskDependency
+    get() = get().buildDependencies
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().singleFile"))
+val <T : Configuration> NamedDomainObjectProvider<T>.singleFile: File
+    get() = get().singleFile
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().files"))
+val <T : Configuration> NamedDomainObjectProvider<T>.files: Set<File>
+    get() = get().files
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().contains(element)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.contains(element: File): Boolean =
+    get().contains(element)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().asPath"))
+val <T : Configuration> NamedDomainObjectProvider<T>.asPath: String
+    get() = get().asPath
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().plus(collection)"))
+operator fun <T : Configuration> NamedDomainObjectProvider<T>.plus(collection: FileCollection): FileCollection =
+    get().plus(collection)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().plus(configuration)"))
+operator fun <T : Configuration> FileCollection.plus(configuration: NamedDomainObjectProvider<T>): FileCollection =
+    plus(configuration.get())
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().minus(collection)"))
+operator fun <T : Configuration> NamedDomainObjectProvider<T>.minus(collection: FileCollection): FileCollection =
+    get().minus(collection)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().minus(configuration)"))
+operator fun <T : Configuration> FileCollection.minus(configuration: NamedDomainObjectProvider<T>): FileCollection =
+    minus(configuration.get())
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().filter(filterSpec"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.filter(filterSpec: Spec<File>) =
+    get().filter(filterSpec)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().isEmpty"))
+val <T : Configuration> NamedDomainObjectProvider<T>.isEmpty: Boolean
+    get() = get().isEmpty
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().asFileTree"))
+val <T : Configuration> NamedDomainObjectProvider<T>.asFileTree: FileTree
+    get() = get().asFileTree
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().resolutionStrategy"))
+val <T : Configuration> NamedDomainObjectProvider<T>.resolutionStrategy
+    get() = get().resolutionStrategy
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().state"))
+val <T : Configuration> NamedDomainObjectProvider<T>.state
+    get() = get().state
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().isVisible"))
+var <T : Configuration> NamedDomainObjectProvider<T>.isVisible
+    get() = get().isVisible
+    set(value) {
+        get().isVisible = value
+    }
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().extendsFrom"))
+val <T : Configuration> NamedDomainObjectProvider<T>.extendsFrom: Set<Configuration>
+    get() = get().extendsFrom
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().setExtendsFrom(superConfigs)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.setExtendsFrom(superConfigs: Iterable<Configuration>): Configuration =
+    get().setExtendsFrom(superConfigs)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().extendsFrom(superConfigs)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.extendsFrom(vararg superConfigs: Configuration) =
+    get().extendsFrom(*superConfigs)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().isTransitive"))
+val <T : Configuration> NamedDomainObjectProvider<T>.isTransitive
+    get() = get().isTransitive
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().setTransitive(t)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.setTransitive(t: Boolean): Configuration =
+    get().setTransitive(t)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().description"))
+val <T : Configuration> NamedDomainObjectProvider<T>.description
+    get() = get().description
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().setDescription(description)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.setDescription(description: String?): Configuration =
+    get().setDescription(description)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().hierarchy"))
+val <T : Configuration> NamedDomainObjectProvider<T>.hierarchy: Set<Configuration>
+    get() = get().hierarchy
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().resolve()"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.resolve(): Set<File> =
+    get().resolve()
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().files(dependencySpec)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.files(dependencySpec: Spec<Dependency>): Set<File> =
+    get().files(dependencySpec)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().files(dependencies)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.files(vararg dependencies: Dependency): Set<File> =
+    get().files(*dependencies)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().fileCollection(dependencySpec)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.fileCollection(dependencySpec: Spec<Dependency>): FileCollection =
+    get().fileCollection(dependencySpec)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().fileCollection(dependencies)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.fileCollection(vararg dependencies: Dependency): FileCollection =
+    get().fileCollection(*dependencies)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().resolvedConfiguration"))
+val <T : Configuration> NamedDomainObjectProvider<T>.resolvedConfiguration
+    get() = get().resolvedConfiguration
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().uploadTaskName"))
+val <T : Configuration> NamedDomainObjectProvider<T>.uploadTaskName
+    get() = get().uploadTaskName
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().getTaskDependencyFromProjectDependency(useDependedOn, taskName)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.getTaskDependencyFromProjectDependency(useDependedOn: Boolean, taskName: String): TaskDependency =
+    get().getTaskDependencyFromProjectDependency(useDependedOn, taskName)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().dependencies"))
+val <T : Configuration> NamedDomainObjectProvider<T>.dependencies
+    get() = get().dependencies
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().allDependencies"))
+val <T : Configuration> NamedDomainObjectProvider<T>.allDependencies
+    get() = get().allDependencies
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().dependencyConstraints"))
+val <T : Configuration> NamedDomainObjectProvider<T>.dependencyConstraints
+    get() = get().dependencyConstraints
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().allDependencyConstraints"))
+val <T : Configuration> NamedDomainObjectProvider<T>.allDependencyConstraints
+    get() = get().allDependencyConstraints
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().artifacts"))
+val <T : Configuration> NamedDomainObjectProvider<T>.artifacts
+    get() = get().artifacts
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().allArtifacts"))
+val <T : Configuration> NamedDomainObjectProvider<T>.allArtifacts
+    get() = get().allArtifacts
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().excludeRules"))
+val <T : Configuration> NamedDomainObjectProvider<T>.excludeRules: Set<ExcludeRule>
+    get() = get().excludeRules
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().exclude(excludeProperties)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.exclude(excludeProperties: Map<String, String>): Configuration =
+    get().exclude(excludeProperties)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().exclude(excludeProperties)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.exclude(vararg excludeProperties: Pair<String, String>): Configuration =
+    get().exclude(excludeProperties.toMap())
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().defaultDependencies(action)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.defaultDependencies(action: DependencySet.() -> Unit) =
+    get().defaultDependencies(action)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().withDependencies(action)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.withDependencies(action: DependencySet.() -> Unit) =
+    get().defaultDependencies(action)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().all"))
+val <T : Configuration> NamedDomainObjectProvider<T>.all: Set<Configuration>
+    get() = get().all
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().incoming"))
+val <T : Configuration> NamedDomainObjectProvider<T>.incoming
+    get() = get().incoming
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().outgoing"))
+val <T : Configuration> NamedDomainObjectProvider<T>.outgoing
+    get() = get().outgoing
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().outgoing(action)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.outgoing(action: ConfigurationPublications.() -> Unit) =
+    get().outgoing(action)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().copy()"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.copy() =
+    get().copy()
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().copyRecursive()"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.copyRecursive() =
+    get().copyRecursive()
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().copy(dependencySpec)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.copy(dependencySpec: Spec<Dependency>) =
+    get().copy(dependencySpec)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().copyRecursive(dependencySpec)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.copyRecursive(dependencySpec: Spec<Dependency>) =
+    get().copyRecursive(dependencySpec)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().isCanBeConsumed"))
+var <T : Configuration> NamedDomainObjectProvider<T>.isCanBeConsumed
+    get() = get().isCanBeConsumed
+    set(value) {
+        get().isCanBeConsumed = value
+    }
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().isCanBeResolved"))
+var <T : Configuration> NamedDomainObjectProvider<T>.isCanBeResolved
+    get() = get().isCanBeResolved
+    set(value) {
+        get().isCanBeResolved = value
+    }
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().attributes"))
+val <T : Configuration> NamedDomainObjectProvider<T>.attributes
+    get() = get().attributes
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().attributes(action)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.attributes(action: AttributeContainer.() -> Unit) =
+    get().attributes(action)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().addToAntBuilder(builder, nodeName, type)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.addToAntBuilder(builder: Any, nodeName: String, type: FileCollection.AntType): Unit =
+    get().addToAntBuilder(builder, nodeName, type)
+
+
+@Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().addToAntBuilder(builder, nodeName)"))
+fun <T : Configuration> NamedDomainObjectProvider<T>.addToAntBuilder(builder: Any, nodeName: String): Any =
+    get().addToAntBuilder(builder, nodeName)
+
+
+private
+const val deprecationMessage = "Scheduled to be removed in Gradle 6.0"

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -17,6 +17,8 @@
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.Incubating
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
@@ -48,6 +50,12 @@ class ScriptHandlerScope(scriptHandler: ScriptHandler) : ScriptHandler by script
      */
     val ConfigurationContainer.classpath: Configuration
         get() = getByName(CLASSPATH_CONFIGURATION)
+
+    /**
+     * The script classpath configuration.
+     */
+    val NamedDomainObjectContainer<Configuration>.classpath: NamedDomainObjectProvider<Configuration>
+        get() = named(CLASSPATH_CONFIGURATION)
 
     /**
      * Adds a dependency to the script classpath.

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -20,7 +20,6 @@ import org.gradle.api.Incubating
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -44,12 +43,6 @@ class ScriptHandlerScope(scriptHandler: ScriptHandler) : ScriptHandler by script
      * The dependencies of the script.
      */
     val dependencies by unsafeLazy { DependencyHandlerScope(scriptHandler.dependencies) }
-
-    /**
-     * The script classpath configuration.
-     */
-    val ConfigurationContainer.classpath: Configuration
-        get() = getByName(CLASSPATH_CONFIGURATION)
 
     /**
      * The script classpath configuration.

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -107,19 +107,32 @@ fun jitProjectSchemaOf(project: Project) =
 
 internal
 fun <T> ProjectSchema<T>.groupedByTarget(): Map<T, ProjectSchema<T>> =
-    (extensions.map { it to EntryKind.Extension } + conventions.map { it to EntryKind.Convention })
+    flatMapGroupedByEntryKind()
         .groupBy { (entry, _) -> entry.target }
         .mapValues { (_, entries) ->
             ProjectSchema(
-                extensions = entries.mapNotNull { (entry, kind) -> entry.takeIf { kind == EntryKind.Extension } },
-                conventions = entries.mapNotNull { (entry, kind) -> entry.takeIf { kind == EntryKind.Convention } },
+                extensions = entries.projectSchemaEntriesOf(EntryKind.Extension),
+                conventions = entries.projectSchemaEntriesOf(EntryKind.Convention),
+                containerElements = entries.projectSchemaEntriesOf(EntryKind.ContainerElement),
                 configurations = emptyList()
             )
         }
 
 
 private
-enum class EntryKind { Extension, Convention }
+fun <T> ProjectSchema<T>.flatMapGroupedByEntryKind() =
+    (extensions.map { it to EntryKind.Extension }
+        + conventions.map { it to EntryKind.Convention }
+        + containerElements.map { it to EntryKind.ContainerElement })
+
+
+private
+fun <T> List<Pair<ProjectSchemaEntry<T>, EntryKind>>.projectSchemaEntriesOf(entryKind: EntryKind) =
+    mapNotNull { (entry, kind) -> entry.takeIf { kind == entryKind } }
+
+
+private
+enum class EntryKind { Extension, Convention, ContainerElement }
 
 
 internal
@@ -573,6 +586,7 @@ fun writeAccessorsTo(writer: BufferedWriter, accessors: Sequence<String>, import
         write(fileHeader)
         newLine()
         appendln("import org.gradle.api.Incubating")
+        appendln("import org.gradle.api.NamedDomainObjectProvider")
         appendln("import org.gradle.api.Project")
         appendln("import org.gradle.api.artifacts.Configuration")
         appendln("import org.gradle.api.artifacts.ConfigurationContainer")

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/CodeGenerator.kt
@@ -237,12 +237,6 @@ fun configurationAccessorFor(name: AccessorNameSpec): String? = name.run {
     codeForAccessor(name) {
         """
             /**
-             * The '$original' configuration.
-             */
-            val ConfigurationContainer.`$kotlinIdentifier`: Configuration
-                get() = getByName("$stringLiteral")
-
-            /**
              * Adds a dependency to the '$original' configuration.
              *
              * @param dependencyNotation notation for the dependency to be added.

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaProvider.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaProvider.kt
@@ -38,6 +38,7 @@ interface ProjectSchemaProvider {
 data class ProjectSchema<out T>(
     val extensions: List<ProjectSchemaEntry<T>>,
     val conventions: List<ProjectSchemaEntry<T>>,
+    val containerElements: List<ProjectSchemaEntry<T>>,
     val configurations: List<String>
 ) : Serializable {
 
@@ -45,10 +46,14 @@ data class ProjectSchema<out T>(
         ProjectSchema(
             extensions.map { it.map(f) },
             conventions.map { it.map(f) },
+            containerElements.map { it.map(f) },
             configurations.toList())
 
     fun isNotEmpty(): Boolean =
-        extensions.isNotEmpty() || conventions.isNotEmpty() || configurations.isNotEmpty()
+        extensions.isNotEmpty()
+            || conventions.isNotEmpty()
+            || containerElements.isNotEmpty()
+            || configurations.isNotEmpty()
 }
 
 
@@ -77,6 +82,7 @@ fun loadMultiProjectSchemaFrom(file: File) =
         ProjectSchema(
             extensions = loadSchemaEntryListFrom(value["extensions"]),
             conventions = loadSchemaEntryListFrom(value["conventions"]),
+            containerElements = loadSchemaEntryListFrom(value["containerElements"]),
             configurations = value["configurations"] as? List<String> ?: emptyList())
     }
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinDslAccessorsSnapshotTaskIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinDslAccessorsSnapshotTaskIntegrationTest.kt
@@ -39,189 +39,186 @@ class KotlinDslAccessorsSnapshotTaskIntegrationTest : AbstractIntegrationTest() 
         val generatedSchema =
             loadMultiProjectSchemaFrom(
                 existing("gradle/project-schema.json"))
+                .mapValues { (_, entry) ->
+                    entry.sortedForComparison()
+                }
 
         val expectedSchema =
             mapOf(
-                ":" to baseProjectSchema,
-                ":sub-groovy" to groovyProjectSchema,
-                ":sub-java" to javaProjectSchema,
-                ":sub-kotlin-dsl" to kotlinDslProjectSchema)
+                ":" to rootProjectSchema.sortedForComparison(),
+                ":sub-groovy" to groovyProjectSchema.sortedForComparison(),
+                ":sub-java" to javaProjectSchema.sortedForComparison(),
+                ":sub-kotlin-dsl" to kotlinDslProjectSchema.sortedForComparison())
 
-        assertThat(
-            generatedSchema,
-            equalTo(expectedSchema))
+        val projectPaths = listOf(":", ":sub-java", ":sub-groovy", ":sub-kotlin-dsl")
+
+        assertThat(generatedSchema.keys, equalTo(projectPaths.toSet()))
+
+        projectPaths.forEach { projectPath ->
+            mapOf(
+                "extensions" to { schema: ProjectSchema<String> -> schema.extensions },
+                "conventions" to { schema: ProjectSchema<String> -> schema.conventions },
+                "containerElements" to { schema: ProjectSchema<String> -> schema.containerElements },
+                "configurations" to { schema: ProjectSchema<String> -> schema.configurations }
+            ).forEach { schemaPartName, schemaPartSupplier ->
+                schemaPartSupplier(generatedSchema[projectPath]!!)
+                assertThat(
+                    "$schemaPartName of '$projectPath'",
+                    schemaPartSupplier(generatedSchema[projectPath]!!),
+                    equalTo(schemaPartSupplier(expectedSchema[projectPath]!!))
+                )
+            }
+        }
     }
 }
 
 
 private
-val baseProjectSchema = ProjectSchema(
+fun ProjectSchema<String>.sortedForComparison(): ProjectSchema<String> =
+    ProjectSchema(
+        extensions.sortedWith(projectSchemaEntryComparator),
+        conventions.sortedWith(projectSchemaEntryComparator),
+        containerElements.sortedWith(projectSchemaEntryComparator),
+        configurations.sorted()
+    )
+
+
+private
+val projectSchemaEntryComparator = Comparator { left: ProjectSchemaEntry<String>, right: ProjectSchemaEntry<String> ->
+    "${left.target}#${left.name}#${left.type}".compareTo("${right.target}#${right.name}#${right.type}")
+}
+
+
+private
+operator fun ProjectSchema<String>.plus(schema: ProjectSchema<String>) =
+    ProjectSchema(
+        extensions + schema.extensions,
+        conventions + schema.conventions,
+        containerElements + schema.containerElements,
+        configurations + schema.configurations
+    )
+
+
+private
+val defaultProjectSchema = ProjectSchema(
     extensions = listOf(
-        ProjectSchemaEntry(
-            "org.gradle.api.Project",
-            "ext",
-            "org.gradle.api.plugins.ExtraPropertiesExtension"),
-        ProjectSchemaEntry(
-            "org.gradle.api.Project",
-            "defaultArtifacts",
-            "org.gradle.api.internal.plugins.DefaultArtifactPublicationSet"),
-        ProjectSchemaEntry(
-            "org.gradle.api.internal.plugins.DefaultArtifactPublicationSet",
-            "ext",
-            "org.gradle.api.plugins.ExtraPropertiesExtension")),
+        ProjectSchemaEntry("org.gradle.api.Project", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension")
+    ),
+    conventions = emptyList(),
+    containerElements = emptyList(),
+    configurations = emptyList()
+)
+
+
+private
+val baseProjectSchema = defaultProjectSchema + ProjectSchema(
+    extensions = listOf(
+        ProjectSchemaEntry("org.gradle.api.Project", "defaultArtifacts", "org.gradle.api.internal.plugins.DefaultArtifactPublicationSet"),
+        ProjectSchemaEntry("org.gradle.api.internal.plugins.DefaultArtifactPublicationSet", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension")
+    ),
     conventions = listOf(
-        ProjectSchemaEntry(
-            "org.gradle.api.Project",
-            "base",
-            "org.gradle.api.plugins.BasePluginConvention")),
-    configurations = listOf("archives", "default"))
+        ProjectSchemaEntry("org.gradle.api.Project", "base", "org.gradle.api.plugins.BasePluginConvention")
+    ),
+    containerElements = listOf(
+        existingConfigurationContainerElement("archives"),
+        existingConfigurationContainerElement("default")
+    ),
+    configurations = listOf(
+        "archives", "default"
+    )
+)
 
 
 private
-fun javaExtensionsWith(otherExtensions: List<ProjectSchemaEntry<String>>) =
-    baseProjectSchema.extensions +
-        listOf(
-            ProjectSchemaEntry(
-                "org.gradle.api.Project",
-                "reporting",
-                "org.gradle.api.reporting.ReportingExtension"),
-            ProjectSchemaEntry(
-                "org.gradle.api.reporting.ReportingExtension",
-                "ext",
-                "org.gradle.api.plugins.ExtraPropertiesExtension"),
-            ProjectSchemaEntry(
-                "org.gradle.api.Project",
-                "sourceSets",
-                "org.gradle.api.tasks.SourceSetContainer"),
-            ProjectSchemaEntry(
-                "org.gradle.api.tasks.SourceSetContainer",
-                "ext",
-                "org.gradle.api.plugins.ExtraPropertiesExtension"),
-            ProjectSchemaEntry(
-                "org.gradle.api.Project",
-                "java",
-                "org.gradle.api.plugins.JavaPluginExtension"),
-            ProjectSchemaEntry(
-                "org.gradle.api.plugins.JavaPluginExtension",
-                "ext",
-                "org.gradle.api.plugins.ExtraPropertiesExtension")
-        ) +
-        otherExtensions +
-        listOf(
-            ProjectSchemaEntry(
-                "org.gradle.api.tasks.SourceSet",
-                "ext",
-                "org.gradle.api.plugins.ExtraPropertiesExtension"))
+val rootProjectSchema = baseProjectSchema + ProjectSchema(
+    extensions = emptyList(),
+    conventions = emptyList(),
+    containerElements = emptyList(),
+    configurations = emptyList()
+)
 
 
 private
-val javaProjectSchema: ProjectSchema<String> =
-    ProjectSchema(
-        extensions = javaExtensionsWith(emptyList()),
-        conventions = baseProjectSchema.conventions + listOf(
-            ProjectSchemaEntry(
-                "org.gradle.api.Project",
-                "java",
-                "org.gradle.api.plugins.JavaPluginConvention")),
-        configurations = (baseProjectSchema.configurations + listOf(
-            "annotationProcessor",
-            "apiElements",
-            "compile", "compileClasspath", "compileOnly",
-            "implementation",
-            "runtime", "runtimeClasspath", "runtimeElements", "runtimeOnly",
-            "testAnnotationProcessor",
-            "testCompile", "testCompileClasspath", "testCompileOnly",
-            "testImplementation",
-            "testRuntime", "testRuntimeClasspath", "testRuntimeOnly")).sorted())
+val javaProjectSchema: ProjectSchema<String> = listOf(
+    "annotationProcessor",
+    "apiElements",
+    "compile", "compileClasspath", "compileOnly",
+    "implementation",
+    "runtime", "runtimeClasspath", "runtimeElements", "runtimeOnly",
+    "testAnnotationProcessor",
+    "testCompile", "testCompileClasspath", "testCompileOnly",
+    "testImplementation",
+    "testRuntime", "testRuntimeClasspath", "testRuntimeOnly"
+).let { configurationNames ->
+
+    baseProjectSchema + ProjectSchema(
+        extensions = listOf(
+            ProjectSchemaEntry("org.gradle.api.Project", "reporting", "org.gradle.api.reporting.ReportingExtension"),
+            ProjectSchemaEntry("org.gradle.api.Project", "sourceSets", "org.gradle.api.tasks.SourceSetContainer"),
+            ProjectSchemaEntry("org.gradle.api.Project", "java", "org.gradle.api.plugins.JavaPluginExtension"),
+            ProjectSchemaEntry("org.gradle.api.plugins.JavaPluginExtension", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
+            ProjectSchemaEntry("org.gradle.api.reporting.ReportingExtension", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
+            ProjectSchemaEntry("org.gradle.api.tasks.SourceSetContainer", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
+            ProjectSchemaEntry("org.gradle.api.tasks.SourceSet", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension")
+        ),
+        conventions = listOf(
+            ProjectSchemaEntry("org.gradle.api.Project", "java", "org.gradle.api.plugins.JavaPluginConvention")
+        ),
+        containerElements = configurationNames.map(::existingConfigurationContainerElement),
+        configurations = configurationNames
+    )
+}
 
 
 private
-val groovyProjectSchema: ProjectSchema<String> =
-    ProjectSchema(
-        extensions = javaExtensionsWith(
-            listOf(
-                ProjectSchemaEntry(
-                    "org.gradle.api.Project",
-                    "groovyRuntime",
-                    "org.gradle.api.tasks.GroovyRuntime"),
-                ProjectSchemaEntry(
-                    "org.gradle.api.tasks.GroovyRuntime",
-                    "ext",
-                    "org.gradle.api.plugins.ExtraPropertiesExtension"))),
-        conventions = javaProjectSchema.conventions,
-        configurations = javaProjectSchema.configurations)
+val groovyProjectSchema: ProjectSchema<String> = javaProjectSchema + ProjectSchema(
+    extensions = listOf(
+        ProjectSchemaEntry("org.gradle.api.Project", "groovyRuntime", "org.gradle.api.tasks.GroovyRuntime"),
+        ProjectSchemaEntry("org.gradle.api.tasks.GroovyRuntime", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension")
+    ),
+    conventions = emptyList(),
+    containerElements = emptyList(),
+    configurations = emptyList()
+)
 
 
 private
-val kotlinDslProjectSchema: ProjectSchema<String> =
-    ProjectSchema(
-        extensions = javaExtensionsWith(
-            listOf(
-                ProjectSchemaEntry(
-                    "org.gradle.api.Project",
-                    "kotlin",
-                    "org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension"),
-                ProjectSchemaEntry(
-                    "org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension",
-                    "ext",
-                    "org.gradle.api.plugins.ExtraPropertiesExtension"),
+val kotlinDslProjectSchema: ProjectSchema<String> = listOf(
+    "api", "apiDependenciesMetadata",
+    "compileOnlyDependenciesMetadata",
+    "embeddedKotlin",
+    "implementationDependenciesMetadata",
+    "kapt",
+    "kaptTest",
+    "kotlinCompilerClasspath",
+    "kotlinCompilerPluginClasspath",
+    "runtimeOnlyDependenciesMetadata",
+    "testApi", "testApiDependenciesMetadata",
+    "testCompileOnlyDependenciesMetadata",
+    "testImplementationDependenciesMetadata",
+    "testRuntimeOnlyDependenciesMetadata"
+).let { configurationNames ->
+    javaProjectSchema + ProjectSchema(
+        extensions = listOf(
+            ProjectSchemaEntry("org.gradle.api.Project", "kotlin", "org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension"),
+            ProjectSchemaEntry("org.gradle.api.Project", "kotlinDslPluginOptions", "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPluginOptions"),
+            ProjectSchemaEntry("org.gradle.api.Project", "samWithReceiver", "org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension"),
+            ProjectSchemaEntry("org.gradle.api.Project", "kotlinScripting", "org.jetbrains.kotlin.gradle.scripting.ScriptingExtension"),
+            ProjectSchemaEntry("org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension", "experimental", "org.jetbrains.kotlin.gradle.dsl.ExperimentalExtension"),
+            ProjectSchemaEntry("org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension", "sourceSets", "org.gradle.api.NamedDomainObjectContainer<org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet>"),
+            ProjectSchemaEntry("org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
+            ProjectSchemaEntry("org.jetbrains.kotlin.gradle.dsl.ExperimentalExtension", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
+            ProjectSchemaEntry("org.gradle.api.NamedDomainObjectContainer<org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet>", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
+            ProjectSchemaEntry("org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
+            ProjectSchemaEntry("org.jetbrains.kotlin.gradle.scripting.ScriptingExtension", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension")
+        ),
+        conventions = emptyList(),
+        containerElements = configurationNames.map(::existingConfigurationContainerElement),
+        configurations = configurationNames
+    )
+}
 
-                ProjectSchemaEntry(
-                    "org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension",
-                    "experimental",
-                    "org.jetbrains.kotlin.gradle.dsl.ExperimentalExtension"),
-                ProjectSchemaEntry(
-                    "org.jetbrains.kotlin.gradle.dsl.ExperimentalExtension",
-                    "ext",
-                    "org.gradle.api.plugins.ExtraPropertiesExtension"),
 
-                ProjectSchemaEntry(
-                    "org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension",
-                    "sourceSets",
-                    "org.gradle.api.NamedDomainObjectContainer<org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet>"
-                ),
-                ProjectSchemaEntry(
-                    "org.gradle.api.NamedDomainObjectContainer<org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet>",
-                    "ext",
-                    "org.gradle.api.plugins.ExtraPropertiesExtension"
-                ),
-
-                ProjectSchemaEntry(
-                    "org.gradle.api.Project",
-                    "kotlinDslPluginOptions",
-                    "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPluginOptions"),
-
-                ProjectSchemaEntry(
-                    "org.gradle.api.Project",
-                    "samWithReceiver",
-                    "org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension"),
-                ProjectSchemaEntry(
-                    "org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension",
-                    "ext",
-                    "org.gradle.api.plugins.ExtraPropertiesExtension"),
-
-                ProjectSchemaEntry(
-                    target = "org.gradle.api.Project",
-                    name = "kotlinScripting",
-                    type = "org.jetbrains.kotlin.gradle.scripting.ScriptingExtension"),
-                ProjectSchemaEntry(
-                    target = "org.jetbrains.kotlin.gradle.scripting.ScriptingExtension",
-                    name = "ext",
-                    type = "org.gradle.api.plugins.ExtraPropertiesExtension")
-            )),
-        conventions = javaProjectSchema.conventions,
-        configurations = (javaProjectSchema.configurations + listOf(
-            "api", "apiDependenciesMetadata",
-            "compileOnlyDependenciesMetadata",
-            "embeddedKotlin",
-            "implementationDependenciesMetadata",
-            "kapt",
-            "kaptTest",
-            "kotlinCompilerClasspath",
-            "kotlinCompilerPluginClasspath",
-            "runtimeOnlyDependenciesMetadata",
-            "testApi", "testApiDependenciesMetadata",
-            "testCompileOnlyDependenciesMetadata",
-            "testImplementationDependenciesMetadata",
-            "testRuntimeOnlyDependenciesMetadata"
-        )).sorted())
+private
+fun existingConfigurationContainerElement(name: String) =
+    ProjectSchemaEntry("org.gradle.api.NamedDomainObjectContainer<org.gradle.api.artifacts.Configuration>", name, "org.gradle.api.internal.artifacts.configurations.DefaultConfiguration")

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -181,6 +181,7 @@ class ProjectSchemaTest : TestWithClassPath() {
                     ProjectSchemaEntry("Project", "base", "Base"),
                     ProjectSchemaEntry("Task", "meta", "Meta")
                 ),
+                containerElements = emptyList(),
                 configurations = listOf(
                     "api",
                     "implementation"
@@ -202,6 +203,7 @@ class ProjectSchemaTest : TestWithClassPath() {
                         conventions = listOf(
                             ProjectSchemaEntry("Project", "base", "Base")
                         ),
+                        containerElements = emptyList(),
                         configurations = emptyList()
                     ),
 
@@ -212,6 +214,7 @@ class ProjectSchemaTest : TestWithClassPath() {
                         conventions = listOf(
                             ProjectSchemaEntry("Task", "meta", "Meta")
                         ),
+                        containerElements = emptyList(),
                         configurations = emptyList()
                     )
                 )
@@ -224,6 +227,7 @@ class ProjectSchemaTest : TestWithClassPath() {
         ProjectSchema(
             extensions = pairs.map { ProjectSchemaEntry(Project::class.java.name!!, it.first, it.second) },
             conventions = emptyList(),
+            containerElements = emptyList(),
             configurations = emptyList())
 
     private


### PR DESCRIPTION
by generating accessors to the existing container elements, leveraging `NamedDomainObjectCollection.collectionSchema`.

Those extensions expose the internal `DefaultConfiguration` type because of https://github.com/gradle/gradle-native/issues/856

Old accessors removed as they conflict with the new and work in less situations. Extensions were added to provide source-compatibility to scripts that were using the old accessors, marked as deprecated and with IDE guidance for replacement.

With the example from the original report in #1118 this is now possible:
```kotlin
configurations {
    implementation {
        exclude(group = "org.foo")
    }
}
```
