### PR TITLE
Let generated source code import default package types

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -147,20 +147,12 @@ fun buildAccessorsFor(
 
 
 internal
-fun importsRequiredBy(schemaSubset: ProjectSchema<TypeAccessibility>): List<String> =
+fun importsRequiredBy(candidateTypes: List<TypeAccessibility>): List<String> =
     defaultPackageTypesIn(
-        candidateTypesForImportIn(schemaSubset)
+        candidateTypes
             .filterIsInstance<TypeAccessibility.Accessible>()
             .map { it.type.kotlinString }
     )
-
-
-private
-fun candidateTypesForImportIn(projectSchema: ProjectSchema<TypeAccessibility>) = projectSchema.run {
-    (extensions.flatMap { listOf(it.target, it.type) }
-        + tasks.map { it.type }
-        + containerElements.map { it.type })
-}
 
 
 internal

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -107,13 +107,13 @@ fun accessorsClassesDir(baseDir: File) = baseDir.resolve("classes")
 
 
 private
-fun configuredProjectSchemaOf(project: Project) =
-    project.takeIf(::enabledJitAccessors)?.let {
+fun configuredProjectSchemaOf(project: Project): TypedProjectSchema? =
+    if (enabledJitAccessors(project)) {
         require(classLoaderScopeOf(project).isLocked) {
             "project.classLoaderScope must be locked before querying the project schema"
         }
         schemaFor(project).takeIf { it.isNotEmpty() }
-    }
+    } else null
 
 
 internal
@@ -378,13 +378,13 @@ class ClassDataFromKotlinMetadataAnnotationVisitor(
 ) : AnnotationVisitor(ASM6) {
 
     /**
-     * @see kotlin.Metadata.d1
+     * @see kotlin.Metadata.data1
      */
     private
     var d1 = mutableListOf<String>()
 
     /**
-     * @see kotlin.Metadata.d2
+     * @see kotlin.Metadata.data2
      */
     private
     var d2 = mutableListOf<String>()

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
@@ -85,7 +85,7 @@ fun importsRequiredBy(accessor: Accessor): List<String> = accessor.run {
         is Accessor.ForExtension -> importsRequiredBy(spec.receiver, spec.type)
         is Accessor.ForConvention -> importsRequiredBy(spec.receiver, spec.type)
         is Accessor.ForTask -> importsRequiredBy(spec.type)
-        is Accessor.ForContainerElement -> importsRequiredBy(spec.type)
+        is Accessor.ForContainerElement -> importsRequiredBy(spec.receiver, spec.type)
         else -> emptyList()
     }
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/Emitter.kt
@@ -68,7 +68,7 @@ fun WriterThread.emitClassFor(accessor: Accessor, srcDir: File, binDir: File): I
     }
 
     val sourceFile = srcDir.resolve("${className.value.removeSuffix("Kt")}.kt")
-    io { writeAccessorsTo(sourceFile, sourceCode.asSequence()) }
+    io { writeAccessorsTo(sourceFile, sourceCode.asSequence(), importsRequiredBy(accessor)) }
 
     val classHeader = metadataWriter.closeHeader()
     val classBytes = classWriter.endKotlinClass(classHeader)
@@ -77,6 +77,23 @@ fun WriterThread.emitClassFor(accessor: Accessor, srcDir: File, binDir: File): I
 
     return className
 }
