### PR TITLE
`kotlin-dsl` plugin sets Kotlin apiVersion and languageVersion to 1.3

### DIFF
--- a/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -52,6 +52,8 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
                 tasks.withType<KotlinCompile>().configureEach {
                     it.kotlinOptions {
                         jvmTarget = this@kotlinDslPluginOptions.jvmTarget.get()
+                        apiVersion = "1.3"
+                        languageVersion = "1.3"
                         freeCompilerArgs += listOf(
                             KotlinCompilerArguments.javaParameters,
                             KotlinCompilerArguments.jsr305Strict,


### PR DESCRIPTION
to match script compilation, see #1274
