### PR TITLE
Refine messages reported to the IDE editor and their lifecycle

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorMessages.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorMessages.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.resolver
+
+
+object EditorMessages {
+
+    const val failure = "Script dependencies resolution failed"
+    const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
+
+    private
+    const val forMoreInformation = "run 'gradle tasks' for more information"
+
+    const val buildConfigurationFailed = "Build configuration failed, $forMoreInformation"
+    const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, $forMoreInformation"
+
+
+    fun defaultErrorMessageFor(cause: Throwable) =
+        "${cause::class.java.name}, $forMoreInformation"
+}

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorMessages.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorMessages.kt
@@ -19,16 +19,18 @@ package org.gradle.kotlin.dsl.resolver
 
 object EditorMessages {
 
-    const val failure = "Script dependencies resolution failed"
-    const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
+    private
+    const val ideLogs = "see IDE logs for more information"
+
+    const val failure = "Script dependencies resolution failed, $ideLogs"
+    const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies, $ideLogs"
 
     private
-    const val forMoreInformation = "run 'gradle tasks' for more information"
+    const val gradleTasks = "run 'gradle tasks' for more information"
 
-    const val buildConfigurationFailed = "Build configuration failed, $forMoreInformation"
-    const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, $forMoreInformation"
-
+    const val buildConfigurationFailed = "Build configuration failed, $gradleTasks"
+    const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, $gradleTasks"
 
     fun defaultErrorMessageFor(cause: Throwable) =
-        "${cause::class.java.name}, $forMoreInformation"
+        "${cause::class.java.name}, $gradleTasks"
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorReports.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorReports.kt
@@ -17,20 +17,30 @@
 package org.gradle.kotlin.dsl.resolver
 
 
+object EditorReports {
+
+    const val locationAwareEditorHintsPropertyName = "org.gradle.kotlin.dsl.internal.locationAwareEditorHints"
+}
+
+
 object EditorMessages {
 
     private
     const val ideLogs = "see IDE logs for more information"
 
+    internal
     const val failure = "Script dependencies resolution failed, $ideLogs"
+
+    internal
     const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies, $ideLogs"
 
     private
     const val gradleTasks = "run 'gradle tasks' for more information"
 
     const val buildConfigurationFailed = "Build configuration failed, $gradleTasks"
+
     const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, $gradleTasks"
 
-    fun defaultErrorMessageFor(cause: Throwable) =
-        "${cause::class.java.name}, $gradleTasks"
+    fun defaultLocationAwareHintMessageFor(runtimeFailure: Throwable) =
+        "${runtimeFailure::class.java.name}, $gradleTasks"
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -72,7 +72,7 @@ fun EditorReportSeverity.toIdeSeverity(): ReportSeverity =
 
 private
 fun EditorPosition.toIdePosition(): Position =
-    Position(line, column)
+    Position(if (line == 0) 0 else line - 1, column)
 
 
 class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -20,7 +20,6 @@ package org.gradle.kotlin.dsl.resolver
 import org.gradle.kotlin.dsl.concurrent.EventLoop
 import org.gradle.kotlin.dsl.concurrent.future
 
-import org.gradle.kotlin.dsl.tooling.models.EditorMessages
 import org.gradle.kotlin.dsl.tooling.models.EditorPosition
 import org.gradle.kotlin.dsl.tooling.models.EditorReport
 import org.gradle.kotlin.dsl.tooling.models.EditorReportSeverity

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -59,9 +59,7 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
     object Messages {
         const val failure = "Script dependencies resolution failed"
         const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
-        const val exceptions = "There were some errors during script dependencies resolution, some dependencies might be missing"
-        const val exceptionsUsingPrevious = "There were some errors during script dependencies resolution, using previous dependencies"
-
+        const val exceptions = "There were some errors during script dependencies resolution"
     }
 
     private
@@ -130,7 +128,7 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
             previousDependencies != null && previousDependencies.classpath.count() > response.classPath.size ->
                 previousDependencies.also {
                     logger.log(ResolvedToPreviousWithErrors(scriptFile, previousDependencies, response.exceptions))
-                    report.warning(Messages.exceptionsUsingPrevious)
+                    report.warning(Messages.exceptions)
                 }
             else ->
                 dependenciesFrom(response).also {

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -47,13 +47,13 @@ typealias Report = (ReportSeverity, String, Position?) -> Unit
 
 
 private
-fun Report.warning(message: String, position: Position? = null) =
-    invoke(ReportSeverity.WARNING, message, position)
+fun Report.error(message: String, position: Position? = null) =
+    invoke(ReportSeverity.ERROR, message, position)
 
 
 private
-fun Report.error(message: String, position: Position? = null) =
-    invoke(ReportSeverity.ERROR, message, position)
+fun Report.fatal(message: String, position: Position? = null) =
+    invoke(ReportSeverity.FATAL, message, position)
 
 
 private
@@ -115,8 +115,8 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
                 previousDependencies)
         } catch (e: Exception) {
             logger.log(ResolutionFailure(script.file, e))
-            if (previousDependencies == null) report.error(EditorMessages.failure)
-            else report.warning(EditorMessages.failureUsingPrevious)
+            if (previousDependencies == null) report.fatal(EditorMessages.failure)
+            else report.error(EditorMessages.failureUsingPrevious)
             previousDependencies
         }
     }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -38,9 +38,15 @@ import kotlin.reflect.full.declaredMemberProperties
 
 
 internal
