### PR TITLE
ntroduce type-safe accessors for plugin ids 

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+
+import org.gradle.internal.classpath.ClassPath
+
+import org.gradle.kotlin.dsl.codegen.compileKotlinApiExtensionsTo
+import org.gradle.kotlin.dsl.codegen.fileHeader
+import org.gradle.kotlin.dsl.codegen.pluginEntriesFrom
+
+import org.gradle.kotlin.dsl.provider.kotlinScriptClassPathProviderOf
+import org.gradle.kotlin.dsl.support.useToRun
+
+import org.gradle.plugin.use.PluginDependenciesSpec
+import org.gradle.plugin.use.PluginDependencySpec
+
+import java.io.File
+
+
+/**
+ * Produces an [AccessorsClassPath] with type-safe accessors for all plugin ids found in the
+ * `buildSrc` classpath of the given [project].
+ *
+ * The accessors provide content-assist for plugin ids and quick navigation to the plugin source code.
+ */
+fun pluginAccessorsClassPath(project: Project): AccessorsClassPath = project.rootProject.let { rootProject ->
+
+    rootProject.getOrCreateProperty("gradleKotlinDsl.pluginAccessorsClassPath") {
+        val buildSrcClassLoaderScope = baseClassLoaderScopeOf(rootProject)
+        val cacheKeySpec = accessorsCacheKeyPrefix + buildSrcClassLoaderScope.exportClassLoader
+        cachedAccessorsClassPathFor(rootProject, cacheKeySpec) { srcDir, binDir ->
+            kotlinScriptClassPathProviderOf(rootProject).run {
+                buildPluginAccessorsFor(
+                    pluginDescriptorsClassPath = exportClassPathFromHierarchyOf(buildSrcClassLoaderScope),
+                    accessorsCompilationClassPath = compilationClassPathOf(buildSrcClassLoaderScope),
+                    srcDir = srcDir,
+                    binDir = binDir
+                )
+            }
+        }
+    }
+}
+
+
+private
+fun baseClassLoaderScopeOf(rootProject: Project) =
+    (rootProject as ProjectInternal).baseClassLoaderScope
+
+
+internal
+fun buildPluginAccessorsFor(
+    pluginDescriptorsClassPath: ClassPath,
+    accessorsCompilationClassPath: ClassPath,
+    srcDir: File,
+    binDir: File
+) {
+    val pluginSpecs = pluginSpecsFrom(pluginDescriptorsClassPath)
+    val pluginTrees = PluginTree.of(pluginSpecs)
+    val accessors = pluginAccessorsFor(pluginTrees)
+    val sourceFile = srcDir.resolve("org/gradle/kotlin/dsl/PluginAccessors.kt")
+    writePluginAccessorsTo(sourceFile, accessors)
+    compileKotlinApiExtensionsTo(
+        binDir,
+        listOf(sourceFile),
+        accessorsCompilationClassPath.asFiles
+    )
+}
+
+
+private
+fun writePluginAccessorsTo(sourceFile: File, accessors: Sequence<PluginAccessor>) {
+    sourceFile.apply { parentFile.mkdirs() }.bufferedWriter().useToRun {
+        appendln(fileHeader)
+        appendln("""
+            import ${PluginDependenciesSpec::class.qualifiedName}
+            import ${PluginDependencySpec::class.qualifiedName}
+        """.replaceIndent())
+        accessors.runEach {
+            newLine()
+            newLine()
+            when (this) {
+                is PluginAccessor.ForPlugin -> {
+                    appendln("""
+                        /**
+                         * The `$id` plugin implemented by [$implementationClass].
+                         */
+                        val `$extendedType`.`$extensionName`: PluginDependencySpec
+                            get() = ${pluginDependenciesSpecOf(extendedType)}.id("$id")
+                    """.replaceIndent())
+                }
+                is PluginAccessor.ForGroup -> {
+                    appendln("""
+                        /**
+                         * The `$id` plugin group.
+                         */
+                        class `$groupType`(internal val plugins: PluginDependenciesSpec)
+
+
+                        /**
+                         * Plugin ids starting with `$id`.
+                         */
+                        val `$extendedType`.`$extensionName`: `$groupType`
+                            get() = `$groupType`(${pluginDependenciesSpecOf(extendedType)})
+                    """.replaceIndent())
+                }
+            }
+        }
+    }
+}
+
+
+private
+fun pluginDependenciesSpecOf(extendedType: String): String = when (extendedType) {
+    "PluginDependenciesSpec" -> "this"
+    else -> "plugins"
+}
+
+
+private
+inline fun <T> Sequence<T>.runEach(f: T.() -> Unit) {
+    forEach { it.run(f) }
+}
+
+
+internal
+fun pluginAccessorsFor(pluginTrees: Map<String, PluginTree>, extendedType: String = "PluginDependenciesSpec"): Sequence<PluginAccessor> = sequence {
+
+    for ((extensionName, pluginTree) in pluginTrees) {
+        when (pluginTree) {
+            is PluginTree.PluginGroup -> {
+                val groupId = pluginTree.path.joinToString(".")
+                val groupType = pluginGroupTypeFor(pluginTree.path)
+                yield(PluginAccessor.ForGroup(groupId, groupType, extendedType, extensionName))
+                yieldAll(pluginAccessorsFor(pluginTree.plugins, groupType))
+            }
+            is PluginTree.PluginSpec -> {
+                yield(
+                    PluginAccessor.ForPlugin(
+                        pluginTree.id,
+                        pluginTree.implementationClass,
+                        extendedType,
+                        extensionName
+                    )
+                )
+            }
+        }
+    }
+}
+
+
+internal
+sealed class PluginAccessor {
+
+    data class ForPlugin(
+        val id: String,
+        val implementationClass: String,
+        val extendedType: String,
+        val extensionName: String
+    ) : PluginAccessor()
+
+    data class ForGroup(
+        val id: String,
+        val groupType: String,
+        val extendedType: String,
+        val extensionName: String
+    ) : PluginAccessor()
+}
+
+
+private
+fun pluginSpecsFrom(pluginDescriptorsClassPath: ClassPath): Iterable<PluginTree.PluginSpec> =
+    pluginDescriptorsClassPath
+        .asFiles
+        .filter { it.isFile && it.extension.equals("jar", true) }
+        .flatMap { pluginEntriesFrom(it) }
+        .map { PluginTree.PluginSpec(it.pluginId, it.implementationClass) }
+
+
+private
+fun pluginGroupTypeFor(path: List<String>) =
+    path.joinToString(separator = "") { it.capitalize() } + "PluginGroup"
+
+

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginTree.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginTree.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+
+internal
+sealed class PluginTree {
+
+    data class PluginGroup(val path: List<String>, val plugins: Map<String, PluginTree>) : PluginTree()
+
+    data class PluginSpec(val id: String, val implementationClass: String) : PluginTree()
+
+    companion object {
+
+        fun of(plugins: Iterable<PluginSpec>): Map<String, PluginTree> {
+            val root = linkedMapOf<String, PluginTree>()
+            plugins.sortedBy { it.id }.forEach { plugin ->
+                val path = plugin.id.split('.')
+                val pluginGroupPath = path.dropLast(1)
+                pluginTreeForGroup(pluginGroupPath, root)
+                    ?.put(path.last(), plugin)
+            }
+            return root
+        }
+
+        private
+        fun pluginTreeForGroup(groupPath: List<String>, root: MutableMap<String, PluginTree>): MutableMap<String, PluginTree>? {
+            var branch = root
+            groupPath.forEachIndexed { index, segment ->
+                when (val group = branch[segment]) {
+                    null -> {
+                        val newGroupMap = linkedMapOf<String, PluginTree>()
+                        val newGroup = PluginGroup(groupPath.take(index + 1), newGroupMap)
+                        branch[segment] = newGroup
+                        branch = newGroupMap
+                    }
+                    is PluginGroup -> {
+                        branch = group.plugins as MutableMap<String, PluginTree>
+                    }
+                    else -> {
+                        return null
+                    }
+                }
+            }
+            return branch
+        }
+    }
+}

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/SingletonProperties.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/SingletonProperties.kt
@@ -23,8 +23,14 @@ import org.gradle.kotlin.dsl.extra
 
 internal
 inline fun <reified T : Any> ExtensionAware.getOrCreateSingletonProperty(crossinline create: () -> T): T =
