### PR TITLE
Let `getting` property delegate use `getByName` instead of `named`

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -408,9 +408,10 @@ private constructor(
             PolymorphicDomainObjectContainerGettingDelegateProvider(container, type, configuration)
     }
 
-    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) =
+    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>) = ExistingDomainObjectDelegate.of(
         when (configuration) {
-            null -> container.named(property.name, type)
-            else -> container.named(property.name, type, configuration)
+            null -> container.getByName(property.name, type)
+            else -> container.getByName(property.name, type, configuration)
         }
+    )
 }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectCollectionExtensionsTest.kt
@@ -382,23 +382,18 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can access named element by getting`() {
 
         val element = DomainObject()
-        val elementProvider = mockDomainObjectProviderFor(element)
         val container = mock<NamedDomainObjectContainer<DomainObject>> {
-            on { named("domainObject") } doReturn elementProvider
+            on { getByName("domainObject") } doReturn element
         }
 
         container {
             // invoke syntax
             val domainObject by getting
-            inOrder(container, elementProvider) {
-                verify(container).named("domainObject")
+            inOrder(container) {
+                verify(container).getByName("domainObject")
                 verifyNoMoreInteractions()
             }
             assertThat(domainObject, sameInstance(element))
-            inOrder(container, elementProvider) {
-                verify(elementProvider).get()
-                verifyNoMoreInteractions()
-            }
         }
 
         container.apply {
@@ -412,9 +407,11 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can configure named element by getting`() {
 
         val element = DomainObject()
-        val elementProvider = mockDomainObjectProviderFor(element)
         val container = mock<NamedDomainObjectContainer<DomainObject>> {
-            on { named("domainObject") } doReturn elementProvider
+            on { getByName(eq("domainObject"), any<Action<DomainObject>>()) } doAnswer {
+                it.getArgument<Action<DomainObject>>(1).execute(element)
+                element
+            }
         }
 
         container {
@@ -436,9 +433,8 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can access named element by getting with type`() {
 
         val element = DomainObject()
-        val elementProvider = mockDomainObjectProviderFor(element)
         val container = mock<NamedDomainObjectContainer<Any>> {
-            on { named("domainObject", DomainObject::class.java) } doReturn elementProvider
+            on { getByName("domainObject") } doReturn element
         }
 
         container {
@@ -458,12 +454,8 @@ class NamedDomainObjectCollectionExtensionsTest {
     fun `can configure named element by getting with type`() {
 
         val element = DomainObject()
-        val elementProvider = mockDomainObjectProviderFor(element)
         val container = mock<NamedDomainObjectContainer<Any>> {
-            on { named(eq("domainObject"), eq(DomainObject::class.java), any<Action<DomainObject>>()) } doAnswer {
-                elementProvider.configure(it.getArgument(2))
-                elementProvider
-            }
+            on { getByName("domainObject") } doReturn element
         }
 
         container {

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -15,7 +15,6 @@ import org.gradle.api.Task
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskProvider
 
 import org.gradle.kotlin.dsl.support.uncheckedCast
 
@@ -274,18 +273,15 @@ class NamedDomainObjectContainerExtensionsTest {
     @Test
     fun `can get element of specific type within configuration block via delegated property`() {
 
-        val taskProvider = mock<TaskProvider<JavaExec>> {
-            on { get() } doReturn mock<JavaExec>()
-        }
+        val task = mock<JavaExec>()
         val tasks = mock<TaskContainer> {
-            on { named("hello", JavaExec::class.java) } doReturn taskProvider
+            on { getByName("hello") } doReturn task
         }
 
         @Suppress("unused_variable")
         tasks {
             val hello by getting(JavaExec::class)
-            val ref = hello // forces the element to be accessed
         }
-        verify(tasks).named("hello", JavaExec::class.java)
+        verify(tasks).getByName("hello")
     }
 }


### PR DESCRIPTION
To minimize confusion when migrating away from the eager API.