### PR TITLE
#390 Document how to leverage the allopen compiler plugin

### DIFF
--- a/samples/project-with-buildSrc/buildSrc/build.gradle.kts
+++ b/samples/project-with-buildSrc/buildSrc/build.gradle.kts
@@ -1,11 +1,9 @@
 plugins {
     `kotlin-dsl`
-
-    // see buildSrc/src/main/kotlin/allopen-compiler-plugin.kt
-    id("org.jetbrains.kotlin.plugin.allopen") version "1.3.0"
+    kotlin("plugin.allopen") version KotlinVersion.CURRENT.toString()
 }
 
-// see buildSrc/src/main/kotlin/allopen-compiler-plugin.kt
+// see buildSrc/src/main/kotlin/my/plugin.allopen.kt
 allOpen {
     annotation("my.AllOpen")
 }

--- a/samples/project-with-buildSrc/buildSrc/build.gradle.kts
+++ b/samples/project-with-buildSrc/buildSrc/build.gradle.kts
@@ -1,6 +1,15 @@
 plugins {
     `kotlin-dsl`
+
+    // see buildSrc/src/main/kotlin/allopen-compiler-plugin.kt
+    id("org.jetbrains.kotlin.plugin.allopen") version "1.3.0"
 }
+
+// see buildSrc/src/main/kotlin/allopen-compiler-plugin.kt
+allOpen {
+    annotation("my.AllOpen")
+}
+
 
 repositories {
     jcenter()

--- a/samples/project-with-buildSrc/buildSrc/src/main/kotlin/HelloTask.kt
+++ b/samples/project-with-buildSrc/buildSrc/src/main/kotlin/HelloTask.kt
@@ -2,7 +2,7 @@ import org.gradle.api.*
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.*
 
-open class HelloTask : DefaultTask() {
+class HelloTask : my.DefaultTask() {
 
     init {
         group = "My"

--- a/samples/project-with-buildSrc/buildSrc/src/main/kotlin/MyProjectExtension.kt
+++ b/samples/project-with-buildSrc/buildSrc/src/main/kotlin/MyProjectExtension.kt
@@ -17,8 +17,8 @@ import org.gradle.api.model.ObjectFactory
 
 import org.gradle.kotlin.dsl.*
 
-
-open class MyProjectExtension(objects: ObjectFactory) {
+@my.AllOpen
+class MyProjectExtension(objects: ObjectFactory) {
 
     val flag = objects.property<Boolean>()
 }

--- a/samples/project-with-buildSrc/buildSrc/src/main/kotlin/MyProjectExtension.kt
+++ b/samples/project-with-buildSrc/buildSrc/src/main/kotlin/MyProjectExtension.kt
@@ -17,8 +17,7 @@ import org.gradle.api.model.ObjectFactory
 
 import org.gradle.kotlin.dsl.*
 
-@my.AllOpen
-class MyProjectExtension(objects: ObjectFactory) {
+class MyProjectExtension(objects: ObjectFactory) : my.Extension {
 
     val flag = objects.property<Boolean>()
 }

--- a/samples/project-with-buildSrc/buildSrc/src/main/kotlin/my/allopen-compiler-plugin.kt
+++ b/samples/project-with-buildSrc/buildSrc/src/main/kotlin/my/allopen-compiler-plugin.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package my
+
+/**
+ * If you don't declare your Task, Project, Extensions, ... as an "open class",
+ * Gradle 5.0 will fails at runtime with the error
+ *   `Cannot create a proxy class for final class at runtime.`
+ *
+ * This will be tentatively fixed in Gradle 5.1 by applying automatically the "allopen" compiler plugin
+ *
+ * See https://github.com/gradle/kotlin-dsl/issues/390
+ *
+ * In the meantime you can work-around this problem by importing this file,
+ * applying the Gradle configuration above, and extending `my.DefaultTask` and `my.Plugin`
+ * and annotating your extension with @my.AllOpen
+ *
+ * ```
+   // build.gradle.kts
+   plugins {
+        id("org.jetbrains.kotlin.plugin.allopen") version "1.3.0"
+    }
+
+    allOpen {
+    annotation("my.AllOpen")
+    }
+ * ```
+ ***/
+annotation class AllOpen
+
+@AllOpen
+abstract class DefaultTask : org.gradle.api.DefaultTask()
+
+@AllOpen
+interface Plugin<T>: org.gradle.api.Plugin<T>

--- a/samples/project-with-buildSrc/buildSrc/src/main/kotlin/my/plugin.allopen.kt
+++ b/samples/project-with-buildSrc/buildSrc/src/main/kotlin/my/plugin.allopen.kt
@@ -46,3 +46,6 @@ abstract class DefaultTask : org.gradle.api.DefaultTask()
 
 @AllOpen
 interface Plugin<T>: org.gradle.api.Plugin<T>
+
+@AllOpen
+interface Extension


### PR DESCRIPTION
### Context

If you don't declare your Task, Project, Extensions, ... as an `open class `,
Gradle 5.0 will fails at runtime with the error

  `> Cannot create a proxy class for final class at runtime.`

This will be tentatively fixed in Gradle 5.1 by applying automatically the "allopen" compiler plugin.

I thought it could be useful in the meantime to have the work-around documented as code in one of the samples. 

See discussion here https://github.com/gradle/kotlin-dsl/issues/390


### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