+
+
+private
+fun importsRequiredBy(accessor: Accessor): List<String> = accessor.run {
+    when (this) {
+        is Accessor.ForExtension -> importsRequiredBy(spec.receiver, spec.type)
+        is Accessor.ForConvention -> importsRequiredBy(spec.receiver, spec.type)
+        is Accessor.ForTask -> importsRequiredBy(spec.type)
+        is Accessor.ForContainerElement -> importsRequiredBy(spec.type)
+        else -> emptyList()
+    }
+}
+
+
+private
+fun importsRequiredBy(vararg candidateTypes: TypeAccessibility): List<String> =
+    importsRequiredBy(candidateTypes.asList())
 
 
 internal

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/AsmExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/AsmExtensions.kt
@@ -30,8 +30,8 @@ import kotlin.reflect.KClass
 internal
 fun publicClass(
     name: InternalName,
-    superName: InternalName = InternalNameOf.javaLangObject,
-    interfaces: Array<String>? = null,
+    superName: InternalName? = null,
+    interfaces: List<InternalName>? = null,
     classBody: ClassWriter.() -> Unit = {}
 ) = beginPublicClass(name, superName, interfaces).run {
     classBody()
@@ -40,7 +40,7 @@ fun publicClass(
 
 
 internal
-fun beginPublicClass(name: InternalName, superName: InternalName = InternalNameOf.javaLangObject, interfaces: Array<String>? = null) =
+fun beginPublicClass(name: InternalName, superName: InternalName? = null, interfaces: List<InternalName>? = null) =
     beginClass(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, name, superName, interfaces)
 
 
@@ -48,10 +48,17 @@ internal
 fun beginClass(
     modifiers: Int,
     name: InternalName,
-    superName: InternalName = InternalNameOf.javaLangObject,
-    interfaces: Array<String>? = null
+    superName: InternalName? = null,
+    interfaces: List<InternalName>? = null
 ): ClassWriter = ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES).apply {
-    visit(Opcodes.V1_8, modifiers, name.value, null, superName.value, interfaces)
+    visit(
+        Opcodes.V1_8,
+        modifiers,
+        name.value,
+        null,
+        (superName ?: InternalNameOf.javaLangObject).value,
+        interfaces?.map { it.value }?.toTypedArray()
+    )
 }
 
 
@@ -304,6 +311,11 @@ fun MethodVisitor.ACONST_NULL() {
 @Suppress("experimental_feature_warning")
 internal
 inline class InternalName(val value: String) {
+
+    companion object {
+        fun from(sourceName: String) = InternalName(sourceName.replace('.', '/'))
+    }
+
     override fun toString() = value
 }
 

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/AsmExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/AsmExtensions.kt
@@ -41,9 +41,18 @@ fun publicClass(
 
 internal
 fun beginPublicClass(name: InternalName, superName: InternalName = InternalNameOf.javaLangObject, interfaces: Array<String>? = null) =
-    ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES).apply {
-        visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, name.value, null, superName.value, interfaces)
-    }
+    beginClass(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL, name, superName, interfaces)
+
+
+internal
+fun beginClass(
+    modifiers: Int,
+    name: InternalName,
+    superName: InternalName = InternalNameOf.javaLangObject,
+    interfaces: Array<String>? = null
+): ClassWriter = ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES).apply {
+    visit(Opcodes.V1_8, modifiers, name.value, null, superName.value, interfaces)
+}
 
 
 internal
