### PR TITLE
Add support for declaring collections of dependencies

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -55,6 +55,14 @@ private constructor(
         dependencies.add(this, dependencyNotation)
 
     /**
+     * Adds dependencies to the given configuration.
+     *
+     * @param dependencyNotations notations for the dependencies to be added.
+     */
+    operator fun String.invoke(dependencyNotations: Collection<Any>) =
+        dependencyNotations.forEach { dependencies.add(this, it) }
+
+    /**
      * Adds a dependency to the given configuration.
      *
      * @param dependencyNotation notation for the dependency to be added.

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.initialization.dsl.ScriptHandler.CLASSPATH_CONFIGURATION
+import org.gradle.kotlin.dsl.accessors.runtime.addDependenciesTo
 
 import org.gradle.kotlin.dsl.support.unsafeLazy
 
@@ -68,6 +69,14 @@ private constructor(
      */
     fun DependencyHandler.classpath(dependencyNotation: Any): Dependency? =
         add(CLASSPATH_CONFIGURATION, dependencyNotation)
+
+    /**
+     * Adds a collection of dependencies to the script classpath.
+     *
+     * @param dependencyNotations notations for the dependencies to be added.
+     */
+    fun DependencyHandler.classpath(dependencyNotations: Collection<Any>) =
+        addDependenciesTo(this, CLASSPATH_CONFIGURATION, dependencyNotations)
 
     /**
      * Adds a dependency to the script classpath.

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -112,6 +112,45 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             source = name.run {
                 """
                     /**
+                     * Adds a collection of dependencies to the '$original' configuration.
+                     *
+                     * @param dependencyNotations notations for the dependencies to be added.
+                     */
+                    fun DependencyHandler.`$kotlinIdentifier`(dependencyNotations: Collection<Any>) =
+                        addDependenciesTo(this, "$stringLiteral", dependencyNotations)
+                """
+            },
+            bytecode = {
+                publicStaticMethod(signature) {
+                    ALOAD(0)
+                    LDC(name.original)
+                    ALOAD(1)
+                    invokeRuntime(
+                        "addDependenciesTo",
+                        "(L${GradleTypeName.dependencyHandler};Ljava/lang/String;Ljava/util/Collection;)V")
+                    RETURN()
+                }
+            },
+            metadata = {
+                writer.writeFunctionOf(
+                    receiverType = GradleType.dependencyHandler,
+                    returnType = KotlinType.unit,
+                    name = signature.name,
+                    parameters = {
+                        visitParameter("dependencyNotations", genericTypeOf(KotlinType.collection, KotlinType.any))
+                    },
+                    signature = signature
+                )
+            },
+            signature = JvmMethodSignature(
+                name.original,
+                "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Ljava/util/Collection;)V"
+            )
+        ),
+        AccessorFragment(
+            source = name.run {
+                """
+                    /**
                      * Adds a dependency to the '$original' configuration.
                      *
                      * @param dependencyNotation notation for the dependency to be added.
@@ -476,17 +515,6 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             signature = JvmMethodSignature(
                 name.original,
                 "(Lorg/gradle/api/artifacts/dsl/ArtifactHandler;Ljava/lang/Object;Lorg/gradle/api/Action;)Lorg/gradle/api/artifacts/PublishArtifact;"
-            )
-        ),
-        AccessorFragment(
-            source = "",
-            bytecode = {
-            },
-            metadata = {
-            },
-            signature = JvmMethodSignature(
-                name.original,
-                ""
             )
         )
     )

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinType.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinType.kt
@@ -29,4 +29,6 @@ object KotlinType {
     val any: KmTypeBuilder = { visitClass("kotlin/Any") }
 
     val typeParameter: KmTypeBuilder = { visitTypeParameter(0) }
+
+    val collection: KmTypeBuilder = { visitClass("kotlin/collections/Collection") }
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
@@ -61,6 +61,15 @@ fun <T : Dependency> addDependencyTo(
 }
 
 
+fun addDependenciesTo(
+    dependencies: DependencyHandler,
+    configuration: String,
+    dependencyNotations: Collection<Any>
+) {
+    dependencyNotations.forEach { dependencies.add(configuration, it) }
+}
+
+
 fun addExternalModuleDependencyTo(
     dependencyHandler: DependencyHandler,
     targetConfiguration: String,

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.plugins.ExtensionAware
 
 import org.hamcrest.CoreMatchers.equalTo
@@ -126,18 +127,25 @@ class DependencyHandlerExtensionsTest {
     }
 
     @Test
-    fun `given configuration name and dependency notation, it will add the dependency`() {
+    fun `given configuration name and dependency notations, it will add the dependencies`() {
 
         val dependencyHandler = newDependencyHandlerMock {
             on { add(any(), any()) } doReturn mock<Dependency>()
         }
 
+        val files = mock<ConfigurableFileCollection>()
+
         val dependencies = DependencyHandlerScope.of(dependencyHandler)
         dependencies {
             "configuration"("notation")
+            "configuration2"(listOf("notation1", "notation2"))
+            "configuration3"(files)
         }
 
         verify(dependencyHandler).add("configuration", "notation")
+        verify(dependencyHandler).add("configuration2", "notation1")
+        verify(dependencyHandler).add("configuration2", "notation2")
+        verify(dependencyHandler).add("configuration3", files)
     }
 
     @Test

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
@@ -325,6 +325,10 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
                         }
                     }
                 }
+
+                val p: Unit = dependencies.api(listOf("module", "anothermodule"))
+
+                val q: Unit = dependencies.api(listOf("module", mapOf("group" to "g", "name" to "n"), projectDependency))
             """
         )
 
@@ -408,6 +412,17 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
             verify(project).dependencies
             verify(dependencies).create(mapOf("group" to "g", "name" to "n"))
             verify(dependencies).add("api", dependency)
+
+            // val p
+            verify(project).dependencies
+            verify(dependencies).add("api", "module")
+            verify(dependencies).add("api", "anothermodule")
+
+            // val q
+            verify(project).dependencies
+            verify(dependencies).add("api", "module")
+            verify(dependencies).add("api", mapOf("group" to "g", "name" to "n"))
+            verify(dependencies).add(eq("api"), same(projectDependency))
 
             verifyNoMoreInteractions()
         }

--- a/subprojects/provider/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
+++ b/subprojects/provider/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
@@ -63,6 +63,15 @@
 
 
     /**
+     * Adds a collection of dependencies to the 'api' configuration.
+     *
+     * @param dependencyNotations notations for the dependencies to be added.
+     */
+    fun DependencyHandler.`api`(dependencyNotations: Collection<Any>) =
+        addDependenciesTo(this, "api", dependencyNotations)
+
+
+    /**
      * Adds a dependency to the 'api' configuration.
      *
      * @param dependencyNotation notation for the dependency to be added.


### PR DESCRIPTION
### Context
The gradle-dsl supports adding multiple dependencies at a time, using collections and varargs syntax.
Thus when transitioning scripts from groovy to kotlin users are forced to adopt a much more verbose syntax.

https://github.com/gradle/kotlin-dsl/issues/639
https://github.com/gradle/kotlin-dsl/issues/1187
https://github.com/gradle/gradle/issues/7649

In #639 the determination was made that this functionality should be added upstream by adding to gradles `DependencyHandler` API, and thus the issue was migrated.  

Not sure that I really agree with that assessment, even if a collection overload is eventually added to the gradle API, the kotlin-dsl will still need to provide specialized configuration accessors pointing to it.

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Provide integration tests to verify changes from a user perspective
- [x] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
