### PR TITLE
Replace exceptions by strings in the buildscript classpath TAPI model

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
@@ -74,7 +74,7 @@ internal
 data class ResolvedDependenciesWithErrors(
     val scriptFile: File?,
     val dependencies: KotlinScriptExternalDependencies,
-    val exceptions: List<Exception>
+    val exceptions: List<String>
 ) : ResolverEvent()
 
 
@@ -82,5 +82,5 @@ internal
 data class ResolvedToPreviousWithErrors(
     val scriptFile: File?,
     val dependencies: KotlinScriptExternalDependencies,
-    val exceptions: List<Exception>
+    val exceptions: List<String>
 ) : ResolverEvent()

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -206,7 +206,7 @@ object DefaultResolverEventLogger : ResolverEventLogger {
         }
 
     private
-    fun stringForExceptions(exceptions: List<Exception>, indentation: Int?) =
+    fun stringForExceptions(exceptions: List<String>, indentation: Int?) =
         if (exceptions.isNotEmpty())
             indentationStringFor(indentation).let {
                 exceptions.joinToString(prefix = "[\n$it\t", separator = ",\n$it\t", postfix = "]") { exception ->
@@ -217,9 +217,15 @@ object DefaultResolverEventLogger : ResolverEventLogger {
 
     private
     fun stringForException(exception: Exception, indentation: Int?) =
+        stringForException(
+            StringWriter().also { exception.printStackTrace(PrintWriter(it)) }.toString(),
+            indentation
+        )
+
+    private
+    fun stringForException(exception: String, indentation: Int?) =
         indentationStringFor(indentation).let {
-            StringWriter().also { writer -> exception.printStackTrace(PrintWriter(writer)) }.toString()
-                .prependIndent(it)
+            exception.prependIndent(it)
         }
 
     private

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRepositoryTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRepositoryTest.kt
@@ -156,7 +156,7 @@ class KotlinBuildScriptModelRepositoryTest {
         override val sourcePath: List<File> = emptyList(),
         override val implicitImports: List<String> = emptyList(),
         override val editorReports: List<EditorReport> = emptyList(),
-        override val exceptions: List<Exception> = emptyList(),
+        override val exceptions: List<String> = emptyList(),
         override val enclosingScriptProjectDir: File? = null
     ) : KotlinBuildScriptModel
 }

--- a/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/subprojects/tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -63,7 +63,9 @@ import org.gradle.kotlin.dsl.typeOf
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 
 import java.io.File
+import java.io.PrintWriter
 import java.io.Serializable
+import java.io.StringWriter
 
 import java.util.*
 
@@ -78,7 +80,7 @@ data class StandardKotlinBuildScriptModel(
     override val sourcePath: List<File>,
     override val implicitImports: List<String>,
     override val editorReports: List<EditorReport>,
-    override val exceptions: List<Exception>,
+    override val exceptions: List<String>,
     override val enclosingScriptProjectDir: File?
 ) : KotlinBuildScriptModel, Serializable
 
@@ -349,7 +351,7 @@ data class KotlinScriptTargetModelBuilder(
             (gradleSource() + classpathSources + accessorsClassPath.src).asFiles,
             implicitImports,
             buildEditorReportsFor(classPathModeExceptionCollector.exceptions),
-            classPathModeExceptionCollector.exceptions,
+            classPathModeExceptionCollector.exceptions.map(::exceptionToString),
             enclosingScriptProjectDir
         )
     }
@@ -379,6 +381,10 @@ data class KotlinScriptTargetModelBuilder(
             exceptions,
             project.isLocationAwareEditorHintsEnabled
         )
+
+    private
+    fun exceptionToString(exception: Exception) =
+        StringWriter().also { exception.printStackTrace(PrintWriter(it)) }.toString()
 }
 
 

--- a/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
+++ b/subprojects/tooling-models/src/main/kotlin/org/gradle/kotlin/dsl/tooling/models/KotlinBuildScriptModel.kt
@@ -24,7 +24,7 @@ interface KotlinBuildScriptModel {
     val sourcePath: List<File>
     val implicitImports: List<String>
     val editorReports: List<EditorReport>
-    val exceptions: List<Exception>
+    val exceptions: List<String>
 
     /**
      * The directory of the project in which the script was found.


### PR DESCRIPTION
During the investigation of #1308, the following stack trace snippet appeared in the Kotlin DSL resolver log:

```
Caused by: org.gradle.api.UncheckedIOException: java.io.StreamCorruptedException: invalid type code: 61
			at org.gradle.internal.UncheckedException.throwAsUncheckedException(UncheckedException.java:61)
			at org.gradle.internal.UncheckedException.throwAsUncheckedException(UncheckedException.java:41)
			at org.gradle.tooling.internal.provider.serialization.PayloadSerializer.deserialize(PayloadSerializer.java:76)
			at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:194)
			at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:135)
			at org.gradle.tooling.internal.provider.DefaultConnection.getModel(DefaultConnection.java:193)
```

At the top of the stack trace it read:

```
at org.gradle.tooling.internal.consumer.ExceptionTransformer.transform(ExceptionTransformer.java:55)
```

Which prompted me to provide this PR as a quick fix to the problem pending some further investigation on its root cause.