-object ResolverEventLogger {
+interface ResolverEventLogger {
+    fun log(event: ResolverEvent)
+}
 
-    fun log(event: ResolverEvent) {
+
+internal
+object DefaultResolverEventLogger : ResolverEventLogger {
+
+    override fun log(event: ResolverEvent) {
         eventLoop.accept(now() to event)
     }
 
@@ -98,7 +104,7 @@ object ResolverEventLogger {
     private
     fun now() = GregorianCalendar.getInstance().time
 
-    private
+    internal
     fun prettyPrint(e: ResolverEvent): String = e.run {
         when (this) {
             is SubmittedModelRequest ->

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -151,6 +151,7 @@ object DefaultResolverEventLogger : ResolverEventLogger {
                 "classPath" to compactStringFor(classPath),
                 "sourcePath" to compactStringFor(sourcePath),
                 "implicitImports" to compactStringFor(implicitImports, '.'),
+                "editorReports" to editorReports.toString(),
                 "exceptions" to stringForExceptions(exceptions, indentation)),
             indentation)
     }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -16,10 +16,10 @@
 
 package org.gradle.kotlin.dsl.resolver
 
-import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver.Messages
-
 import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.customInstallation
+
+import org.gradle.kotlin.dsl.tooling.models.EditorMessages
 
 import kotlin.script.dependencies.KotlinScriptExternalDependencies
 import kotlin.script.dependencies.ScriptContents
@@ -146,7 +146,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
 
         recorder.apply {
             assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
-            assertSingleFileWarningReport(Messages.exceptions)
+            assertSingleFileWarningReport(EditorMessages.exceptions)
         }
     }
 
@@ -168,7 +168,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
 
         recorder.apply {
             assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
-            assertSingleFileWarningReport(Messages.exceptions)
+            assertSingleFileWarningReport(EditorMessages.exceptions)
         }
     }
 
@@ -186,7 +186,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
 
         recorder.apply {
             assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
-            assertSingleFileWarningReport(Messages.exceptions)
+            assertSingleFileWarningReport(EditorMessages.exceptions)
         }
     }
 
@@ -205,7 +205,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
 
         recorder.apply {
             assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
-            assertSingleFileWarningReport(Messages.exceptions)
+            assertSingleFileWarningReport(EditorMessages.exceptions)
         }
     }
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -229,7 +229,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
             environment(*env),
             recorder,
             null
