### PR TITLE
Precompute message in order not to leak Project instance

### DIFF
--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -70,7 +70,7 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
 private
 fun KotlinCompile.applyExperimentalWarning(experimentalWarning: Boolean) =
     replaceLoggerWith(
-        if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger, project)
+        if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger, project.kotlinDslPluginExperimentalWarning())
         else KotlinCompilerWarningSilencingLogger(logger)
     )
 
@@ -93,11 +93,11 @@ fun KotlinCompile.replaceLoggerWith(logger: Logger) {
 private
 class KotlinCompilerWarningSubstitutingLogger(
     private val delegate: Logger,
-    private val project: Project
+    private val kotlinDslPluginExperimentalWarning: String
 ) : Logger by delegate {
 
     override fun warn(message: String) {
-        if (message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) delegate.warn(project.kotlinDslPluginExperimentalWarning())
+        if (message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) delegate.warn(kotlinDslPluginExperimentalWarning)
         else delegate.warn(message)
     }
 }

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -70,7 +70,7 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
 private
 fun KotlinCompile.applyExperimentalWarning(experimentalWarning: Boolean) =
     replaceLoggerWith(
-        if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger, project.kotlinDslPluginExperimentalWarning())
+        if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger, project.toString(), project.experimentalWarningLink)
         else KotlinCompilerWarningSilencingLogger(logger)
     )
 
@@ -93,11 +93,12 @@ fun KotlinCompile.replaceLoggerWith(logger: Logger) {
 private
 class KotlinCompilerWarningSubstitutingLogger(
     private val delegate: Logger,
-    private val kotlinDslPluginExperimentalWarning: String
+    private val target: String,
+    private val link: String
 ) : Logger by delegate {
 
     override fun warn(message: String) {
-        if (message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) delegate.warn(kotlinDslPluginExperimentalWarning)
+        if (message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) delegate.warn(kotlinDslPluginExperimentalWarning(target, link))
         else delegate.warn(message)
     }
 }
@@ -116,13 +117,8 @@ class KotlinCompilerWarningSilencingLogger(
 }
 
 
-private
-fun Project.kotlinDslPluginExperimentalWarning() =
-    kotlinDslPluginExperimentalWarning(project, experimentalWarningLink)
-
-
 internal
-fun kotlinDslPluginExperimentalWarning(target: Any, link: Any) =
+fun kotlinDslPluginExperimentalWarning(target: String, link: String) =
     "The `kotlin-dsl` plugin applied to $target enables experimental Kotlin compiler features. For more information see $link"
 
 


### PR DESCRIPTION
The KotlinCompile task logger goes through RMI to the Kotlin Compiler daemon. Holding a Project instance per task exacerbated a memory leak in the Kotlin compiler infrastructure.

This only impacted `KotlinCompile` tasks with the `kotlin-dsl` plugin applied.

Also see https://youtrack.jetbrains.com/issue/KT-27639