### PR TITLE
Add invoke operator to Callable

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/CallableExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/CallableExtensions.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import java.util.concurrent.Callable
+
+
+/**
+ * Enables function invocation syntax on [Callable] references.
+ * @see Callable.call
+ */
+operator fun <V> Callable<V>.invoke(): V =
+    call()

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/CallableExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/CallableExtensionsTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.concurrent.Callable
+
+
+class CallableExtensionsTest {
+
+    @Test
+    fun `Callable#call can be called using invoke`() {
+        val answer = "42"
+        val answerCallable = Callable { answer }
+
+        assertEquals(answer, answerCallable())
+    }
+}


### PR DESCRIPTION
Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@plexxi.com>

### Context
```kotlin
val testCallable = Callable<String> {
    "something"
}
// PR Makes it so that this can compile.
testCallable()
```

This brings the API inline with the Groovy DSL.

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [ ] Ensure that tests pass locally: `./gradlew check --parallel`