-        ).get()!!
+        ).get().also { assertThat("resolved script dependencies", it, notNullValue()) }!!
 
     private
     fun withPrecompiledScriptBuildSrc() {

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.resolver
+
+import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependenciesResolver.Messages
+
+import org.gradle.kotlin.dsl.fixtures.AbstractIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.customInstallation
+
+import kotlin.script.dependencies.KotlinScriptExternalDependencies
+import kotlin.script.dependencies.ScriptContents
+import kotlin.script.dependencies.ScriptContents.Position
+import kotlin.script.dependencies.ScriptDependenciesResolver.ReportSeverity
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.hasItems
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+import java.io.File
+
+import kotlin.reflect.KClass
+
+
+class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `succeeds with no script`() {
+
+        withDefaultSettings()
+        assertSucceeds()
+    }
+
+    @Test
+    fun `succeeds on init script`() {
+
+        withDefaultSettings()
+        assertSucceeds(withFile("my.init.gradle.kts", """
+            require(this is Gradle)
+        """))
+    }
+
+    @Test
+    fun `succeeds on settings script`() {
+
+        assertSucceeds(withSettings("""
+            require(this is Settings)
+        """))
+
+        recorder.clear()
+
+        assertSucceeds(withFile("my.settings.gradle.kts", """
+            require(this is Settings)
+        """))
+    }
+
+    @Test
+    fun `succeeds on project script`() {
+
+        withDefaultSettings()
+        assertSucceeds(withFile("build.gradle.kts", """
+            require(this is Project)
+        """))
+
+        recorder.clear()
+
+        assertSucceeds(withFile("plugin.gradle.kts", """
+            require(this is Project)
+        """))
+    }
+
+    @Test
+    fun `succeeds on precompiled init script`() {
+
+        withPrecompiledScriptBuildSrc()
+
+        withDefaultSettings()
+
+        assertSucceeds(withFile("buildSrc/src/main/kotlin/my-plugin.init.gradle.kts", """
+            require(this is Gradle)
+        """))
+    }
+
+    @Test
+    fun `succeeds on precompiled settings script`() {
+
+        withPrecompiledScriptBuildSrc()
+
+        withSettings("""
+            apply(plugin = "my-plugin")
+        """)
+
+        assertSucceeds(withFile("buildSrc/src/main/kotlin/my-plugin.settings.gradle.kts", """
+            require(this is Settings)
+        """))
+    }
+
+
+    @Test
+    fun `succeeds on precompiled project script`() {
+
+        withPrecompiledScriptBuildSrc()
+
+        withDefaultSettings()
+        withBuildScript("""
+            plugins {
+                id("my-plugin")
+            }
+        """)
+
+        assertSucceeds(withFile("buildSrc/src/main/kotlin/my-plugin.gradle.kts", """
+            require(this is Project)
+        """))
+    }
+
+    @Test
+    fun `report file warning on script compilation failure in currently edited script`() {
+
+        withDefaultSettings()
+        val editedScript = withBuildScript("""
+            doNotExists()
+        """)
+
+        resolvedScriptDependencies(editedScript).apply {
+            assertContainsBasicDependencies()
+        }
+
+        recorder.apply {
+            assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
+            assertSingleFileWarningReport(Messages.exceptions)
+        }
+    }
+
+    @Test
+    fun `report file warning on script compilation failure in another script`() {
+
+        withSettings("""
+            include("a", "b")
+        """)
+        withBuildScript("")
+        withBuildScriptIn("a", """
+            doNotExists()
+        """)
+        val editedScript = withBuildScriptIn("b", "")
+
+        resolvedScriptDependencies(editedScript).apply {
+            assertContainsBasicDependencies()
+        }
+
+        recorder.apply {
+            assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
+            assertSingleFileWarningReport(Messages.exceptions)
+        }
+    }
+
+    @Test
+    fun `report file warning on runtime failure in currently edited script`() {
+
+        withDefaultSettings()
+        val editedScript = withBuildScript("""
+            configurations.getByName("doNotExists")
+        """)
+
+        resolvedScriptDependencies(editedScript).apply {
+            assertContainsBasicDependencies()
+        }
+
+        recorder.apply {
+            assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
+            assertSingleFileWarningReport(Messages.exceptions)
+        }
+    }
+
+
+    @Test
+    fun `report file warning on runtime failure in another script`() {
+
+        withDefaultSettings()
+        val editedScript = withBuildScript("""
+            configurations.getByName("doNotExists")
+        """)
+
+        resolvedScriptDependencies(editedScript).apply {
+            assertContainsBasicDependencies()
+        }
+
+        recorder.apply {
+            assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
+            assertSingleFileWarningReport(Messages.exceptions)
+        }
+    }
+
+    private
+    val recorder = ResolverTestRecorder()
+
+    private
+    val resolver = KotlinBuildScriptDependenciesResolver(recorder)
+
+    private
+    fun environment(vararg entries: Pair<String, Any?>) =
+        mapOf(
+            "projectRoot" to projectRoot,
+            "gradleHome" to customInstallation()
+        ) + entries.toMap()
+
+    private
+    fun resolvedScriptDependencies(scriptFile: File? = null, vararg env: Pair<String, Any?>) =
+        resolver.resolve(
+            scriptContentFor(scriptFile),
+            environment(*env),
+            recorder,
+            null
+        ).get()!!
+
+    private
+    fun withPrecompiledScriptBuildSrc() {
+        withDefaultSettingsIn("buildSrc")
+        withBuildScriptIn("buildSrc", """
+            plugins {
+                `java-gradle-plugin`
+                `kotlin-dsl`
+                `kotlin-dsl-precompiled-script-plugins`
+            }
+        """)
+    }
+
+    private
+    fun assertSucceeds(editedScript: File? = null) {
+
+        resolvedScriptDependencies(editedScript).apply {
+            assertContainsBasicDependencies()
+        }
+
+        recorder.apply {
+            assertSuccessScenario()
+        }
+    }
+
+    private
+    fun KotlinScriptExternalDependencies.assertContainsBasicDependencies() {
+        assertTrue(classpath.toList().isNotEmpty())
+        assertTrue(imports.toList().isNotEmpty())
+        assertTrue(sources.toList().isNotEmpty())
+    }
+}
+
+
+private
+fun scriptContentFor(scriptFile: File?) =
+    mock<ScriptContents> {
+        on { file } doReturn scriptFile
+    }
+
+
+private
+class ResolverTestRecorder : ResolverEventLogger, (ReportSeverity, String, Position?) -> Unit {
+
+    data class LogEvent(
+        val event: ResolverEvent,
+        val prettyPrinted: String
+    )
+
+    data class IdeReport(
+        val severity: ReportSeverity,
+        val message: String,
+        val position: Position?
+    )
+
+    val events = mutableListOf<LogEvent>()
+    val reports = mutableListOf<IdeReport>()
+
+    override fun log(event: ResolverEvent) {
+        DefaultResolverEventLogger.prettyPrint(event).let { prettyPrinted ->
+            events.add(LogEvent(event, prettyPrinted))
+        }
+    }
+
+    override fun invoke(severity: ReportSeverity, message: String, position: Position?) {
+        reports.add(IdeReport(severity, message, position))
+    }
+
+    fun clear() {
+        events.clear()
+        reports.clear()
+    }
+
+    fun assertSuccessScenario() {
+        assertThat(
+            events.map { it.event },
+            hasItems(
+                instanceOf(ResolutionRequest::class.java),
+                instanceOf(SubmittedModelRequest::class.java),
+                instanceOf(ReceivedModelResponse::class.java),
+                instanceOf(ResolvedDependencies::class.java)
+            )
+        )
+        assertThat(events.size, equalTo(4))
+        assertTrue(reports.isEmpty())
+    }
+
+    fun <T : ResolverEvent> assertLastEventIsInstanceOf(eventType: KClass<T>) {
+        assertThat(
+            events.last().event,
+            instanceOf(eventType.java)
+        )
+    }
+
+    fun assertSingleFileWarningReport(message: String) {
+        assertThat(reports.size, equalTo(1))
+        reports.single().let { report ->
+            assertThat(report.severity, equalTo(ReportSeverity.WARNING))
+            assertThat(report.position, nullValue())
+            assertThat(report.message, equalTo(message))
+        }
+    }
+}

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -186,7 +186,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
 
         recorder.apply {
             assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
-            assertSingleLineErrorReport("Configuration with name 'doNotExists' not found.", 2)
+            assertSingleLineErrorReport("Configuration with name 'doNotExists' not found.", 1)
         }
     }
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -173,7 +173,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
     }
 
     @Test
