### PR TITLE
Add convenience method for `MapProperty` that was introduced in 5.1

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ObjectFactoryExtensions.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ObjectFactoryExtensions.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl
 import org.gradle.api.Named
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 
@@ -74,3 +75,12 @@ inline fun <reified T> ObjectFactory.setProperty(): SetProperty<T> =
  */
 inline fun <reified T> ObjectFactory.listProperty(): ListProperty<T> =
     listProperty(T::class.java)
+
+
+/**
+ * Creates a [MapProperty] that holds values of the given key type [K] and value type [V].
+ *
+ * @see [ObjectFactory.mapProperty]
+ */
+inline fun <reified K, reified V> ObjectFactory.mapProperty(): MapProperty<K, V> =
+    mapProperty(K::class.java, V::class.java)

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ObjectFactoryExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/ObjectFactoryExtensionsTest.kt
@@ -27,6 +27,7 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
+import org.gradle.api.provider.MapProperty
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Assert.assertThat
@@ -108,6 +109,21 @@ class ObjectFactoryExtensionsTest {
 
         inOrder(objectFactory) {
             verify(objectFactory).listProperty(String::class.java)
+            verifyNoMoreInteractions()
+        }
+    }
+
+    @Test
+    fun mapProperty() {
+
+        val objectFactory = mock<ObjectFactory> {
+            on { mapProperty(any<Class<*>>(), any<Class<*>>()) } doReturn mock<MapProperty<String, Int>>()
+        }
+
+        objectFactory.mapProperty<String, Int>()
+
+        inOrder(objectFactory) {
+            verify(objectFactory).mapProperty(String::class.java, Int::class.javaObjectType)
             verifyNoMoreInteractions()
         }
     }


### PR DESCRIPTION
### Context

Similar convenience like the other `*property()` methods

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
