### PR TITLE
 Let `creating` property delegate use `create` instead of `register`

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -325,11 +325,12 @@ private constructor(
             NamedDomainObjectContainerCreatingDelegateProvider(container, configuration)
     }
 
-    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) =
+    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) = ExistingDomainObjectDelegate.of(
         when (configuration) {
-            null -> container.register(property.name)
-            else -> container.register(property.name, configuration)
+            null -> container.create(property.name)
+            else -> container.create(property.name, configuration)
         }
+    )
 }
 
 
@@ -369,11 +370,12 @@ private constructor(
             PolymorphicDomainObjectContainerCreatingDelegateProvider(container, type, configuration)
     }
 
-    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) =
+    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) = ExistingDomainObjectDelegate.of(
         when (configuration) {
-            null -> container.register(property.name, type)
-            else -> container.register(property.name, type, configuration)
+            null -> container.create(property.name, type)
+            else -> container.create(property.name, type, configuration)
         }
+    )
 }
 
 

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -554,9 +554,7 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can register and configure element by creating with type`() {
 
         val fooObject = DomainObject()
-        val fooObjectProvider = mockDomainObjectProviderFor(fooObject)
         val barObject = DomainObject()
-        val barObjectProvider = mockDomainObjectProviderFor(barObject)
         val container = mock<PolymorphicDomainObjectContainer<Any>> {
             onCreateWithAction("foo", DomainObject::class, fooObject)
             onCreateWithAction("bar", DomainObject::class, barObject)

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -261,14 +261,14 @@ class NamedDomainObjectContainerExtensionsTest {
     fun `can create element within configuration block via delegated property`() {
 
         val tasks = mock<TaskContainer> {
-            on { register("hello") } doReturn mock<TaskProvider<Task>>()
+            on { create("hello") } doReturn mock<Task>()
         }
 
         tasks {
             @Suppress("unused_variable")
             val hello by creating
         }
-        verify(tasks).register("hello")
+        verify(tasks).create("hello")
     }
 
     @Test


### PR DESCRIPTION
To minimize confusion when migrating away from the eager API.