-    fun `report file error on runtime failure in currently edited script`() {
+    fun `report file warning on runtime failure in currently edited script`() {
         withDefaultSettings()
         val editedScript = withBuildScript("""
             configurations.getByName("doNotExists")
@@ -185,12 +185,12 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
 
         recorder.apply {
             assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
-            assertSingleFileErrorReport(EditorMessages.buildConfigurationFailedInCurrentScript)
+            assertSingleFileWarningReport(EditorMessages.buildConfigurationFailedInCurrentScript)
         }
     }
 
     @Test
-    fun `report line error on runtime failure in currently edited script when location aware hints are enabled`() {
+    fun `report line warning on runtime failure in currently edited script when location aware hints are enabled`() {
 
         withDefaultSettings()
         withFile("gradle.properties", """
@@ -206,7 +206,7 @@ class KotlinScriptDependenciesResolverTest : AbstractIntegrationTest() {
 
         recorder.apply {
             assertLastEventIsInstanceOf(ResolvedDependenciesWithErrors::class)
-            assertSingleLineErrorReport("Configuration with name 'doNotExists' not found.", 1)
+            assertSingleLineWarningReport("Configuration with name 'doNotExists' not found.", 1)
         }
     }
 
@@ -362,10 +362,6 @@ class ResolverTestRecorder : ResolverEventLogger, (ReportSeverity, String, Posit
         assertSingleFileReport(ReportSeverity.WARNING, message)
     }
 
-    fun assertSingleFileErrorReport(message: String) {
-        assertSingleFileReport(ReportSeverity.ERROR, message)
-    }
-
     fun assertSingleFileReport(severity: ReportSeverity, message: String) {
         assertSingleEditorReport()
         reports.single().let { report ->
@@ -375,10 +371,10 @@ class ResolverTestRecorder : ResolverEventLogger, (ReportSeverity, String, Posit
         }
     }
 
-    fun assertSingleLineErrorReport(message: String, line: Int) {
+    fun assertSingleLineWarningReport(message: String, line: Int) {
         assertSingleEditorReport()
         reports.single().let { report ->
-            assertThat(report.severity, equalTo(ReportSeverity.ERROR))
+            assertThat(report.severity, equalTo(ReportSeverity.WARNING))
             assertThat(report.position, notNullValue())
             assertThat(report.position!!.line, equalTo(line))
             assertThat(report.message, equalTo(message))

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -16,8 +16,6 @@
 
 package org.gradle.kotlin.dsl.resolver
 
-import org.gradle.kotlin.dsl.tooling.models.EditorMessages
-
 import kotlin.script.dependencies.KotlinScriptExternalDependencies
 import kotlin.script.dependencies.ScriptContents
 import kotlin.script.dependencies.ScriptContents.Position

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -16,10 +16,11 @@
 
 package org.gradle.kotlin.dsl.tooling.builders
 
-import org.gradle.kotlin.dsl.tooling.models.EditorMessages
 import org.gradle.kotlin.dsl.tooling.models.EditorPosition
 import org.gradle.kotlin.dsl.tooling.models.EditorReport
 import org.gradle.kotlin.dsl.tooling.models.EditorReportSeverity
+
+import org.gradle.kotlin.dsl.resolver.EditorMessages
 
 import org.gradle.internal.exceptions.LocationAwareException
 

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -26,7 +26,6 @@ import org.gradle.internal.exceptions.LocationAwareException
 
 import java.io.File
 import java.io.Serializable
-import java.util.Scanner
 
 
 internal
@@ -164,13 +163,23 @@ fun File.readLinesRange() =
 
 private
 fun File.countLines(): Long {
-    Scanner(this).use { scanner ->
+    inputStream().buffered().use { input ->
+
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        val newLine = '\n'.toByte()
+
         var count = 0L
-        while (scanner.hasNextLine()) {
-            count++
-            scanner.nextLine()
+        var noNewLineBeforeEOF = false
+        var readCount = input.read(buffer)
+
+        while (readCount != -1) {
+            for (idx in 0 until readCount) {
+                if (buffer[idx] == newLine) count++
+            }
+            noNewLineBeforeEOF = buffer[readCount - 1] != newLine
+            readCount = input.read(buffer)
         }
-        if (scanner.hasNext()) count++
+        if (noNewLineBeforeEOF) count++
         return count
     }
 }

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.tooling.builders
+
+import org.gradle.kotlin.dsl.tooling.models.EditorMessages
+import org.gradle.kotlin.dsl.tooling.models.EditorPosition
+import org.gradle.kotlin.dsl.tooling.models.EditorReport
+import org.gradle.kotlin.dsl.tooling.models.EditorReportSeverity
+
+import java.io.File
+import java.io.Serializable
+
+
+internal
+fun buildEditorReportsFor(scriptFile: File?, exceptions: List<Exception>): List<EditorReport> =
+    if (exceptions.isEmpty()) emptyList()
+    else listOf(
+        wholeFileWarning(EditorMessages.exceptions)
+    )
+
+
+private
+fun wholeFileWarning(message: String) =
+    DefaultEditorReport(EditorReportSeverity.WARNING, message)
+
+
+private
+data class DefaultEditorReport(
+    override val severity: EditorReportSeverity,
+    override val message: String,
+    override val position: EditorPosition? = null
+) : EditorReport, Serializable

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -26,6 +26,7 @@ import org.gradle.internal.exceptions.LocationAwareException
 
 import java.io.File
 import java.io.Serializable
+import java.util.Scanner
 
 
 internal
@@ -153,6 +154,23 @@ data class DefaultEditorPosition(
 ) : EditorPosition, Serializable
 
 
-private
+internal
 fun File.readLinesRange() =
-    1..readLines().size
+    countLines().let { count ->
+        if (count == 0L) 0..0L
+        else 1..count
+    }
+
+
+private
+fun File.countLines(): Long {
+    Scanner(this).use { scanner ->
+        var count = 0L
+        while (scanner.hasNextLine()) {
+            count++
+            scanner.nextLine()
+        }
+        if (scanner.hasNext()) count++
+        return count
+    }
+}

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -42,7 +42,9 @@ fun inferEditorReportsFrom(scriptFile: File, exceptions: Sequence<Exception>): L
     val actualLinesRange = scriptFile.readLinesRange()
     exceptions.runtimeFailuresLocatedIn(scriptFile.path).forEach { failure ->
         if (failure.lineNumber in actualLinesRange) {
-            reports.add(lineError(failure.cause!!.message!!, failure.lineNumber))
+            val cause = failure.cause!!
+            val message = cause.message?.takeIf { it.isNotBlank() } ?: EditorMessages.defaultErrorMessageFor(cause)
+            reports.add(lineError(message, failure.lineNumber))
         } else {
             reports.add(wholeFileError(EditorMessages.buildConfigurationFailedInCurrentScript))
         }
@@ -119,7 +121,7 @@ data class DefaultEditorReport(
 ) : EditorReport, Serializable
 
 
-private
+internal
 data class DefaultEditorPosition(
     override val line: Int,
     override val column: Int = 0

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -73,9 +73,9 @@ fun reportRuntimeExceptionsLocatedIn(
     val actualLinesRange = if (locationAwareHints) scriptFile.readLinesRange() else LongRange.EMPTY
     exceptions.runtimeFailuresLocatedIn(scriptFile.path).forEach { failure ->
         if (locationAwareHints && failure.lineNumber in actualLinesRange) {
-            reports.add(lineError(messageForLocationAwareEditorHint(failure), failure.lineNumber))
+            reports.add(lineWarning(messageForLocationAwareEditorHint(failure), failure.lineNumber))
         } else {
-            reports.add(wholeFileError(EditorMessages.buildConfigurationFailedInCurrentScript))
+            reports.add(wholeFileWarning(EditorMessages.buildConfigurationFailedInCurrentScript))
         }
     }
 }
@@ -138,13 +138,8 @@ fun wholeFileWarning(message: String) =
 
 
 private
-fun wholeFileError(message: String) =
-    DefaultEditorReport(EditorReportSeverity.ERROR, message)
-
-
-private
-fun lineError(message: String, line: Int) =
-    DefaultEditorReport(EditorReportSeverity.ERROR, message, DefaultEditorPosition(line))
+fun lineWarning(message: String, line: Int) =
+    DefaultEditorReport(EditorReportSeverity.WARNING, message, DefaultEditorPosition(line))
 
 
 private

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -29,7 +29,7 @@ internal
 fun buildEditorReportsFor(scriptFile: File?, exceptions: List<Exception>): List<EditorReport> =
     if (exceptions.isEmpty()) emptyList()
     else listOf(
-        wholeFileWarning(EditorMessages.exceptions)
+        wholeFileWarning(EditorMessages.buildConfigurationFailed)
     )
 
 

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -47,6 +47,7 @@ import org.gradle.kotlin.dsl.provider.KotlinScriptClassPathProvider
 import org.gradle.kotlin.dsl.provider.KotlinScriptEvaluator
 import org.gradle.kotlin.dsl.provider.ignoringErrors
 
+import org.gradle.kotlin.dsl.resolver.EditorReports
 import org.gradle.kotlin.dsl.resolver.SourceDistributionResolver
 import org.gradle.kotlin.dsl.resolver.SourcePathProvider
 import org.gradle.kotlin.dsl.resolver.kotlinBuildScriptModelTarget
@@ -319,7 +320,7 @@ data class KotlinScriptTargetModelBuilder(
             (scriptClassPath + accessorsClassPath.bin).asFiles,
             (gradleSource() + classpathSources + accessorsClassPath.src).asFiles,
             implicitImports,
-            buildEditorReportsFor(scriptFile, classPathModeExceptionCollector.exceptions),
+            buildEditorReportsFor(classPathModeExceptionCollector.exceptions),
             classPathModeExceptionCollector.exceptions)
     }
 
@@ -340,6 +341,14 @@ data class KotlinScriptTargetModelBuilder(
 
     val implicitImports
         get() = project.scriptImplicitImports
+
+    private
+    fun buildEditorReportsFor(exceptions: List<Exception>) =
+        buildEditorReportsFor(
+            scriptFile,
+            exceptions,
+            project.isLocationAwareEditorHintsEnabled
+        )
 }
 
 
@@ -404,6 +413,11 @@ val Project.hierarchy: Sequence<Project>
             yield(project)
         }
     }
+
+
+private
+val Project.isLocationAwareEditorHintsEnabled: Boolean
+    get() = findProperty(EditorReports.locationAwareEditorHintsPropertyName) == "true"
 
 
 private

--- a/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
+++ b/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
@@ -40,7 +40,8 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
         val reports = buildEditorReportsFor(
             script,
-            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, 3))
+            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, 3)),
+            true
         )
 
         assertThat(reports.size, equalTo(1))
@@ -58,7 +59,8 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
         val reports = buildEditorReportsFor(
             script,
-            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, 3))
+            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, 3)),
+            true
         )
 
         assertThat(reports.size, equalTo(1))