-    extra.run {
-        val property = T::class.qualifiedName!!
-        if (has(property)) get(property) as T
-        else create().also { set(property, it) }
-    }
+    getOrCreateProperty(T::class.qualifiedName!!, create)
+
+
+internal
+inline fun <reified T : Any> ExtensionAware.getOrCreateProperty(
+    property: String,
+    crossinline create: () -> T
+): T = extra.run {
+    if (has(property)) get(property) as T
+    else create().also { set(property, it) }
+}

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildCacheFormat.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildCacheFormat.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.cache
 import org.gradle.internal.id.UniqueId
 
 import org.gradle.kotlin.dsl.support.normalisedPathRelativeTo
+import org.gradle.kotlin.dsl.support.useToRun
 
 import java.io.DataInputStream
 import java.io.DataOutputStream
@@ -137,11 +138,6 @@ fun DataInputStream.unpackFilesTo(outputDir: File): Long {
 
     return entryCount
 }
-
-
-private
-inline fun <T : AutoCloseable, U> T.useToRun(action: T.() -> U): U =
-    use { run(action) }
 
 
 private

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/PluginIdExtensions.kt
@@ -240,11 +240,11 @@ object UserGuideLink {
 }
 
 
-private
+internal
 data class PluginEntry(val pluginId: String, val implementationClass: String)
 
 
