### PR TITLE
Rename PluginAware.apply<T>(to) to PluginAware.applyTo<T>(targets)

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginAwareExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/PluginAwareExtensions.kt
@@ -59,12 +59,12 @@ inline fun <reified T : Plugin<*>> PluginAware.apply() {
  * The given class should implement the [Plugin] interface.
  *
  * @param T the plugin type.
- * @param to the plugin target object or collection of objects
+ * @param targets the plugin target objects or collections of objects
  * @see [PluginAware.apply]
  */
-inline fun <reified T : Plugin<*>> PluginAware.apply(to: Any) {
+inline fun <reified T : Plugin<*>> PluginAware.applyTo(vararg targets: Any) {
     apply {
         it.plugin(T::class.java)
-        it.to(to)
+        it.to(*targets)
     }
 }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginAwareExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/PluginAwareExtensionsTest.kt
@@ -64,28 +64,28 @@ class PluginAwareExtensionsTest {
         val arbitraryTarget = "something"
 
         newPluginAwareMock<PluginAware>().run {
-            target.apply<AnyPlugin>(to = arbitraryTarget)
+            target.applyTo<AnyPlugin>(arbitraryTarget)
             inOrder(configurationAction) {
                 verify(configurationAction).plugin(AnyPlugin::class.java)
                 verify(configurationAction).to(arbitraryTarget)
             }
         }
         newPluginAwareMock<Gradle>().run {
-            target.apply<AnyPlugin>(to = arbitraryTarget)
+            target.applyTo<AnyPlugin>(arbitraryTarget)
             inOrder(configurationAction) {
                 verify(configurationAction).plugin(AnyPlugin::class.java)
                 verify(configurationAction).to(arbitraryTarget)
             }
         }
         newPluginAwareMock<Settings>().run {
-            target.apply<AnyPlugin>(to = arbitraryTarget)
+            target.applyTo<AnyPlugin>(arbitraryTarget)
             inOrder(configurationAction) {
                 verify(configurationAction).plugin(AnyPlugin::class.java)
                 verify(configurationAction).to(arbitraryTarget)
             }
         }
         newPluginAwareMock<Project>().run {
-            target.apply<AnyPlugin>(to = arbitraryTarget)
+            target.applyTo<AnyPlugin>(arbitraryTarget)
             inOrder(configurationAction) {
                 verify(configurationAction).plugin(AnyPlugin::class.java)
                 verify(configurationAction).to(arbitraryTarget)


### PR DESCRIPTION
in order to remove the ambiguity with PluginAware.apply(from/plugin)

See #1161 