### PR TITLE
Let build cache integration be disabled via system property

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildServices.kt
@@ -46,4 +46,4 @@ object BuildServices {
 
 private
 val isKotlinDslBuildCacheEnabled: Boolean
-    get() = System.getProperty("org.gradle.kotlin.dsl.caching.buildcache", null) == "true"
+    get() = System.getProperty("org.gradle.kotlin.dsl.caching.buildcache", null) != "false"


### PR DESCRIPTION
Before this commit, build cache integration had to be explicitly enabled for Kotlin DSL scripts by setting the value of the system property `org.gradle.kotlin.dsl.caching.buildcache` to `true`.

With this commit, build cache integration is enabled by default and can be disabled by setting the value of said system property to`false`.