### PR TITLE
Remove support for deferred configurable extensions

### DIFF
--- a/samples/gradle-plugin/plugin/settings.gradle.kts
+++ b/samples/gradle-plugin/plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/samples/maven-publish/settings.gradle.kts
+++ b/samples/maven-publish/settings.gradle.kts
@@ -1,1 +1,3 @@
 rootProject.name = "maven-publish"
+
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/samples/precompiled-script-plugin/plugin/settings.gradle.kts
+++ b/samples/precompiled-script-plugin/plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -361,11 +361,13 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     }
 
     @Test
-    fun `can configure deferred configurable extension`() {
+    fun `can configure publishing extension`() {
+
+        withSettings("""
+            enableFeaturePreview("STABLE_PUBLISHING")
+        """)
 
         withBuildScript("""
-
-            import org.gradle.api.publish.maven.MavenPublication
 
             plugins {
                 `java-library`

--- a/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTest.kt
+++ b/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginTest.kt
@@ -259,6 +259,8 @@ class PrecompiledScriptPluginTest : AbstractPluginTest() {
 
                     $pluginManagementBlock
 
+                    enableFeaturePreview("STABLE_PUBLISHING")
+
                 """)
 
                 withFile("build.gradle.kts", """

--- a/subprojects/provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
+++ b/subprojects/provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
@@ -64,9 +64,7 @@ fun targetSchemaFor(target: Any, targetType: TypeOf<*>): TargetTypedSchema {
         if (target is ExtensionAware) {
             accessibleExtensionsSchema(target.extensions.extensionsSchema).forEach { schema ->
                 extensions.add(ProjectSchemaEntry(targetType, schema.name, schema.publicType))
-                if (!schema.isDeferredConfigurable) {
-                    collectSchemaOf(target.extensions.getByName(schema.name), schema.publicType)
-                }
+                collectSchemaOf(target.extensions.getByName(schema.name), schema.publicType)
             }
         }
         if (target is Project) {

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ProjectExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ProjectExtensionsTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 
 import org.gradle.api.Action
@@ -15,7 +14,6 @@ import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.plugins.Convention
 import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.reflect.TypeOf
 
 import org.junit.Assert.fail
@@ -23,23 +21,6 @@ import org.junit.Test
 
 
 class ProjectExtensionsTest {
-
-    @Test
-    fun `can configure deferred configurable extension`() {
-
-        val project = mock<Project>()
-        val convention = mock<Convention>()
-        val extensionType = typeOf<PublishingExtension>()
-
-        whenever(project.convention)
-            .thenReturn(convention)
-
-        project.configure<PublishingExtension> {
-            fail("configuration action should be deferred")
-        }
-
-        verify(convention).configure(eq(extensionType), any())
-    }
 
     @Test
     fun `can get generic project extension by type`() {


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Gradle 5.0 will remove `@DeferredConfigurable`.

See gradle/gradle#6276

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
