### PR TITLE
Generate type-safe accessors for extensions of project.dependencies

### DIFF
--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -1000,6 +1000,35 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
         build("help")
     }
 
+    @Test
+    fun `accessors to extensions of the dependency handler`() {
+
+        withKotlinBuildSrc()
+        withFile("buildSrc/src/main/kotlin/Mine.kt", """
+            open class Mine {
+                val some = 19
+                val more = 23
+            }
+        """)
+        withFile("buildSrc/src/main/kotlin/my-plugin.gradle.kts", """
+            (dependencies as ExtensionAware).extensions.create<Mine>("mine")
+        """)
+
+        withBuildScript("""
+            plugins {
+                `my-plugin`
+            }
+
+            dependencies {
+                println(mine.some + project.dependencies.mine.more)
+            }
+        """.trimIndent())
+
+        build("help").apply {
+            assertThat(output, containsString("42"))
+        }
+    }
+
     private
     fun withBuildSrc(contents: FoldersDslExpression) {
         withFolders {

--- a/subprojects/provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
+++ b/subprojects/provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
@@ -20,6 +20,7 @@ import org.gradle.api.NamedDomainObjectCollectionSchema
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionsSchema
 import org.gradle.api.reflect.HasPublicType
@@ -82,6 +83,7 @@ fun targetSchemaFor(target: Any, targetType: TypeOf<*>): TargetTypedSchema {
             accessibleContainerSchema(target.tasks.collectionSchema).forEach { schema ->
                 tasks.add(ProjectSchemaEntry(typeOfTaskContainer, schema.name, schema.publicType))
             }
+            collectSchemaOf(target.dependencies, typeOfDependencyHandler)
             // WARN eagerly realize all source sets
             sourceSetsOf(target)?.forEach { sourceSet ->
                 collectSchemaOf(sourceSet, typeOfSourceSet)
@@ -161,6 +163,10 @@ val typeOfConfigurationContainer = typeOf<NamedDomainObjectContainer<Configurati
 
 private
 val typeOfSourceSet = typeOf<SourceSet>()
+
+
+private
+val typeOfDependencyHandler = typeOf<DependencyHandler>()
 
 
 private

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.plugins.ExtensionAware
 
 
 /**
@@ -28,14 +29,19 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
  *
  * @see [DependencyHandler]
  */
-class DependencyHandlerScope
+open class DependencyHandlerScope
 private constructor(
     val dependencies: DependencyHandler
 ) : DependencyHandler by dependencies {
 
     companion object {
         fun of(dependencies: DependencyHandler) =
-            DependencyHandlerScope(dependencies)
+            ExtensionAwareDependencyHandlerScope(dependencies) as DependencyHandlerScope
+
+        private
+        class ExtensionAwareDependencyHandlerScope(
+            dependencies: DependencyHandler
+        ) : DependencyHandlerScope(dependencies), ExtensionAware by (dependencies as ExtensionAware)
     }
 
     /**

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -35,8 +35,8 @@ private constructor(
 ) : DependencyHandler by dependencies {
 
     companion object {
-        fun of(dependencies: DependencyHandler) =
-            ExtensionAwareDependencyHandlerScope(dependencies) as DependencyHandlerScope
+        fun of(dependencies: DependencyHandler): DependencyHandlerScope =
+            ExtensionAwareDependencyHandlerScope(dependencies)
 
         private
         class ExtensionAwareDependencyHandlerScope(

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -311,8 +311,8 @@ class DependencyHandlerExtensionsTest {
             verifyNoMoreInteractions()
         }
     }
-
-    private
-    fun newDependencyHandlerMock(stubbing: KStubbing<DependencyHandler>.(DependencyHandler) -> Unit = {}) =
-        mock<DependencyHandler>(extraInterfaces = arrayOf(ExtensionAware::class), stubbing = stubbing)
 }
+
+
+fun newDependencyHandlerMock(stubbing: KStubbing<DependencyHandler>.(DependencyHandler) -> Unit = {}) =
+    mock<DependencyHandler>(extraInterfaces = arrayOf(ExtensionAware::class), stubbing = stubbing)

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.inOrder
+import com.nhaarman.mockito_kotlin.KStubbing
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
@@ -19,6 +20,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.plugins.ExtensionAware
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
@@ -40,7 +42,7 @@ class DependencyHandlerExtensionsTest {
             "classifier" to "cls",
             "ext" to "x")
 
-        val dependencies: DependencyHandler = mock()
+        val dependencies = newDependencyHandlerMock()
         val dependency: ExternalModuleDependency = mock()
         whenever(dependencies.create(expectedModuleMap)).thenReturn(dependency)
 
@@ -58,7 +60,7 @@ class DependencyHandlerExtensionsTest {
     @Test
     fun `given group and module, 'exclude' extension will build corresponding map`() {
 
-        val dependencies = DependencyHandlerScope.of(mock())
+        val dependencies = DependencyHandlerScope.of(newDependencyHandlerMock())
         val dependency: ExternalModuleDependency = mock()
         val events = mutableListOf<String>()
         whenever(dependencies.create("dependency")).then {
@@ -93,7 +95,7 @@ class DependencyHandlerExtensionsTest {
     @Test
     fun `given path and configuration, 'project' extension will build corresponding map`() {
 
-        val dependencies = DependencyHandlerScope.of(mock())
+        val dependencies = DependencyHandlerScope.of(newDependencyHandlerMock())
         val dependency: ProjectDependency = mock()
         val events = mutableListOf<String>()
         val expectedProjectMap = mapOf("path" to ":project", "configuration" to "default")
@@ -126,7 +128,7 @@ class DependencyHandlerExtensionsTest {
     @Test
     fun `given configuration name and dependency notation, it will add the dependency`() {
 
-        val dependencyHandler = mock<DependencyHandler> {
+        val dependencyHandler = newDependencyHandlerMock {
             on { add(any(), any()) } doReturn mock<Dependency>()
         }
 
@@ -141,7 +143,7 @@ class DependencyHandlerExtensionsTest {
     @Test
     fun `given configuration and dependency notation, it will add the dependency to the named configuration`() {
 
-        val dependencyHandler = mock<DependencyHandler> {
+        val dependencyHandler = newDependencyHandlerMock {
             on { add(any(), any()) } doReturn mock<Dependency>()
         }
         val configuration = mock<Configuration> {
@@ -167,7 +169,7 @@ class DependencyHandlerExtensionsTest {
         val antLauncherDependency = mock<ExternalModuleDependency>(name = "antLauncherDependency")
         val antJUnitDependency = mock<ExternalModuleDependency>(name = "antJUnitDependency")
 
-        val dependencies = mock<DependencyHandler> {
+        val dependencies = newDependencyHandlerMock {
             on { module("org.codehaus.groovy:groovy:2.4.7") } doReturn clientModule
 
             on { create("commons-cli:commons-cli:1.0") } doReturn commonsCliDependency
@@ -214,7 +216,7 @@ class DependencyHandlerExtensionsTest {
     @Test
     fun `dependency on configuration using string notation doesn't cause IllegalStateException`() {
 
-        val dependencyHandler = mock<DependencyHandler> {
+        val dependencyHandler = newDependencyHandlerMock {
             on { add(any(), any()) }.thenReturn(null)
         }
 
@@ -231,7 +233,7 @@ class DependencyHandlerExtensionsTest {
     @Test
     fun `dependency on configuration doesn't cause IllegalStateException`() {
 
-        val dependencyHandler = mock<DependencyHandler> {
+        val dependencyHandler = newDependencyHandlerMock {
             on { add(any(), any()) }.thenReturn(null)
         }
 
@@ -257,7 +259,7 @@ class DependencyHandlerExtensionsTest {
             on { add(any(), any()) } doReturn constraint
             on { add(any(), any(), any()) } doReturn constraint
         }
-        val dependenciesHandler = mock<DependencyHandler> {
+        val dependenciesHandler = newDependencyHandlerMock {
             on { constraints } doReturn constraintHandler
             on { constraints(any()) } doAnswer {
                 (it.getArgument(0) as Action<DependencyConstraintHandler>).execute(constraintHandler)
@@ -309,4 +311,8 @@ class DependencyHandlerExtensionsTest {
             verifyNoMoreInteractions()
         }
     }
+
+    private
+    fun newDependencyHandlerMock(stubbing: KStubbing<DependencyHandler>.(DependencyHandler) -> Unit = {}) =
+        mock<DependencyHandler>(extraInterfaces = arrayOf(ExtensionAware::class), stubbing = stubbing)
 }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScopeTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScopeTest.kt
@@ -66,7 +66,7 @@ class ScriptHandlerScopeTest {
         val constraintHandler = mock<DependencyConstraintHandler> {
             on { add(any(), any()) } doReturn constraint
         }
-        val dependencies = mock<DependencyHandler>(arrayOf(ExtensionAware::class)) {
+        val dependencies = newDependencyHandlerMock {
             on { constraints } doReturn constraintHandler
             on { constraints(any()) } doAnswer {
                 (it.getArgument(0) as Action<DependencyConstraintHandler>).execute(constraintHandler)

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScopeTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScopeTest.kt
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.initialization.dsl.ScriptHandler
+import org.gradle.api.plugins.ExtensionAware
 
 import org.gradle.kotlin.dsl.support.configureWith
 
@@ -42,7 +43,7 @@ class ScriptHandlerScopeTest {
     fun `can exclude modules from classpath dependency`() {
 
         val dependency = mock<ExternalModuleDependency>()
-        val dependencies = mock<DependencyHandler> {
+        val dependencies = mock<DependencyHandler>(arrayOf(ExtensionAware::class)) {
             on { create("...") } doReturn dependency
         }
         val buildscript = mock<ScriptHandler> {
@@ -65,7 +66,7 @@ class ScriptHandlerScopeTest {
         val constraintHandler = mock<DependencyConstraintHandler> {
             on { add(any(), any()) } doReturn constraint
         }
-        val dependencies = mock<DependencyHandler> {
+        val dependencies = mock<DependencyHandler>(arrayOf(ExtensionAware::class)) {
             on { constraints } doReturn constraintHandler
             on { constraints(any()) } doAnswer {
                 (it.getArgument(0) as Action<DependencyConstraintHandler>).execute(constraintHandler)


### PR DESCRIPTION
This PR adds generation of type-safe accessors for extensions of `project.dependencies`.

Note that `DependencyHandler` doesn't expose that it implements `ExtensionAware`, this PR doesn't change that and does not expose it either on `DependencyHandlerScope`.

See #1185 