@@ -54,7 +63,7 @@ fun ClassWriter.endClass(): ByteArray {
 
 
 internal
-fun ClassWriter.publicDefaultConstructor(superName: InternalName) {
+fun ClassWriter.publicDefaultConstructor(superName: InternalName = InternalNameOf.javaLangObject) {
     publicMethod("<init>", "()V") {
         ALOAD(0)
         INVOKESPECIAL(superName, "<init>", "()V")

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/DefaultPackageTypesTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/DefaultPackageTypesTest.kt
@@ -25,11 +25,20 @@ import org.junit.Test
 class DefaultPackageTypesTest : TestWithClassPath() {
 
     @Test
-    fun `#defaultPackageTypesIn generic type`() {
+    fun `#defaultPackageTypesIn (generic type)`() {
 
         assertThat(
-            defaultPackageTypesIn(listOf("gradle.Container<Extension>")),
-            equalTo(listOf("Extension"))
+            defaultPackageTypesIn(listOf("java.util.Map<Key, Value>")),
+            equalTo(listOf("Key", "Value"))
+        )
+    }
+
+    @Test
+    fun `#defaultPackageTypesIn (duplicate types)`() {
+
+        assertThat(
+            defaultPackageTypesIn(listOf("java.util.Map<Value, Value>")),
+            equalTo(listOf("Value"))
         )
     }
 }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/DefaultPackageTypesTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/DefaultPackageTypesTest.kt
@@ -16,10 +16,6 @@
 
 package org.gradle.kotlin.dsl.accessors
 
-import org.gradle.kotlin.dsl.accessors.TypeAccessibility.Accessible
-import org.gradle.kotlin.dsl.fixtures.classLoaderFor
-import org.gradle.kotlin.dsl.support.useToRun
-
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 
@@ -35,36 +31,5 @@ class DefaultPackageTypesTest : TestWithClassPath() {
             defaultPackageTypesIn(listOf("gradle.Container<Extension>")),
             equalTo(listOf("Extension"))
         )
-    }
-
-    @Test
-    fun `#importsRequiredBy takes container elements into account`() {
-
-        val classPath = classPathWithPublicTypes(
-            "Container",
-            "DefaultPackageType"
-        )
-        classLoaderFor(classPath).useToRun {
-            assertThat(
-                importsRequiredBy(
-                    ProjectSchema(
-                        containerElements = listOf(
-                            ProjectSchemaEntry(
-                                Accessible(schemaTypeFor("Container")),
-                                "element",
-                                Accessible(schemaTypeFor("DefaultPackageType"))
-                            )
-                        ),
-                        extensions = emptyList(),
-                        conventions = emptyList(),
-                        tasks = emptyList(),
-                        configurations = emptyList()
-                    )
-                ),
-                equalTo(
-                    listOf("DefaultPackageType")
-                )
-            )
-        }
     }
 }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -216,4 +216,9 @@ class ProjectSchemaTest : TestWithClassPath() {
 
 internal
 fun ClassLoader.schemaTypeFor(typeString: String): SchemaType =
-    SchemaType(TypeOf.typeOf<Any?>(loadClass(typeString)))
+    SchemaType(loadTypeOf(typeString))
+
+
+internal
+fun ClassLoader.loadTypeOf(typeString: String) =
+    TypeOf.typeOf<Any?>(loadClass(typeString))

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectSchemaTest.kt
@@ -17,8 +17,6 @@ import org.junit.Test
 import org.objectweb.asm.Opcodes.ACC_PUBLIC
 import org.objectweb.asm.Opcodes.ACC_SYNTHETIC
 
-import java.net.URLClassLoader
-
 
 @Suppress("unused")
 class PublicGenericType<T>
@@ -217,5 +215,5 @@ class ProjectSchemaTest : TestWithClassPath() {
 
 
 internal
-fun URLClassLoader.schemaTypeFor(typeString: String): SchemaType =
+fun ClassLoader.schemaTypeFor(typeString: String): SchemaType =
     SchemaType(TypeOf.typeOf<Any?>(loadClass(typeString)))

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/TestWithClassPath.kt
@@ -5,15 +5,14 @@ import org.gradle.internal.classpath.DefaultClassPath
 
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.classEntriesFor
+import org.gradle.kotlin.dsl.support.bytecode.InternalName
+import org.gradle.kotlin.dsl.support.bytecode.beginClass
+import org.gradle.kotlin.dsl.support.bytecode.endClass
+import org.gradle.kotlin.dsl.support.bytecode.publicDefaultConstructor
 import org.gradle.kotlin.dsl.support.zipTo
 
-import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes.ACC_PRIVATE
 import org.objectweb.asm.Opcodes.ACC_PUBLIC
-import org.objectweb.asm.Opcodes.ALOAD
-import org.objectweb.asm.Opcodes.INVOKESPECIAL
-import org.objectweb.asm.Opcodes.RETURN
-import org.objectweb.asm.Opcodes.V1_7
 
 import java.io.File
 
@@ -23,70 +22,71 @@ import kotlin.reflect.KClass
 open class TestWithClassPath : TestWithTempFiles() {
 
     protected
-    fun jarClassPathWith(vararg classes: KClass<*>): ClassPath =
-        classPathOf(file("cp.jar").also { jar ->
-            zipTo(jar, classEntriesFor(*classes.map { it.java }.toTypedArray()))
-        })
+    fun jarClassPathWith(vararg classes: KClass<*>): ClassPath = classPathOf(
+        file("cp.jar").also { jar ->
+            zipTo(jar, classEntriesFor(classes))
+        }
+    )
 
     protected
-    fun classPathWith(vararg classes: KClass<*>): ClassPath =
-        classPathOf(file("cp").also { rootDir ->
-            for ((path, bytes) in classEntriesFor(*classes.map { it.java }.toTypedArray())) {
+    fun classPathWith(vararg classes: KClass<*>): ClassPath = classPathOf(
+        newFolder().also { rootDir ->
+            for ((path, bytes) in classEntriesFor(classes)) {
                 File(rootDir, path).apply {
                     parentFile.mkdirs()
                     writeBytes(bytes)
                 }
             }
-        })
-
-    protected
-    fun classPathWithPublicType(name: String) =
-        classPathWithType(name, ACC_PUBLIC)
-
-    protected
-    fun classPathWithPrivateType(name: String) =
-        classPathWithType(name, ACC_PRIVATE)
-
-    protected
-    fun classPathWithType(name: String, vararg modifiers: Int): ClassPath =
-        classPathOf(file("cp").also { rootDir ->
-            classFileForType(name, rootDir, *modifiers)
-        })
-
-    protected
-    fun classPathWithPublicTypes(vararg names: String): ClassPath =
-        classPathOf(file("cp").also { rootDir ->
-            for (name in names) {
-                classFileForType(name, rootDir, ACC_PUBLIC)
-            }
-        })
-
-    private
-    fun classFileForType(name: String, rootDir: File, vararg modifiers: Int) {
-        val internalName = name.replace(".", "/")
-        File(rootDir, "$internalName.class").apply {
-            parentFile.mkdirs()
-            writeBytes(classBytesOf(internalName, *modifiers))
         }
-    }
-
-    private
-    fun classBytesOf(name: String, vararg modifiers: Int): ByteArray =
-        ClassWriter(0).run {
-            visit(V1_7, modifiers.fold(0, Int::plus), name, null, "java/lang/Object", null)
-            visitMethod(ACC_PUBLIC, "<init>", "()V", null, null).apply {
-                visitCode()
-                visitVarInsn(ALOAD, 0)
-                visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
-                visitInsn(RETURN)
-                visitMaxs(1, 1)
-            }
-            visitEnd()
-            toByteArray()
-        }
+    )
 }
 
 
 internal
-fun classPathOf(vararg files: File) =
-    DefaultClassPath.of(files.asList())
+fun TestWithTempFiles.classPathWithPublicType(name: String) =
+    classPathWithType(name, ACC_PUBLIC)
+
+
+internal
+fun TestWithTempFiles.classPathWithPrivateType(name: String) =
+    classPathWithType(name, ACC_PRIVATE)
+
+
+internal
+fun TestWithTempFiles.classPathWithType(name: String, vararg modifiers: Int): ClassPath = classPathOf(
+    newFolder().also { rootDir ->
+        writeClassFileTo(rootDir, name, *modifiers)
+    }
+)
+
+
+internal
+fun TestWithTempFiles.classPathWithPublicTypes(vararg names: String): ClassPath = classPathOf(
+    newFolder().also { rootDir ->
+        for (name in names) {
+            writeClassFileTo(rootDir, name, ACC_PUBLIC)
+        }
+    }
+)
+
+
+internal
+fun classPathOf(vararg files: File) = DefaultClassPath.of(files.asList())
+
+
+private
+fun writeClassFileTo(rootDir: File, name: String, vararg modifiers: Int) {
+    val internalName = name.replace(".", "/")
+    File(rootDir, "$internalName.class").apply {
+        parentFile.mkdirs()
+        writeBytes(classBytesOf(internalName, *modifiers))
+    }
+}
+
+
+private
+fun classBytesOf(name: String, vararg modifiers: Int): ByteArray =
+    beginClass(modifiers.fold(0, Int::plus), InternalName(name)).run {
+        publicDefaultConstructor()
+        endClass()
+    }

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractDslTest.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractDslTest.kt
@@ -26,7 +26,7 @@ import java.io.File
 abstract class AbstractDslTest : TestWithTempFiles() {
 
     protected
-    val kotlinDslEvalBaseCacheDir by lazy {
+    val kotlinDslEvalBaseCacheDir: File by lazy {
         newFolder("kotlin-dsl-eval-cache")
     }
 

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
@@ -14,6 +14,12 @@ abstract class TestWithTempFiles {
     val root: File
         get() = tempFolder.root
 
+    /**
+     * See [org.junit.rules.TemporaryFolder.newFolder]
+     */
+    fun newFolder(): File =
+        tempFolder.newFolder()
+
     protected
     fun file(fileName: String) =
         File(root, fileName)
@@ -27,6 +33,6 @@ abstract class TestWithTempFiles {
         newFile(fileName).apply { writeText(text) }
 
     protected
-    fun newFolder(vararg folderNames: String) =
+    fun newFolder(vararg folderNames: String): File =
         tempFolder.newFolder(*folderNames)
 }

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
@@ -45,6 +45,10 @@ inline fun withClassLoaderFor(vararg classPath: File, action: ClassLoader.() -> 
     classLoaderFor(*classPath).use(action)
 
 
+inline fun withClassLoaderFor(classPath: ClassPath, action: ClassLoader.() -> Unit) =
+    classLoaderFor(classPath).use(action)
+
+
 fun classLoaderFor(classPath: ClassPath): URLClassLoader =
     classLoaderFor(*classPath.asFiles.toTypedArray())
 

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/zipUtils.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/zipUtils.kt
@@ -1,7 +1,10 @@
 package org.gradle.kotlin.dsl.fixtures
 
 import org.gradle.kotlin.dsl.support.zipTo
+
 import java.io.ByteArrayOutputStream
+
+import kotlin.reflect.KClass
 
 
 fun zipOf(entries: Sequence<Pair<String, ByteArray>>): ByteArray =
@@ -9,6 +12,10 @@ fun zipOf(entries: Sequence<Pair<String, ByteArray>>): ByteArray =
         zipTo(this, entries)
         toByteArray()
     }
+
+
+fun classEntriesFor(classes: Array<out KClass<*>>) =
+    classEntriesFor(*classes.map { it.java }.toTypedArray())
 
 
 fun classEntriesFor(vararg classes: Class<*>): Sequence<Pair<String, ByteArray>> =


### PR DESCRIPTION
To enable quick documentation and navigation to the sources of default package types.

See #1205