### PR TITLE
Let generated extensions jar be reproducible

### DIFF
--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
@@ -26,8 +26,11 @@ import org.gradle.api.tasks.TaskCollection
 import org.gradle.util.GradleVersion
 
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -235,7 +238,12 @@ class GradleApiExtensionsIntegrationTest : AbstractPluginIntegrationTest() {
 
         assertThat(
             generatedSourceCode,
-            allOf(extensions.map { containsMultiLineString(it) })
+            allOf(extensions.map { containsString(it.normaliseLineSeparators().trimIndent()) })
+        )
+
+        assertThat(
+            generatedSourceCode,
+            not(containsString("\r"))
         )
     }
 }

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
@@ -23,6 +23,7 @@ import org.gradle.api.Task
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.TaskCollection
 
+import org.gradle.internal.hash.HashUtil
 import org.gradle.util.GradleVersion
 
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
@@ -30,6 +31,7 @@ import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
@@ -185,17 +187,21 @@ class GradleApiExtensionsIntegrationTest : AbstractPluginIntegrationTest() {
     }
 
     @Test
+    fun `generated jar is reproducible`() {
+        val generatedJarHash = HashUtil.createHash(generatedExtensionsJarFromTestKitUserHome(), "MD5")
+        assertThat(
+            generatedJarHash.asZeroPaddedHexString(32),
+            equalTo("04261b4b0c42d4ffaf9aec92547776ed")
+        )
+    }
+
+    @Test
     fun `generated jar contains Gradle API extensions sources and byte code`() {
 
         withBuildScript("")
         build("help")
 
-        val gradleUserHomeDir = File(System.getProperty("org.gradle.testkit.dir"))
-
-        val generatedJar = gradleUserHomeDir.resolve("caches")
-            .listFiles { f -> f.isDirectory && f.name == GradleVersion.current().version }.single()
-            .resolve("generated-gradle-jars")
-            .listFiles { f -> f.isFile && f.name.startsWith("gradle-kotlin-dsl-extensions-") }.single()
+        val generatedJar = generatedExtensionsJarFromTestKitUserHome()
 
         val (generatedSources, generatedClasses) = JarFile(generatedJar)
             .use { it.entries().toList().map { entry -> entry.name } }
@@ -246,4 +252,12 @@ class GradleApiExtensionsIntegrationTest : AbstractPluginIntegrationTest() {
             not(containsString("\r"))
         )
     }
+
+    private
+    fun generatedExtensionsJarFromTestKitUserHome(): File =
+        File(System.getProperty("org.gradle.testkit.dir"))
+            .resolve("caches")
+            .listFiles { f -> f.isDirectory && f.name == GradleVersion.current().version }.single()
+            .resolve("generated-gradle-jars")
+            .listFiles { f -> f.isFile && f.name.startsWith("gradle-kotlin-dsl-extensions-") }.single()
 }

--- a/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/integ-tests/src/test/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -25,8 +25,8 @@ import org.gradle.kotlin.dsl.fixtures.LightThought
 import org.gradle.kotlin.dsl.fixtures.ZeroThought
 import org.gradle.kotlin.dsl.fixtures.canPublishBuildScan
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
-import org.gradle.kotlin.dsl.fixtures.convertLineSeparators
 import org.gradle.kotlin.dsl.fixtures.rootProjectDir