-private
+internal
 fun pluginEntriesFrom(jar: File): List<PluginEntry> =
     JarFile(jar).use { jarFile ->
         jarFile.entries().asSequence().filter {

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -144,7 +144,6 @@ class KotlinScriptClassPathProvider(
     fun computeCompilationClassPath(scope: ClassLoaderScope): ClassPath =
         gradleKotlinDsl + exportClassPathFromHierarchyOf(scope)
 
-    private
     fun exportClassPathFromHierarchyOf(scope: ClassLoaderScope): ClassPath {
         require(scope.isLocked) {
             "$scope must be locked before it can be used to compute a classpath!"

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -45,6 +45,8 @@ import org.gradle.internal.operations.CallableBuildOperation
 import org.gradle.internal.scripts.CompileScriptBuildOperationType.Details
 import org.gradle.internal.scripts.CompileScriptBuildOperationType.Result
 
+import org.gradle.kotlin.dsl.accessors.pluginAccessorsClassPath
+
 import org.gradle.kotlin.dsl.cache.ScriptCache
 
 import org.gradle.kotlin.dsl.execution.EvalOption
@@ -149,6 +151,11 @@ class StandardKotlinScriptEvaluator(
 
     inner class InterpreterHost : Interpreter.Host {
 
+        override fun pluginAccessorsFor(scriptHost: KotlinScriptHost<*>): ClassPath =
+            (scriptHost.target as? Project)?.let {
+                pluginAccessorsClassPath(it).bin
+            } ?: ClassPath.EMPTY
+
         override fun runCompileBuildOperation(scriptPath: String, stage: String, action: () -> String): String =
 
             buildOperationExecutor.call(object : CallableBuildOperation<String> {
@@ -200,7 +207,8 @@ class StandardKotlinScriptEvaluator(
                 DefaultPluginRequests.EMPTY,
                 scriptHost.scriptHandler as ScriptHandlerInternal?,
                 null,
-                scriptHost.targetScope)
+                scriptHost.targetScope
+            )
 
             (scriptHost.target as? Settings)?.run {
                 addKotlinEapRepository()

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/CompactTree.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/CompactTree.kt
@@ -28,7 +28,7 @@ fun compactStringFor(files: Iterable<java.io.File>) =
 
 internal
 fun compactStringFor(paths: Iterable<String>, separator: Char) =
-    CompactTree.Companion.of(paths.map { it.splitIncluding(separator).toList() }).toString()
+    CompactTree.of(paths.map { it.splitIncluding(separator).toList() }).toString()
 
 
 private
@@ -41,7 +41,7 @@ sealed class CompactTree {
                 .filter { it.isNotEmpty() }
                 .groupBy({ it[0] }, { it.drop(1) })
                 .map { (label, remaining) ->
-                    val subTree = CompactTree.Companion.of(remaining)
+                    val subTree = CompactTree.of(remaining)
                     when (subTree) {
                         is CompactTree.Empty -> CompactTree.Label(label)
                         is CompactTree.Label -> CompactTree.Label(

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
@@ -21,3 +21,8 @@ import java.io.File
 
 internal
 fun userHome() = File(System.getProperty("user.home"))
+
+
+internal
+inline fun <T : AutoCloseable, U> T.useToRun(action: T.() -> U): U =
+    use { run(action) }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPathTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPathTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.kotlin.dsl.fixtures.testCompilationClassPath
+import org.gradle.kotlin.dsl.support.zipTo
+
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+
+class PluginAccessorsClassPathTest : TestWithClassPath() {
+
+    @Test
+    fun `#buildPluginAccessorsFor`() {
+
+        // given:
+        val pluginsJar = file("plugins.jar").also {
+            zipTo(it, sequenceOf(
+                "META-INF/gradle-plugins/my.own.plugin.properties" to "implementation-class=my.Plugin".toByteArray()
+            ))
+        }
+
+        val srcDir = newFolder("src")
+        val binDir = newFolder("bin")
+
+        // when:
+        buildPluginAccessorsFor(
+            pluginDescriptorsClassPath = classPathOf(pluginsJar),
+            accessorsCompilationClassPath = testCompilationClassPath,
+            srcDir = srcDir,
+            binDir = binDir
+        )
+
+        // then:
+        assertThat(
+            srcDir.resolve("org/gradle/kotlin/dsl/PluginAccessors.kt").readText(),
+            containsMultiLineString("""
+
+                /**
+                 * The `my` plugin group.
+                 */
+                class `MyPluginGroup`(internal val plugins: PluginDependenciesSpec)
+
+
+                /**
+                 * Plugin ids starting with `my`.
+                 */
+                val `PluginDependenciesSpec`.`my`: `MyPluginGroup`
+                    get() = `MyPluginGroup`(this)
+
+
+                /**
+                 * The `my.own` plugin group.
+                 */
+                class `MyOwnPluginGroup`(internal val plugins: PluginDependenciesSpec)
+
+
+                /**
+                 * Plugin ids starting with `my.own`.
+                 */
+                val `MyPluginGroup`.`own`: `MyOwnPluginGroup`
+                    get() = `MyOwnPluginGroup`(plugins)
+
+
+                /**
+                 * The `my.own.plugin` plugin implemented by [my.Plugin].
+                 */
+                val `MyOwnPluginGroup`.`plugin`: PluginDependencySpec
+                    get() = plugins.id("my.own.plugin")
+            """)
+        )
+    }
+}

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+
+class PluginAccessorsTest {
+
+    @Test
+    fun `#pluginAccessorsFor`() {
+
+        assertThat(
+            pluginAccessorsFor(
+                linkedMapOf(
+                    "my-plugin" to PluginTree.PluginSpec(
+                        "my-plugin", "my.Plugin"
+                    ),
+                    "my" to PluginTree.PluginGroup(
+                        listOf("my"),
+                        linkedMapOf(
+                            "plugin-a" to PluginTree.PluginSpec("my.plugin-a", "my.PluginA")
+                        )
+                    )
+                )
+            ).toList(),
+            equalTo(
+                listOf(
+                    PluginAccessor.ForPlugin("my-plugin", "my.Plugin", "PluginDependenciesSpec", "my-plugin"),
+                    PluginAccessor.ForGroup("my", "MyPluginGroup", "PluginDependenciesSpec", "my"),
+                    PluginAccessor.ForPlugin("my.plugin-a", "my.PluginA", "MyPluginGroup", "plugin-a")
+                )
+            )
+        )
+    }
+}

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginTreeTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/PluginTreeTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.accessors
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+
+class PluginTreeTest {
+
+    @Test
+    fun `PluginTree#of`() {
+
+        val flatPlugin = PluginTree.PluginSpec("flat-plugin", "FlatPlugin")
+        val nestedPluginA = PluginTree.PluginSpec("nested.plugin-a", "NestedPluginA")
+        val nestedPluginB = PluginTree.PluginSpec("nested.other.plugin-b", "NestedPluginB")
+        val nestedPluginC = PluginTree.PluginSpec("nested.other.plugin-c", "NestedPluginC")
+        assertThat(
+            PluginTree.of(
+                listOf(
+                    flatPlugin,
+                    nestedPluginA,
+                    nestedPluginB,
+                    nestedPluginC,
+                    // plugins with ids prefixed by other plugin ids
+                    // cannot be properly supported due to the side-effecting nature
+                    // of `PluginDependenciesSpec#id`
+                    PluginTree.PluginSpec("flat-plugin.conflict", "IgnoredPlugin"),
+                    PluginTree.PluginSpec("nested.plugin-a.conflict", "IgnoredPlugin")
+                ).shuffled()
+            ),
+            equalTo<Map<String, PluginTree>>(
+                linkedMapOf(
+                    flatPlugin.id to flatPlugin,
+                    "nested" to PluginTree.PluginGroup(
+                        listOf("nested"),
+                        linkedMapOf(
+                            "plugin-a" to nestedPluginA,
+                            "other" to PluginTree.PluginGroup(
+                                listOf("nested", "other"),
+                                linkedMapOf(
+                                    "plugin-b" to nestedPluginB,
+                                    "plugin-c" to nestedPluginC
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+}

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
@@ -54,10 +54,6 @@ open class TestWithClassPath : TestWithTempFiles() {
         })
 
     private
-    fun classPathOf(vararg files: File) =
-        DefaultClassPath.of(files.asList())
-
-    private
     fun classFileForType(name: String, rootDir: File, vararg modifiers: Int) {
         File(rootDir, "${name.replace(".", "/")}.class").apply {
             parentFile.mkdirs()
@@ -80,3 +76,8 @@ open class TestWithClassPath : TestWithTempFiles() {
             toByteArray()
         }
 }
+
+
+internal
+fun classPathOf(vararg files: File) =
+    DefaultClassPath.of(files.asList())

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/PluginDependenciesSpecAccessorsIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/PluginDependenciesSpecAccessorsIntegrationTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+
+class PluginDependenciesSpecAccessorsIntegrationTest : ScriptModelIntegrationTest() {
+
+    @Test
+    fun `can use accessors for plugins in the buildSrc classpath`() {
+
+        withKotlinBuildSrc()
+        withFile("buildSrc/src/main/kotlin/my/plugin-a.gradle.kts", """
+            package my
+            println("*my.plugin-a*")
+        """)
+
+        withBuildScript("""
+            plugins {
+                my.`plugin-a`
+            }
+        """)
+
+        assertThat(
+            build("help", "-q").output,
+            containsString("*my.plugin-a*")
+        )
+    }
+}

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -151,6 +151,9 @@ class SimplifiedKotlinScriptEvaluator(
         override fun compilationClassPathOf(classLoaderScope: ClassLoaderScope): ClassPath =
             scriptCompilationClassPath
 
+        override fun pluginAccessorsFor(scriptHost: KotlinScriptHost<*>): ClassPath =
+            ClassPath.EMPTY
+
         override fun startCompilerOperation(description: String): AutoCloseable =
             mock()
 

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -29,8 +29,6 @@ import org.gradle.api.invocation.Gradle
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 
-import org.gradle.tooling.provider.model.ToolingModelBuilder
-
 import org.gradle.groovy.scripts.TextResourceScriptSource
 
 import org.gradle.internal.classpath.ClassPath
@@ -38,7 +36,8 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.resource.BasicTextResourceLoader
 
 import org.gradle.kotlin.dsl.accessors.AccessorsClassPath
-import org.gradle.kotlin.dsl.accessors.accessorsClassPathFor
+import org.gradle.kotlin.dsl.accessors.pluginAccessorsClassPath
+import org.gradle.kotlin.dsl.accessors.projectAccessorsClassPath
 
 import org.gradle.kotlin.dsl.execution.EvalOption
 
@@ -57,10 +56,11 @@ import org.gradle.kotlin.dsl.support.KotlinScriptType
 import org.gradle.kotlin.dsl.support.kotlinScriptTypeFor
 import org.gradle.kotlin.dsl.support.serviceOf
 
-import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 import org.gradle.kotlin.dsl.tooling.models.EditorReport
+import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
+import org.gradle.kotlin.dsl.typeOf
 
-import org.gradle.kotlin.dsl.*
+import org.gradle.tooling.provider.model.ToolingModelBuilder
 
 import java.io.File
 import java.io.Serializable
@@ -171,7 +171,7 @@ fun projectScriptModelBuilder(scriptFile: File?, project: Project) =
         scriptFile = scriptFile,
         project = project,
         scriptClassPath = project.scriptCompilationClassPath,
-        accessorsClassPath = { classPath -> accessorsClassPathFor(project, classPath) },
+        accessorsClassPath = { classPath -> projectAccessorsClassPath(project, classPath) + pluginAccessorsClassPath(project) },
         sourceLookupScriptHandlers = sourceLookupScriptHandlersFor(project))
 
 

--- a/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelIntegrationTest.kt
+++ b/subprojects/tooling-builders/src/test/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptTemplateModelIntegrationTest.kt
@@ -65,7 +65,10 @@ class KotlinBuildScriptTemplateModelIntegrationTest : AbstractIntegrationTest() 
 
     private
     fun isolatedClassLoaderFor(classPath: List<File>) =
-        DefaultClassLoaderFactory().createIsolatedClassLoader(DefaultClassPath.of(classPath))
+        DefaultClassLoaderFactory().createIsolatedClassLoader(
+            "kotlin-dsl-script-templates",
+            DefaultClassPath.of(classPath)
+        )
 
     private
     fun stop(loader: ClassLoader) {


### PR DESCRIPTION
With this PR the Kotlin DSL will generate type-safe accessors for all plugin ids found in the `buildSrc` classpath.

So instead of writing:

```kotlin
plugins {
    id("gradlebuild.strict-compile")
    id("gradlebuild.classcycle")
}
```

One can write:

```kotlin
plugins {
    gradlebuild.`strict-compile`
    gradlebuild.classcycle
}
```

All while enjoying content assist and source code navigation all the way down to the plugin implementation class.