### PR TITLE
Remove dependencies pinning from `embedded-kotlin` and add cross-kotlin-version coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,8 @@ allprojects {
     version = "1.0.2-SNAPSHOT"
 }
 
-val publishedPluginsVersion by extra { "1.0" }
-val futurePluginsVersion = "1.0.1"
+val publishedPluginsVersion by extra { "1.0.1" }
+val futurePluginsVersion = "1.0.2"
 project(":plugins") {
     group = "org.gradle.kotlin"
     version = futurePluginsVersion

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -36,8 +36,7 @@ import javax.inject.Inject
  *
  * Applies the `org.jetbrains.kotlin.jvm` plugin,
  * adds compile only dependencies on `kotlin-stdlib` and `kotlin-reflect`,
- * configures an embedded repository that contains all embedded Kotlin libraries,
- * and pins them to the embedded Kotlin version.
+ * configures an embedded repository that contains all embedded Kotlin libraries.
  */
 open class EmbeddedKotlinPlugin @Inject internal constructor(
     private val embeddedKotlin: EmbeddedKotlinProvider
@@ -60,10 +59,6 @@ open class EmbeddedKotlinPlugin @Inject internal constructor(
 
             kotlinArtifactConfigurationNames.forEach {
                 configurations.getByName(it).extendsFrom(embeddedKotlinConfiguration)
-            }
-
-            configurations.all {
-                embeddedKotlin.pinDependenciesOn(it, "stdlib-jdk8", "reflect", "compiler-embeddable")
             }
         }
     }

--- a/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.plugins.dsl
+
+import org.gradle.kotlin.dsl.embeddedKotlinVersion
+import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
+
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+
+@RunWith(Parameterized::class)
+class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
+
+    private
+    val kotlinVersion: String
+
+) : AbstractPluginTest() {
+
+    companion object {
+
+        @Parameterized.Parameters(name = "{0}")
+        @JvmStatic
+        fun testedKotlinVersions() = listOf(
+            embeddedKotlinVersion,
+            "1.2.20"
+        )
+    }
+
+    @Test
+    fun `kotlin-dsl plugin in buildSrc and production code using kotlin-gradle-plugin `() {
+
+        withDefaultSettingsIn("buildSrc")
+        withBuildScriptIn("buildSrc", """
+            import org.jetbrains.kotlin.config.KotlinCompilerVersion
+
+            plugins {
+                `kotlin-dsl`
+            }
+
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                implementation(kotlin("gradle-plugin", "$kotlinVersion"))
+            }
+
+            println("buildSrc build script classpath kotlin compiler version " + KotlinCompilerVersion.VERSION)
+        """)
+        withFile("buildSrc/src/main/kotlin/my-plugin.gradle.kts", """
+            apply<org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin>()
+        """)
+
+        withDefaultSettings()
+        withBuildScript("""
+            import org.jetbrains.kotlin.config.KotlinCompilerVersion
+
+            plugins {
+                `my-plugin`
+            }
+
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                implementation(kotlin("stdlib"))
+            }
+
+            println("root build script classpath kotlin compiler version " + KotlinCompilerVersion.VERSION)
+        """)
+        withFile("src/main/kotlin/SomeSource.kt", "fun main(args: Array<String>) {}")
+
+        buildWithPlugin("classes").apply {
+            assertThat(
+                output,
+                allOf(
+                    containsString("buildSrc build script classpath kotlin compiler version $embeddedKotlinVersion"),
+                    containsString("root build script classpath kotlin compiler version $kotlinVersion")
+                )
+            )
+        }
+    }
+}

--- a/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/subprojects/plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -160,34 +160,6 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
     }
 
     @Test
-    fun `embedded kotlin modules versions are pinned to the embedded Kotlin version`() {
-
-        withBuildScript("""
-
-            plugins {
-                `embedded-kotlin`
-            }
-
-            $repositoriesBlock
-
-            dependencies {
-                ${dependencyDeclarationsFor("compile", listOf("stdlib", "reflect", "compiler-embeddable"), "1.1.1")}
-                compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:0.15")
-            }
-
-            configurations["compileClasspath"].files.map { println(it) }
-
-        """)
-
-        val result = buildWithPlugin("dependencies")
-
-        listOf("stdlib", "reflect", "compiler-embeddable").forEach {
-            assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-$it:1.1.1 -> $embeddedKotlinVersion"))
-            assertThat(result.output, containsString("kotlin-$it-$embeddedKotlinVersion.jar"))
-        }
-    }
-
-    @Test
     fun `can add embedded dependencies to custom configuration`() {
 
         withBuildScript("""
@@ -211,38 +183,12 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
     }
 
     @Test
-    fun `embedded kotlin dependencies are pinned on custom configurations too`() {
-        withBuildScript("""
-
-            plugins {
-                `embedded-kotlin`
-            }
-
-            val customConfiguration by configurations.creating
-            customConfiguration.extendsFrom(configurations["embeddedKotlin"])
-
-            dependencies {
-                ${dependencyDeclarationsFor("customConfiguration", listOf("stdlib", "reflect", "compiler-embeddable"), "1.1.1")}
-                customConfiguration("org.jetbrains.kotlinx:kotlinx-coroutines-core:0.15")
-            }
-
-            $repositoriesBlock
-
-            configurations["customConfiguration"].files.map { println(it) }
-        """)
-
-        val result = buildWithPlugin("dependencies", "--configuration", "customConfiguration")
-
-        listOf("stdlib", "reflect", "compiler-embeddable").forEach {
-            assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-$it:1.1.1 -> $embeddedKotlinVersion"))
-            assertThat(result.output, containsString("kotlin-$it-$embeddedKotlinVersion.jar"))
-        }
-    }
-
-    @Test
     fun `can be used with GRADLE_METADATA feature preview enabled`() {
 
-        withSettings("""enableFeaturePreview("GRADLE_METADATA")""")
+        withSettings("""
+            $defaultSettingsScript
+            enableFeaturePreview("GRADLE_METADATA")
+        """)
 
         withBuildScript("""
 

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -64,11 +64,6 @@ class EmbeddedKotlinProvider constructor(
         }
     }
 
-    fun pinDependenciesOn(configuration: Configuration, vararg kotlinModules: String) {
-        val pinnedDependencies = transitiveClosureOf(*kotlinModules)
-        pinDependenciesOn(configuration, pinnedDependencies)
-    }
-
     internal
     fun pinDependenciesOn(configuration: Configuration, pinnedDependencies: Set<EmbeddedModule>) {
         configuration.resolutionStrategy.eachDependency { details ->


### PR DESCRIPTION
This PR removes dependencies pinning from the `embedded-kotlin` plugin. It is confusing and unnecessary. It also adds a cross-version test for using the `kotlin-dsl` plugin in `buildSrc` while using a different Kotlin version to compile production sources, it works down to kotlin 1.2.20.