+import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
@@ -572,7 +572,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
             withBuildScript("foo")
 
         assertThat(
-            buildFailureOutput().convertLineSeparators(),
+            buildFailureOutput().normaliseLineSeparators(),
             containsString("""
                 FAILURE: Build failed with an exception.
 
@@ -596,7 +596,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
         withBuildScript("publishing { }")
 
         assertThat(
-            buildFailureOutput().convertLineSeparators(),
+            buildFailureOutput().normaliseLineSeparators(),
             containsString("""
                 * What went wrong:
                 Script compilation errors:
@@ -617,7 +617,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
         val buildFile = withBuildScript("println(foo)\n\n\n\n\nprintln(\"foo\").bar.bazar\n\n\n\nprintln(cathedral)")
 
         assertThat(
-            buildFailureOutput().convertLineSeparators(),
+            buildFailureOutput().normaliseLineSeparators(),
             allOf(
                 containsString("""
                     FAILURE: Build failed with an exception.

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -31,6 +31,7 @@ import org.gradle.kotlin.dsl.concurrent.IO
 import org.gradle.kotlin.dsl.concurrent.withAsynchronousIO
 
 import org.gradle.kotlin.dsl.support.ClassBytesRepository
+import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.support.useToRun
 
@@ -495,16 +496,16 @@ fun enabledJitAccessors(project: Project) =
 internal
 fun IO.writeAccessorsTo(outputFile: File, accessors: List<String>, imports: List<String> = emptyList()) = io {
     outputFile.bufferedWriter().useToRun {
-        appendln(fileHeaderWithImports)
+        appendReproducibleNewLine(fileHeaderWithImports)
         if (imports.isNotEmpty()) {
             imports.forEach {
-                appendln("import $it")
+                appendReproducibleNewLine("import $it")
             }
-            appendln()
+            appendReproducibleNewLine()
         }
         accessors.forEach {
-            appendln(it.replaceIndent())
-            appendln()
+            appendReproducibleNewLine(it.replaceIndent())
+            appendReproducibleNewLine()
         }
     }
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -34,6 +34,7 @@ import org.gradle.kotlin.dsl.concurrent.writeFile
 
 import org.gradle.kotlin.dsl.provider.kotlinScriptClassPathProviderOf
 
+import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
 import org.gradle.kotlin.dsl.support.bytecode.ALOAD
 import org.gradle.kotlin.dsl.support.bytecode.ARETURN
 import org.gradle.kotlin.dsl.support.bytecode.DUP
@@ -181,15 +182,15 @@ fun ClassWriter.emitAccessorMethodFor(accessor: PluginAccessor, signature: JvmMe
 private
 fun IO.writePluginAccessorsSourceCodeTo(sourceFile: File, accessors: List<PluginAccessor>) = io {
     sourceFile.bufferedWriter().useToRun {
-        appendln(fileHeader)
+        appendReproducibleNewLine(fileHeader)
 
-        appendln("""
+        appendReproducibleNewLine("""
             import ${PluginDependenciesSpec::class.qualifiedName}
             import ${PluginDependencySpec::class.qualifiedName}
         """.replaceIndent())
 
         defaultPackageTypesIn(accessors).forEach {
-            appendln("import $it")
+            appendReproducibleNewLine("import $it")
         }
 
         accessors.runEach {
@@ -199,7 +200,7 @@ fun IO.writePluginAccessorsSourceCodeTo(sourceFile: File, accessors: List<Plugin
             val pluginsRef = pluginDependenciesSpecOf(extendedType)
             when (this) {
                 is PluginAccessor.ForPlugin -> {
-                    appendln("""
+                    appendReproducibleNewLine("""
                         /**
                          * The `$id` plugin implemented by [$implementationClass].
                          */
@@ -209,7 +210,7 @@ fun IO.writePluginAccessorsSourceCodeTo(sourceFile: File, accessors: List<Plugin
                 }
                 is PluginAccessor.ForGroup -> {
                     val groupType = extension.returnType.sourceName
-                    appendln("""
+                    appendReproducibleNewLine("""
                         /**
                          * The `$id` plugin group.
                          */

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsGenerator.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsGenerator.kt
@@ -20,6 +20,7 @@ package org.gradle.kotlin.dsl.codegen
 
 import org.gradle.api.file.RelativePath
 import org.gradle.api.specs.Spec
+import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
 import org.gradle.kotlin.dsl.support.useToRun
 
 import java.io.File
@@ -268,15 +269,15 @@ data class KotlinExtensionFunction(
 
     fun toKotlinString(): String = StringBuilder().apply {
 
-        appendln("""
+        appendReproducibleNewLine("""
             /**
              * $description.
              *
              * @see ${targetType.sourceName}.$name
              */
         """.trimIndent())
-        if (isDeprecated) appendln("""@Deprecated("Deprecated Gradle API")""")
-        if (isIncubating) appendln("@org.gradle.api.Incubating")
+        if (isDeprecated) appendReproducibleNewLine("""@Deprecated("Deprecated Gradle API")""")
+        if (isIncubating) appendReproducibleNewLine("@org.gradle.api.Incubating")
         append("inline fun ")
         if (typeParameters.isNotEmpty()) append("${typeParameters.joinInAngleBrackets { it.toTypeParameterString() }} ")
         append(targetType.sourceName)
@@ -287,9 +288,9 @@ data class KotlinExtensionFunction(
         append(parameters.toDeclarationString())
         append("): ")
         append(returnType.toTypeArgumentString())
-        appendln(" =")
-        appendln("`$name`(${parameters.toArgumentsString()})".prependIndent())
-        appendln()
+        appendReproducibleNewLine(" =")
+        appendReproducibleNewLine("`$name`(${parameters.toArgumentsString()})".prependIndent())
+        appendReproducibleNewLine()
     }.toString()
 
     private

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
@@ -26,3 +26,12 @@ fun userHome() = File(System.getProperty("user.home"))
 internal
 inline fun <T : AutoCloseable, U> T.useToRun(action: T.() -> U): U =
     use { run(action) }
+
+
+/**
+ * Appends value to the given Appendable and simple `\n` line separator after it.
+ *
+ * Always using the same line separator on all systems to allow for reproducible outputs.
+ */
+fun Appendable.appendReproducibleNewLine(value: CharSequence = ""): Appendable =
+    append(value).append("\n")

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.kotlin.dsl.support
 
+import org.gradle.api.internal.file.archive.ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES
+
 import org.gradle.util.TextUtil.normaliseFileSeparators
 
 import java.io.File
@@ -29,10 +31,39 @@ import java.util.zip.ZipOutputStream
 
 
 fun zipTo(zipFile: File, baseDir: File) {
-    zipTo(zipFile, baseDir, baseDir.walkTopDown())
+    zipTo(zipFile, baseDir, baseDir.walkReproducibly())
 }
 
 
+private
+fun File.walkReproducibly(): Sequence<File> = sequence {
+    yield(this@walkReproducibly)
+    if (isDirectory) {
+        var directories: List<File> = listOf(this@walkReproducibly)
+        while (directories.isNotEmpty()) {
+            val subDirectories = mutableListOf<File>()
+            directories.forEach { dir ->
+                dir.listFiles()?.groupBy { it.isDirectory }?.also { children ->
+                    children[false]?.sortedBy(fileName)?.also { childFiles ->
+                        yieldAll(childFiles)
+                    }
+                    children[true]?.sortedBy(fileName)?.also { childDirectories ->
+                        yieldAll(childDirectories)
+                        subDirectories.addAll(childDirectories)
+                    }
+                }
+            }
+            directories = subDirectories
+        }
+    }
+}
+
+
+private
+val fileName: (File) -> String = { it.name }
+
+
+private
 fun zipTo(zipFile: File, baseDir: File, files: Sequence<File>) {
     zipTo(zipFile, fileEntriesRelativeTo(baseDir, files))
 }
@@ -57,11 +88,15 @@ fun zipTo(zipFile: File, entries: Sequence<Pair<String, ByteArray>>) {
 }
 
 
+private
 fun zipTo(outputStream: OutputStream, entries: Sequence<Pair<String, ByteArray>>) {
     ZipOutputStream(outputStream).use { zos ->
         entries.forEach { entry ->
             val (path, bytes) = entry
-            zos.putNextEntry(ZipEntry(path).apply { size = bytes.size.toLong() })
+            zos.putNextEntry(ZipEntry(path).apply {
+                time = CONSTANT_TIME_FOR_ZIP_ENTRIES
+                size = bytes.size.toLong()
+            })
             zos.write(bytes)
             zos.closeEntry()
         }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/support/zip.kt
@@ -43,13 +43,11 @@ fun File.walkReproducibly(): Sequence<File> = sequence {
         while (directories.isNotEmpty()) {
             val subDirectories = mutableListOf<File>()
             directories.forEach { dir ->
-                dir.listFiles()?.groupBy { it.isDirectory }?.also { children ->
-                    children[false]?.sortedBy(fileName)?.also { childFiles ->
-                        yieldAll(childFiles)
-                    }
-                    children[true]?.sortedBy(fileName)?.also { childDirectories ->
-                        yieldAll(childDirectories)
-                        subDirectories.addAll(childDirectories)
+                dir.listFiles()?.partition { it.isDirectory }?.also { (childDirectories, childFiles) ->
+                    yieldAll(childFiles.sortedBy(fileName))
+                    childDirectories.sortedBy(fileName).also {
+                        yieldAll(it)
+                        subDirectories.addAll(it)
                     }
                 }
             }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -30,8 +30,9 @@ import org.gradle.kotlin.dsl.fixtures.codegen.ClassAndGroovyNamedArguments
 import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClass
 import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClassParameterizedType
 import org.gradle.kotlin.dsl.fixtures.codegen.GroovyNamedArguments
-import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 
+import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
 import org.junit.Test
 
@@ -307,7 +308,7 @@ class GradleApiExtensionsTest : TestWithClassPath() {
         println(generatedSourceCode)
 
         expectedExtensions.forEach { expectedExtension ->
-            assertThat(generatedSourceCode, containsMultiLineString(expectedExtension))
+            assertThat(generatedSourceCode, containsString(expectedExtension.normaliseLineSeparators().trimIndent()))
         }
     }
 

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/string.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/string.kt
@@ -9,7 +9,3 @@ fun String.toPlatformLineSeparators() =
 
 fun <T> Iterable<T>.joinLines(transform: (T) -> String) =
     joinToString(separator = "\n", transform = transform)
-
-
-fun String.convertLineSeparators() =
-    TextUtil.normaliseLineSeparators(this)

--- a/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/zipUtils.kt
+++ b/subprojects/test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/zipUtils.kt
@@ -1,17 +1,6 @@
 package org.gradle.kotlin.dsl.fixtures
 
-import org.gradle.kotlin.dsl.support.zipTo
-
-import java.io.ByteArrayOutputStream
-
 import kotlin.reflect.KClass
-
-
-fun zipOf(entries: Sequence<Pair<String, ByteArray>>): ByteArray =
-    ByteArrayOutputStream().run {
-        zipTo(this, entries)
-        toByteArray()
-    }
 
 
 fun classEntriesFor(classes: Array<out KClass<*>>) =


### PR DESCRIPTION
in order for script compilation classpath and `KotlinCompile` classpath in projects using the `kotlin-dsl` plugin (e.g. `buildSrc`) to be reproducible leading to more cache hits

See #1286 