### PR TITLE
Allow scripts larger than 64KB

### DIFF
--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/cache/ScriptCache.kt
@@ -71,7 +71,7 @@ class ScriptCache(
     }
 
     private
-    val cacheProperties = mapOf("version" to "14")
+    val cacheProperties = mapOf("version" to "15")
 
     private
     fun cacheDirOf(baseDir: File) = File(baseDir, "cache")

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/ExecutableProgram.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/ExecutableProgram.kt
@@ -22,6 +22,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.hash.HashCode
 
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
+import org.gradle.kotlin.dsl.support.useToRun
 
 import org.gradle.plugin.management.internal.PluginRequests
 
@@ -69,8 +70,8 @@ abstract class ExecutableProgram {
             accessorsClassPath: ClassPath?
         )
 
-        fun compileSecondStageScript(
-            scriptText: String,
+        fun compileSecondStageOf(
+            program: StagedProgram,
             scriptHost: KotlinScriptHost<*>,
             scriptTemplateId: String,
             sourceHash: HashCode,
@@ -88,6 +89,8 @@ abstract class ExecutableProgram {
 
     abstract class StagedProgram : ExecutableProgram() {
 
+        abstract val secondStageScriptText: String
+
         abstract fun loadSecondStageFor(
             programHost: Host,
             scriptHost: KotlinScriptHost<*>,
@@ -95,5 +98,10 @@ abstract class ExecutableProgram {
             sourceHash: HashCode,
             accessorsClassPath: ClassPath?
         ): Class<*>
+
+        fun loadScriptResource(resourcePath: String): String =
+            javaClass.getResourceAsStream(resourcePath).bufferedReader().useToRun {
+                readText()
+            }
     }
 }

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -426,8 +426,8 @@ class Interpreter(val host: Host) {
                 host.compilationClassPathOf(scriptHost.targetScope)
             ).bin
 
-        override fun compileSecondStageScript(
-            scriptText: String,
+        override fun compileSecondStageOf(
+            program: ExecutableProgram.StagedProgram,
             scriptHost: KotlinScriptHost<*>,
             scriptTemplateId: String,
             sourceHash: HashCode,
@@ -469,7 +469,7 @@ class Interpreter(val host: Host) {
 
                         scriptSource.withLocationAwareExceptionHandling {
 
-                            withTemporaryScriptFileFor(originalScriptPath, scriptText) { scriptFile ->
+                            withTemporaryScriptFileFor(originalScriptPath, program.secondStageScriptText) { scriptFile ->
 
                                 ResidualProgramCompiler(
                                     outputDir,

--- a/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/subprojects/provider/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -163,7 +163,7 @@ class ResidualProgramCompiler(
     private
     fun storeStringToResource(secondStageScriptText: String): String {
         val hash = Hashing.hashString(secondStageScriptText)
-        val resourcePath = "gradle-kotlin-dsl/$hash"
+        val resourcePath = "scripts/$hash.gradle.kts"
         writeResourceFile(resourcePath, secondStageScriptText)
         return resourcePath
     }

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
@@ -182,8 +182,8 @@ class ResidualProgramCompilerTest : TestWithTempFiles() {
                 sourceHash,
                 null)
 
-            verify(programHost).compileSecondStageScript(
-                source.text,
+            verify(programHost).compileSecondStageOf(
+                program,
                 scriptHost,
                 stage2SettingsTemplateId,
                 sourceHash,
@@ -464,6 +464,11 @@ class ResidualProgramCompilerTest : TestWithTempFiles() {
                 program.loadSecondStageFor(programHost, scriptHost, scriptTemplateId, sourceHash, accessorsClassPath)
             }
 
+            assertThat(
+                program.secondStageScriptText,
+                equalTo(stagedProgram.source.text)
+            )
+
             inOrder(programHost) {
 
                 verify(programHost).applyPluginsTo(
@@ -479,8 +484,8 @@ class ResidualProgramCompilerTest : TestWithTempFiles() {
                     sourceHash = sourceHash,
                     accessorsClassPath = accessorsClassPath)
 
-                verify(programHost).compileSecondStageScript(
-                    stagedProgram.source.text,
+                verify(programHost).compileSecondStageOf(
+                    program,
                     scriptHost,
                     scriptTemplateId,
                     sourceHash,

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -9,8 +9,40 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Assert.assertThat
 import org.junit.Test
 
+import java.io.StringWriter
+
 
 class KotlinBuildScriptIntegrationTest : AbstractIntegrationTest() {
+
+    @Test
+    fun `scripts larger than 64KB are supported`() {
+
+        withBuildScriptLargerThan64KB("""
+            tasks.register("run") {
+                doLast { println("*42*") }
+            }
+        """)
+
+        assertThat(
+            build("run").output,
+            containsString("*42*")
+        )
+    }
+
+    private
+    fun withBuildScriptLargerThan64KB(suffix: String) =
+        withBuildScript(StringWriter().run {
+            var bytesWritten = 0
+            var i = 0
+            while (bytesWritten < 64 * 1024) {
+                val stmt = "val v$i = $i\n"
+                write(stmt)
+                i += 1
+                bytesWritten += stmt.length * 2
+            }
+            write(suffix)
+            toString()
+        })
 
     @Test
     fun `can use Kotlin 1 dot 3 language features`() {

--- a/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/provider/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -38,7 +38,7 @@ class KotlinBuildScriptIntegrationTest : AbstractIntegrationTest() {
                 val stmt = "val v$i = $i\n"
                 write(stmt)
                 i += 1
-                bytesWritten += stmt.length * 2
+                bytesWritten += stmt.toByteArray().size
             }
             write(suffix)
             toString()


### PR DESCRIPTION
By storing large scripts as a resource instead of a script constant in the emitted bytecode.

Resolves #1305