### PR TITLE
Remove usage of StartParameter.isRecompileScripts

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
@@ -38,7 +38,6 @@ object BuildServices {
         return ScriptCache(
             cacheRepository,
             cacheKeyBuilder,
-            startParameters.isRecompileScripts,
             hasBuildCacheIntegration
         )
     }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
@@ -43,9 +43,6 @@ class ScriptCache(
     val cacheKeyBuilder: CacheKeyBuilder,
 
     private
-    val recompileScripts: Boolean,
-
-    private
     val hasBuildCacheIntegration: Boolean
 ) {
 
@@ -58,7 +55,6 @@ class ScriptCache(
         val cacheKey = cacheKeyFor(cacheKeySpec)
 
         return cacheRepository.cache(cacheKey)
-            .apply { if (recompileScripts) withValidator { false } }
             .withProperties(cacheProperties)
             .withInitializer {
                 initializeCacheDir(


### PR DESCRIPTION
The `--recompile-scripts` option will be removed from Gradle 5.0.

See gradle/gradle#6306