@@ -80,7 +82,8 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
             listOf(
                 LocationAwareException(java.lang.Exception(null as String?), script.canonicalPath, 1),
                 LocationAwareException(java.lang.Exception(""), script.canonicalPath, 2)
-            )
+            ),
+            true
         )
 
         assertThat(reports.size, equalTo(2))
@@ -88,7 +91,7 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
             assertThat(report.severity, equalTo(EditorReportSeverity.ERROR))
             assertThat(report.position, notNullValue())
             assertThat(report.position!!.line, equalTo(idx + 1))
-            assertThat(report.message, equalTo(EditorMessages.defaultErrorMessageFor(java.lang.Exception())))
+            assertThat(report.message, equalTo(EditorMessages.defaultLocationAwareHintMessageFor(java.lang.Exception())))
         }
     }
 

--- a/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
+++ b/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
@@ -34,7 +34,7 @@ import org.junit.Test
 class EditorReportsBuilderTest : TestWithTempFiles() {
 
     @Test
-    fun `report file error on runtime failure in currently edited script on out of range line number`() {
+    fun `report file warning on runtime failure in currently edited script on out of range line number`() {
 
         val script = withTwoLinesScript()
 
@@ -46,7 +46,7 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
         assertThat(reports.size, equalTo(1))
         reports.single().let { report ->
-            assertThat(report.severity, equalTo(EditorReportSeverity.ERROR))
+            assertThat(report.severity, equalTo(EditorReportSeverity.WARNING))
             assertThat(report.position, nullValue())
             assertThat(report.message, equalTo(EditorMessages.buildConfigurationFailedInCurrentScript))
         }
@@ -65,7 +65,7 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
         assertThat(reports.size, equalTo(1))
         reports.single().let { report ->
-            assertThat(report.severity, equalTo(EditorReportSeverity.ERROR))
+            assertThat(report.severity, equalTo(EditorReportSeverity.WARNING))
             assertThat(report.position, notNullValue())
             assertThat(report.position!!.line, equalTo(3))
             assertThat(report.message, equalTo("BOOM"))
@@ -73,7 +73,7 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
     }
 
     @Test
-    fun `report line error on runtime failure in currently edited script with cause without message`() {
+    fun `report line warning on runtime failure in currently edited script with cause without message`() {
 
         val script = withTwoLinesScript()
 
@@ -88,7 +88,7 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
         assertThat(reports.size, equalTo(2))
         reports.forEachIndexed { idx, report ->
-            assertThat(report.severity, equalTo(EditorReportSeverity.ERROR))
+            assertThat(report.severity, equalTo(EditorReportSeverity.WARNING))
             assertThat(report.position, notNullValue())
             assertThat(report.position!!.line, equalTo(idx + 1))
             assertThat(report.message, equalTo(EditorMessages.defaultLocationAwareHintMessageFor(java.lang.Exception())))

--- a/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
+++ b/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.tooling.builders
+
+import org.gradle.kotlin.dsl.tooling.models.EditorMessages
+import org.gradle.kotlin.dsl.tooling.models.EditorReportSeverity
+
+import org.gradle.internal.exceptions.LocationAwareException
+
+import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+
+class EditorReportsBuilderTest : TestWithTempFiles() {
+
+    @Test
+    fun `report file error on runtime failure in currently edited script on out of range line number`() {
+
+        val script = withTwoLinesScript()
+
+        val reports = buildEditorReportsFor(
+            script,
+            listOf(LocationAwareException(Exception("BOOM"), script.canonicalPath, 3))
+        )
+
+        assertThat(reports.size, equalTo(1))
+        reports.single().let { report ->
+            assertThat(report.severity, equalTo(EditorReportSeverity.ERROR))
+            assertThat(report.position, nullValue())
+            assertThat(report.message, equalTo(EditorMessages.buildConfigurationFailedInCurrentScript))
+        }
+    }
+
+    private
+    fun withTwoLinesScript() =
+        file("empty.gradle.kts").also { it.writeText("\n\n") }
+}

--- a/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
+++ b/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
@@ -24,6 +24,7 @@ import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
 import org.junit.Assert.assertThat
 import org.junit.Test
@@ -46,6 +47,28 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
             assertThat(report.severity, equalTo(EditorReportSeverity.ERROR))
             assertThat(report.position, nullValue())
             assertThat(report.message, equalTo(EditorMessages.buildConfigurationFailedInCurrentScript))
+        }
+    }
+
+    @Test
+    fun `report line error on runtime failure in currently edited script with cause without message`() {
+
+        val script = withTwoLinesScript()
+
+        val reports = buildEditorReportsFor(
+            script,
+            listOf(
+                LocationAwareException(java.lang.Exception(null as String?), script.canonicalPath, 1),
+                LocationAwareException(java.lang.Exception(""), script.canonicalPath, 2)
+            )
+        )
+
+        assertThat(reports.size, equalTo(2))
+        reports.forEachIndexed { idx, report ->
+            assertThat(report.severity, equalTo(EditorReportSeverity.ERROR))
+            assertThat(report.position, notNullValue())
+            assertThat(report.position!!.line, equalTo(idx + 1))
+            assertThat(report.message, equalTo(EditorMessages.defaultErrorMessageFor(java.lang.Exception())))
         }
     }
 

--- a/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
+++ b/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
@@ -16,8 +16,9 @@
 
 package org.gradle.kotlin.dsl.tooling.builders
 
-import org.gradle.kotlin.dsl.tooling.models.EditorMessages
 import org.gradle.kotlin.dsl.tooling.models.EditorReportSeverity
+
+import org.gradle.kotlin.dsl.resolver.EditorMessages
 
 import org.gradle.internal.exceptions.LocationAwareException
 

--- a/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
+++ b/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilderTest.kt
@@ -75,5 +75,5 @@ class EditorReportsBuilderTest : TestWithTempFiles() {
 
     private
     fun withTwoLinesScript() =
-        file("empty.gradle.kts").also { it.writeText("\n\n") }
+        file("two.gradle.kts").also { it.writeText("\n\n") }
 }

--- a/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -51,5 +51,6 @@ interface EditorPosition {
 object EditorMessages {
     const val failure = "Script dependencies resolution failed"
     const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
-    const val exceptions = "There were some errors during script dependencies resolution"
+
+    const val buildConfigurationFailed = "Build configuration failed, run 'gradle tasks' for more information"
 }

--- a/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -36,9 +36,7 @@ interface EditorReport {
 }
 
 
-enum class EditorReportSeverity {
-    WARNING
-}
+enum class EditorReportSeverity { WARNING, ERROR }
 
 
 interface EditorPosition {

--- a/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -23,5 +23,33 @@ interface KotlinBuildScriptModel {
     val classPath: List<File>
     val sourcePath: List<File>
     val implicitImports: List<String>
+    val editorReports: List<EditorReport>
     val exceptions: List<Exception>
+}
+
+
+interface EditorReport {
+
+    val severity: EditorReportSeverity
+    val message: String
+    val position: EditorPosition?
+}
+
+
+enum class EditorReportSeverity {
+    WARNING
+}
+
+
+interface EditorPosition {
+
+    val line: Int
+    val column: Int
+}
+
+
+object EditorMessages {
+    const val failure = "Script dependencies resolution failed"
+    const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
+    const val exceptions = "There were some errors during script dependencies resolution"
 }

--- a/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -50,6 +50,13 @@ object EditorMessages {
     const val failure = "Script dependencies resolution failed"
     const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
 
-    const val buildConfigurationFailed = "Build configuration failed, run 'gradle tasks' for more information"
-    const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, run 'gradle tasks' for more information"
+    private
+    const val forMoreInformation = "run 'gradle tasks' for more information"
+
+    const val buildConfigurationFailed = "Build configuration failed, $forMoreInformation"
+    const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, $forMoreInformation"
+
+
+    fun defaultErrorMessageFor(cause: Throwable) =
+        "${cause::class.java.name}, $forMoreInformation"
 }

--- a/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -51,4 +51,5 @@ object EditorMessages {
     const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
 
     const val buildConfigurationFailed = "Build configuration failed, run 'gradle tasks' for more information"
+    const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, run 'gradle tasks' for more information"
 }

--- a/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -44,19 +44,3 @@ interface EditorPosition {
     val line: Int
     val column: Int
 }
-
-
-object EditorMessages {
-    const val failure = "Script dependencies resolution failed"
-    const val failureUsingPrevious = "Script dependencies resolution failed, using previous dependencies"
-
-    private
-    const val forMoreInformation = "run 'gradle tasks' for more information"
-
-    const val buildConfigurationFailed = "Build configuration failed, $forMoreInformation"
-    const val buildConfigurationFailedInCurrentScript = "This script caused build configuration to fail, $forMoreInformation"
-
-
-    fun defaultErrorMessageFor(cause: Throwable) =
-        "${cause::class.java.name}, $forMoreInformation"
-}


### PR DESCRIPTION
This PR lets text of IDE reports be simpler and actionable and also refine how failures are reported, distinguishing those happening in the currently edited script from those coming from other parts of the build logic. See the added coverage for handled cases.

To try it out:
```
./gradlew customInstallation
```
Then import a build in IntelliJ using the Gradle installation from `./build/custom`

This PR also introduces support for location aware hints for build configuration runtime failures originating from the currently edited script. This feature is disabled by default and can be enabled using an internal property. There are some UX issues to iron out but this will allow us to try it out, see the added coverage.

This PR is part of #89