### PR TITLE
Let the kotlin-dsl plugin configure precompiled script plugins support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,8 @@ allprojects {
     version = "1.0-SNAPSHOT"
 }
 
-val publishedPluginsVersion by extra { "1.0-rc-8" }
-val futurePluginsVersion = "1.0-rc-9"
+val publishedPluginsVersion by extra { "1.0-rc-9" }
+val futurePluginsVersion = "1.0-rc-10"
 project(":plugins") {
     group = "org.gradle.kotlin"
     version = futurePluginsVersion

--- a/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
+++ b/buildSrc/src/main/kotlin/codegen/GenerateKotlinDependencyExtensions.kt
@@ -115,6 +115,19 @@ val PluginDependenciesSpec.`kotlin-dsl`: PluginDependencySpec
 
 
 /**
+ * The `kotlin-dsl.base` plugin.
+ *
+ * Equivalent to `id("org.gradle.kotlin.kotlin-dsl.base") version "$kotlinDslPluginsVersion"`
+ *
+ * You can also use `` `kotlin-dsl-base` version "$kotlinDslPluginsVersion" `` if you want to use a different version.
+ *
+ * @see org.gradle.kotlin.dsl.plugins.base.KotlinDslBasePlugin
+ */
+val PluginDependenciesSpec.`kotlin-dsl-base`: PluginDependencySpec
+    get() = id("org.gradle.kotlin.kotlin-dsl.base") version "$kotlinDslPluginsVersion"
+
+
+/**
  * The `kotlin-dsl.precompiled-script-plugins` plugin.
  *
  * Equivalent to `id("org.gradle.kotlin.kotlin-dsl.precompiled-script-plugins") version "$kotlinDslPluginsVersion"`

--- a/samples/precompiled-script-plugin/plugin/build.gradle.kts
+++ b/samples/precompiled-script-plugin/plugin/build.gradle.kts
@@ -1,7 +1,5 @@
 plugins {
-    `java-gradle-plugin`
     `kotlin-dsl`
-    `kotlin-dsl-precompiled-script-plugins`
     `maven-publish`
 }
 

--- a/samples/project-with-buildSrc/README.md
+++ b/samples/project-with-buildSrc/README.md
@@ -1,7 +1,7 @@
 project-with-buildSrc
 =====================
 
-A build with logic defined in [`buildSrc`](./buildSrc) including a [custom task](./buildSrc/src/main/kotlin/HelloTask.kt#L5) as well as [an extension property and an extension function](./buildSrc/src/main/kotlin/extensions.kt).
+A build with logic defined in [`buildSrc`](./buildSrc) including a [custom task](./buildSrc/src/main/kotlin/HelloTask.kt#L5), a [custom precompiled script plugin](./buildSrc/src/main/kotlin/my-plugin.gradle.kts) as well as [an extension property and an extension function](./buildSrc/src/main/kotlin/extensions.kt).
 
 List the available tasks with:
 

--- a/samples/project-with-buildSrc/build.gradle.kts
+++ b/samples/project-with-buildSrc/build.gradle.kts
@@ -1,3 +1,11 @@
+plugins {
+    // Apply the `my-plugin` defined in buildSrc/src/main/kotlin/my-plugin.gradle.kts
+    id("my-plugin")
+}
+
+my {
+    flag.set(true)
+}
 
 withHelloTask()
 

--- a/samples/project-with-buildSrc/buildSrc/src/main/kotlin/MyProjectExtension.kt
+++ b/samples/project-with-buildSrc/buildSrc/src/main/kotlin/MyProjectExtension.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.gradle.api.model.ObjectFactory
+
+import org.gradle.kotlin.dsl.*
+
+
+open class MyProjectExtension(objects: ObjectFactory) {
+
+    val flag = objects.property<Boolean>()
+}

--- a/samples/project-with-buildSrc/buildSrc/src/main/kotlin/my-plugin.gradle.kts
+++ b/samples/project-with-buildSrc/buildSrc/src/main/kotlin/my-plugin.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val my = extensions.create<MyProjectExtension>("my", project.objects)
+
+tasks.register("myReport") {
+    doLast {
+        println("my.flag = ${my.flag.get()}")
+    }
+}

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
@@ -142,8 +142,6 @@ class GradleApiExtensionsIntegrationTest : AbstractPluginIntegrationTest() {
         withBuildScriptIn("buildSrc", """
             plugins {
                 `kotlin-dsl`
-                `kotlin-dsl-precompiled-script-plugins`
-                `java-gradle-plugin`
             }
 
             $repositoriesBlock

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -830,7 +830,6 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
 
             plugins {
                 `kotlin-dsl`
-                `java-gradle-plugin`
             }
 
             gradlePlugin {

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -11,8 +11,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
         withBuildScript("""
             plugins {
                 `kotlin-dsl`
-                `kotlin-dsl-precompiled-script-plugins`
-                `java-gradle-plugin`
                 id("org.gradle.kotlin.ktlint-convention")
             }
 

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -352,8 +352,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
 
             plugins {
                 `kotlin-dsl`
-                `kotlin-dsl-precompiled-script-plugins`
-                `java-gradle-plugin`
             }
 
             $repositoriesBlock
@@ -581,7 +579,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
         withFile("buildSrc/build.gradle.kts", """
             plugins {
                 `kotlin-dsl`
-                `java-gradle-plugin`
             }
 
             gradlePlugin {
@@ -634,7 +631,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
 
         withBuildScriptIn("buildSrc", """
             plugins {
-                `java-gradle-plugin`
                 `kotlin-dsl`
             }
 
@@ -728,7 +724,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
 
         withBuildScriptIn("buildSrc", """
             plugins {
-                `java-gradle-plugin`
                 `kotlin-dsl`
             }
 

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -35,6 +35,12 @@ bundledGradlePlugin(
     pluginClass = "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPlugin")
 
 bundledGradlePlugin(
+    name = "kotlinDslBase",
+    shortDescription = "Gradle Kotlin DSL Base Plugin",
+    pluginId = "org.gradle.kotlin.kotlin-dsl.base",
+    pluginClass = "org.gradle.kotlin.dsl.plugins.base.KotlinDslBasePlugin")
+
+bundledGradlePlugin(
     name = "kotlinDslCompilerSettings",
     shortDescription = "Gradle Kotlin DSL Compiler Settings",
     pluginId = "org.gradle.kotlin.kotlin-dsl.compiler-settings",

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
@@ -19,12 +19,10 @@ package org.gradle.kotlin.dsl.plugins.base
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
-import org.gradle.api.plugins.JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME
-
 import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslCompilerPlugins
 import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPluginOptions
 import org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
+import org.gradle.kotlin.dsl.plugins.embedded.kotlinArtifactConfigurationNames
 
 import org.gradle.kotlin.dsl.*
 
@@ -48,10 +46,7 @@ class KotlinDslBasePlugin : Plugin<Project> {
         apply<EmbeddedKotlinPlugin>()
         createOptionsExtension()
         apply<KotlinDslCompilerPlugins>()
-        addGradleKotlinDslDependencyTo(
-            COMPILE_ONLY_CONFIGURATION_NAME,
-            TEST_IMPLEMENTATION_CONFIGURATION_NAME
-        )
+        addGradleKotlinDslDependencyTo(kotlinArtifactConfigurationNames)
     }
 
     private
@@ -59,7 +54,7 @@ class KotlinDslBasePlugin : Plugin<Project> {
         extensions.add("kotlinDslPluginOptions", KotlinDslPluginOptions(objects))
 
     private
-    fun Project.addGradleKotlinDslDependencyTo(vararg configurations: String) =
+    fun Project.addGradleKotlinDslDependencyTo(configurations: List<String>) =
         configurations.forEach {
             dependencies.add(it, gradleKotlinDsl())
         }

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.plugins.base
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
+import org.gradle.api.plugins.JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME
+
+import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslCompilerPlugins
+import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPluginOptions
+import org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
+
+import org.gradle.kotlin.dsl.*
+
+
+/**
+ * The `kotlin-dsl-base` plugin.
+ *
+ * - Applies the `embedded-kotlin` plugin
+ * - Adds the `gradleKotlinDsl()` dependency to the `compileOnly` and `testImplementation` configurations
+ * - Configures the Kotlin DSL compiler plugins
+ *
+ * You can use the `kotlinDslPluginOptions` extension of type [KotlinDslPluginOptions] to configure the plugin.
+ *
+ * @see KotlinDslPluginOptions
+ * @see org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
+ */
+class KotlinDslBasePlugin : Plugin<Project> {
+
+    override fun apply(project: Project): Unit = project.run {
+
+        apply<EmbeddedKotlinPlugin>()
+        createOptionsExtension()
+        apply<KotlinDslCompilerPlugins>()
+        addGradleKotlinDslDependencyTo(
+            COMPILE_ONLY_CONFIGURATION_NAME,
+            TEST_IMPLEMENTATION_CONFIGURATION_NAME
+        )
+    }
+
+    private
+    fun Project.createOptionsExtension() =
+        extensions.add("kotlinDslPluginOptions", KotlinDslPluginOptions(objects))
+
+    private
+    fun Project.addGradleKotlinDslDependencyTo(vararg configurations: String) =
+        configurations.forEach {
+            dependencies.add(it, gradleKotlinDsl())
+        }
+}

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
@@ -18,7 +18,10 @@ package org.gradle.kotlin.dsl.plugins.dsl
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-import org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
+import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
+
+import org.gradle.kotlin.dsl.plugins.base.KotlinDslBasePlugin
+import org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins
 
 import org.gradle.kotlin.dsl.*
 
@@ -26,46 +29,20 @@ import org.gradle.kotlin.dsl.*
 /**
  * The `kotlin-dsl` plugin.
  *
- * - Applies the `embedded-kotlin` plugin
- * - Adds the `gradleKotlinDsl()` dependency to the `compileOnly` and `testImplementation` configurations
- * - Configures the Kotlin DSL compiler plugins
+ * - Applies the `java-gradle-plugin` plugin
+ * - Applies the `kotlin-dsl.base` plugin
+ * - Applies the `kotlin-dsl.precompiled-script-plugins` plugin
  *
- * You can use the `kotlinDslPluginOptions` extension of type [KotlinDslPluginOptions] to configure the plugin.
- *
- * @see KotlinDslPluginOptions
- * @see org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
+ * @see JavaGradlePluginPlugin
+ * @see KotlinDslBasePlugin
+ * @see PrecompiledScriptPlugins
  */
 class KotlinDslPlugin : Plugin<Project> {
 
-    override fun apply(project: Project) {
-        project.run {
+    override fun apply(project: Project): Unit = project.run {
 
-            applyEmbeddedKotlinPlugin()
-            createOptionsExtension()
-            applyKotlinDslCompilerPlugins()
-            addGradleKotlinDslDependencyTo("compileOnly", "testImplementation")
-        }
-    }
-
-    private
-    fun Project.applyEmbeddedKotlinPlugin() {
-        plugins.apply(EmbeddedKotlinPlugin::class.java)
-    }
-
-    private
-    fun Project.createOptionsExtension() {
-        extensions.add("kotlinDslPluginOptions", KotlinDslPluginOptions(objects))
-    }
-
-    private
-    fun Project.applyKotlinDslCompilerPlugins() {
-        plugins.apply(KotlinDslCompilerPlugins::class.java)
-    }
-
-    private
-    fun Project.addGradleKotlinDslDependencyTo(vararg configurations: String) {
-        configurations.forEach {
-            dependencies.add(it, gradleKotlinDsl())
-        }
+        apply<JavaGradlePluginPlugin>()
+        apply<KotlinDslBasePlugin>()
+        apply<PrecompiledScriptPlugins>()
     }
 }

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -58,7 +58,7 @@ open class EmbeddedKotlinPlugin @Inject internal constructor(
                 embeddedKotlinConfiguration.name,
                 "stdlib-jdk8", "reflect")
 
-            listOf(COMPILE_ONLY_CONFIGURATION_NAME, TEST_IMPLEMENTATION_CONFIGURATION_NAME).forEach {
+            kotlinArtifactConfigurationNames.forEach {
                 configurations.getByName(it).extendsFrom(embeddedKotlinConfiguration)
             }
 
@@ -83,3 +83,8 @@ fun Logger.warnOnDifferentKotlinVersion(kotlinVersion: String?) {
         )
     }
 }
+
+
+internal
+val kotlinArtifactConfigurationNames =
+    listOf(COMPILE_ONLY_CONFIGURATION_NAME, TEST_IMPLEMENTATION_CONFIGURATION_NAME)

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -19,6 +19,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 
+import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
+import org.gradle.api.plugins.JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME
+
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
@@ -55,7 +58,7 @@ open class EmbeddedKotlinPlugin @Inject internal constructor(
                 embeddedKotlinConfiguration.name,
                 "stdlib-jdk8", "reflect")
 
-            listOf("compileOnly", "testImplementation").forEach {
+            listOf(COMPILE_ONLY_CONFIGURATION_NAME, TEST_IMPLEMENTATION_CONFIGURATION_NAME).forEach {
                 configurations.getByName(it).extendsFrom(embeddedKotlinConfiguration)
             }
 

--- a/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -47,7 +47,6 @@ class KotlinDslPluginTest : AbstractPluginTest() {
         withBuildScript("""
 
             plugins {
-                `java-gradle-plugin`
                 `kotlin-dsl`
             }
 
@@ -102,7 +101,6 @@ class KotlinDslPluginTest : AbstractPluginTest() {
         withBuildScript("""
 
             plugins {
-                `java-gradle-plugin`
                 `kotlin-dsl`
             }
 

--- a/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTest.kt
+++ b/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTest.kt
@@ -18,7 +18,6 @@ import org.gradle.kotlin.dsl.fixtures.assertFailsWith
 import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
 import org.gradle.kotlin.dsl.fixtures.assertStandardOutputOf
 import org.gradle.kotlin.dsl.fixtures.classLoaderFor
-import org.gradle.kotlin.dsl.fixtures.joinLines
 import org.gradle.kotlin.dsl.fixtures.withFolders
 
 import org.gradle.kotlin.dsl.precompile.PrecompiledInitScript
@@ -100,7 +99,7 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
         // given:
         val expectedMessage = "Not on my watch!"
 
-        withKotlinDslPluginPlus()
+        withKotlinDslPlugin()
 
         withFile("src/main/kotlin/my-project-script.gradle.kts", """
             throw IllegalStateException("$expectedMessage")
@@ -195,7 +194,7 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
 
                 withFile(
                     "build.gradle.kts",
-                    scriptWithKotlinDslPluginPlus())
+                    scriptWithKotlinDslPlugin())
             }
         }
 
@@ -357,7 +356,7 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
 
     private
     fun givenPrecompiledKotlinScript(fileName: String, code: String) {
-        withKotlinDslPluginPlus()
+        withKotlinDslPlugin()
         withFile("src/main/kotlin/$fileName", code)
         compileKotlin()
     }
@@ -374,15 +373,14 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
             .loadClass(className)
 
     private
-    fun withKotlinDslPluginPlus(vararg additionalPlugins: String) =
-        withBuildScript(scriptWithKotlinDslPluginPlus(*additionalPlugins))
+    fun withKotlinDslPlugin() =
+        withBuildScript(scriptWithKotlinDslPlugin())
 
     private
-    fun scriptWithKotlinDslPluginPlus(vararg additionalPlugins: String): String =
+    fun scriptWithKotlinDslPlugin(): String =
         """
             plugins {
                 `kotlin-dsl`
-                ${additionalPlugins.asIterable().joinLines { "`$it`" }}
             }
 
             $repositoriesBlock

--- a/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTest.kt
+++ b/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTest.kt
@@ -100,7 +100,7 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
         // given:
         val expectedMessage = "Not on my watch!"
 
-        withPrecompiledScriptPluginsPlus("java-gradle-plugin")
+        withKotlinDslPluginPlus()
 
         withFile("src/main/kotlin/my-project-script.gradle.kts", """
             throw IllegalStateException("$expectedMessage")
@@ -195,7 +195,7 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
 
                 withFile(
                     "build.gradle.kts",
-                    scriptWithPrecompiledScriptPluginsPlus("java-gradle-plugin"))
+                    scriptWithKotlinDslPluginPlus())
             }
         }
 
@@ -265,8 +265,6 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
 
                     plugins {
                         `kotlin-dsl`
-                        `kotlin-dsl-precompiled-script-plugins`
-                        `java-gradle-plugin`
                         `maven-publish`
                     }
 
@@ -359,7 +357,7 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
 
     private
     fun givenPrecompiledKotlinScript(fileName: String, code: String) {
-        withPrecompiledScriptPluginsPlus()
+        withKotlinDslPluginPlus()
         withFile("src/main/kotlin/$fileName", code)
         compileKotlin()
     }
@@ -376,15 +374,14 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
             .loadClass(className)
 
     private
-    fun withPrecompiledScriptPluginsPlus(vararg additionalPlugins: String) =
-        withBuildScript(scriptWithPrecompiledScriptPluginsPlus(*additionalPlugins))
+    fun withKotlinDslPluginPlus(vararg additionalPlugins: String) =
+        withBuildScript(scriptWithKotlinDslPluginPlus(*additionalPlugins))
 
     private
-    fun scriptWithPrecompiledScriptPluginsPlus(vararg additionalPlugins: String): String =
+    fun scriptWithKotlinDslPluginPlus(vararg additionalPlugins: String): String =
         """
             plugins {
                 `kotlin-dsl`
-                `kotlin-dsl-precompiled-script-plugins`
                 ${additionalPlugins.asIterable().joinLines { "`$it`" }}
             }
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinDslAccessorsSnapshotTaskIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinDslAccessorsSnapshotTaskIntegrationTest.kt
@@ -201,6 +201,8 @@ val kotlinDslProjectSchema: ProjectSchema<String> = listOf(
 ).let { configurationNames ->
     javaProjectSchema + ProjectSchema(
         extensions = listOf(
+            ProjectSchemaEntry("org.gradle.api.Project", "gradlePlugin", "org.gradle.plugin.devel.GradlePluginDevelopmentExtension"),
+            ProjectSchemaEntry("org.gradle.plugin.devel.GradlePluginDevelopmentExtension", "ext", "org.gradle.api.plugins.ExtraPropertiesExtension"),
             ProjectSchemaEntry("org.gradle.api.Project", "kotlin", "org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension"),
             ProjectSchemaEntry("org.gradle.api.Project", "kotlinDslPluginOptions", "org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPluginOptions"),
             ProjectSchemaEntry("org.gradle.api.Project", "samWithReceiver", "org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension"),

--- a/subprojects/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ProjectWithBuildSrcSampleTest.kt
+++ b/subprojects/samples-tests/src/test/kotlin/org/gradle/kotlin/dsl/samples/ProjectWithBuildSrcSampleTest.kt
@@ -24,7 +24,15 @@ import org.junit.Test
 class ProjectWithBuildSrcSampleTest : AbstractSampleTest("project-with-buildSrc") {
 
     @Test
-    fun `testProfile`() {
+    fun `test precompiled script plugin`() {
+        assertThat(
+            build("myReport").output,
+            containsString("my.flag = true")
+        )
+    }
+
+    @Test
+    fun `test profile`() {
         val output = build("printProfile").output
         assertThat(
             output,
@@ -37,7 +45,7 @@ class ProjectWithBuildSrcSampleTest : AbstractSampleTest("project-with-buildSrc"
     }
 
     @Test
-    fun `testProfile with property`() {
+    fun `test profile with property`() {
         val output = build("printProfile", "-Pprofile=prod").output
         assertThat(
             output,


### PR DESCRIPTION
One can still opt-out by only applying `kotlin-dsl-base`.