### PR TITLE
Generate compilable accessors for tasks with types in the default package

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -251,8 +251,7 @@ private
 fun importsRequiredBy(schemaSubset: ProjectSchema<TypeAccessibility>): List<String> =
     defaultPackageTypesIn(
         schemaSubset
-            .extensions
-            .flatMap { listOf(it.target, it.type) }
+            .run { extensions.flatMap { listOf(it.target, it.type) } + tasks.map { it.type } }
             .filterIsInstance<TypeAccessibility.Accessible>()
             .map { it.type }
     )

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TypeAccessibilityProviderTest.kt
@@ -46,6 +46,11 @@ class TypeAccessibilityProviderTest : TestWithClassPath() {
             assertTrue(leafs.isEmpty())
         }
 
+        classNamesFromTypeString("CustomTask").apply {
+            assertThat(all, hasItems("CustomTask"))
+            assertThat(leafs, hasItems("CustomTask"))
+        }
+
         classNamesFromTypeString("java.util.List<String>").apply {
             assertThat(all, hasItems("java.util.List"))
             assertTrue(leafs.isEmpty())


### PR DESCRIPTION
By explicitly importing task types from the default package in the generated code.

Resolves #1158