### PR TITLE
Add implicit import for java.util.concurrent.Callable

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
@@ -42,5 +42,6 @@ class ImplicitImports(private val importsReader: ImportsReader) {
             "java.util.concurrent.Callable",
             "java.util.concurrent.TimeUnit",
             "java.math.BigDecimal",
+            "java.math.BigInteger",
             "java.io.File")
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
@@ -39,6 +39,7 @@ class ImplicitImports(private val importsReader: ImportsReader) {
             // TODO: let this be contributed by :plugins
             "org.gradle.kotlin.dsl.plugins.dsl.*",
             // TODO: infer list of types below at build time by inspecting the Gradle API
+            "java.util.concurrent.Callable",
             "java.util.concurrent.TimeUnit",
             "java.math.BigDecimal",
             "java.io.File")

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
@@ -33,6 +33,7 @@ class ImplicitImportsTest : AbstractIntegrationTest() {
             val b = TimeUnit.DAYS
             val c = File("some")
             val d = BigDecimal.ONE
+            val e = BigInteger.ONE
         """)
 
         build("help")

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/support/ImplicitImportsTest.kt
@@ -24,4 +24,17 @@ class ImplicitImportsTest : AbstractIntegrationTest() {
         // then:
         assertThat(result.output, containsString("*org.gradle.api.tasks.bundling.Jar*"))
     }
+
+    @Test
+    fun `can use kotlin-dsl implicit imports`() {
+
+        withBuildScript("""
+            val a = Callable { "some" }
+            val b = TimeUnit.DAYS
+            val c = File("some")
+            val d = BigDecimal.ONE
+        """)
+
+        build("help")
+    }
 }


### PR DESCRIPTION
given it's required for many Gradle API when deferring computation, e.g. `copySpec { from(Callable { .. }) }`

Note that `copySpec { from(provider { .. }) }` also works