### PR TITLE
Plugin classes don't need to be open

### DIFF
--- a/samples/gradle-plugin/plugin/src/main/kotlin/plugin/MyPlugin.kt
+++ b/samples/gradle-plugin/plugin/src/main/kotlin/plugin/MyPlugin.kt
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.Copy
 
 import org.gradle.kotlin.dsl.*
 
-open class MyPlugin : Plugin<Project> {
+class MyPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.run {

--- a/samples/provider-properties/build.gradle.kts
+++ b/samples/provider-properties/build.gradle.kts
@@ -11,7 +11,7 @@ configure<GreetingPluginExtension> {
         buildFile("b.txt"))
 }
 
-open class GreetingPlugin : Plugin<Project> {
+class GreetingPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
 

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -146,7 +146,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
             import org.gradle.api.*
             import org.gradle.kotlin.dsl.*
 
-            open class DeepThoughtPlugin : Plugin<Project> {
+            class DeepThoughtPlugin : Plugin<Project> {
                 override fun apply(project: Project) {
                     project.run {
                         task("compute") {
@@ -832,7 +832,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
 
             class Book(val name: String)
 
-            open class MyPlugin : Plugin<Project> {
+            class MyPlugin : Plugin<Project> {
                 override fun apply(project: Project): Unit = project.run {
                     extensions.add(typeOf<MutableMap<String, String>>(), "mapOfString", mutableMapOf("foo" to "bar"))
                     extensions.add(typeOf<MutableMap<String, Int>>(), "mapOfInt", mutableMapOf("deep" to 42))

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -617,7 +617,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
 
             open class MyExtension<T>
 
-            open class FooPlugin : Plugin<Project> {
+            class FooPlugin : Plugin<Project> {
                 override fun apply(project: Project): Unit = project.run {
                     // Using add() without specifying the public type causes type erasure
                     extensions.add("mine", MyExtension<String>())
@@ -671,7 +671,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
             import org.gradle.api.internal.*
             import org.gradle.api.internal.plugins.*
 
-            open class MyPlugin : Plugin<Project> {
+            class MyPlugin : Plugin<Project> {
                 override fun apply(project: Project): Unit = project.run {
 
                     val rootExtension = MyExtension("root")
@@ -762,7 +762,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
             import org.gradle.api.*
             import org.gradle.api.plugins.*
 
-            open class MyPlugin : Plugin<Project> {
+            class MyPlugin : Plugin<Project> {
                 override fun apply(project: Project): Unit = project.run {
                     convention.plugins.put("myConvention", MyPrivateConventionImpl())
                 }

--- a/subprojects/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
+++ b/subprojects/plugins-experiments/src/main/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPlugin.kt
@@ -24,7 +24,7 @@ val rulesetJar by lazy {
 }
 
 
-open class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
+class GradleKotlinDslKtlintConventionPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
 

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -38,7 +38,7 @@ import javax.inject.Inject
  * adds compile only dependencies on `kotlin-stdlib` and `kotlin-reflect`,
  * configures an embedded repository that contains all embedded Kotlin libraries.
  */
-open class EmbeddedKotlinPlugin @Inject internal constructor(
+class EmbeddedKotlinPlugin @Inject internal constructor(
     private val embeddedKotlin: EmbeddedKotlinProvider
 ) : Plugin<Project> {
 

--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
@@ -46,7 +46,7 @@ import java.io.File
 /*
  * Exposes `*.gradle.kts` scripts from regular Kotlin source-sets as binary Gradle plugins.
  */
-open class PrecompiledScriptPlugins : Plugin<Project> {
+class PrecompiledScriptPlugins : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
 


### PR DESCRIPTION
Only types decorated at runtime by Gradle needs to be open.
Relates to #390 